### PR TITLE
[FIX] awesome_tshirt: use {'clickable': '1'} option

### DIFF
--- a/awesome_tshirt/views/views.xml
+++ b/awesome_tshirt/views/views.xml
@@ -8,7 +8,7 @@
       <field name="arch" type="xml">
         <form>
           <header>
-            <field name="state" widget="statusbar" options="{'clickable': 1}"/>
+            <field name="state" widget="statusbar" options="{'clickable': '1'}"/>
           </header>
           <sheet>
             <group>

--- a/awesome_tshirt/views/views.xml
+++ b/awesome_tshirt/views/views.xml
@@ -8,7 +8,7 @@
       <field name="arch" type="xml">
         <form>
           <header>
-            <field name="state" widget="statusbar" clickable="1"/>
+            <field name="state" widget="statusbar" options="{'clickable': 1}"/>
           </header>
           <sheet>
             <group>


### PR DESCRIPTION
This outdated clickable attribute should be assigned in options attribute object which is used for statusbar widget