### PR TITLE
[FIX] 18.0 Module Awesome_Gallery setup creates error

### DIFF
--- a/awesome_gallery/models/ir_ui_view.py
+++ b/awesome_gallery/models/ir_ui_view.py
@@ -6,3 +6,8 @@ class View(models.Model):
     _inherit = 'ir.ui.view'
 
     type = fields.Selection(selection_add=[('gallery', "Awesome Gallery")])
+
+    def _get_view_info(self):
+        infos = super()._get_view_info()
+        infos['gallery'] = {'icon': 'fa fa-image'}
+        return infos

--- a/awesome_gallery/views/views.xml
+++ b/awesome_gallery/views/views.xml
@@ -4,7 +4,7 @@
     <record id="contacts.action_contacts" model="ir.actions.act_window">
         <field name="name">Contacts</field>
         <field name="res_model">res.partner</field>
-        <field name="view_mode">kanban,tree,form,activity</field>
+        <field name="view_mode">kanban,list,form,activity</field>
         <field name="search_view_id" ref="base.view_res_partner_filter"/>
         <field name="context">{'default_is_company': True}</field>
         <field name="help" type="html">


### PR DESCRIPTION
Steps to Reproduce:
====

1. Checkout the origin/18.0 branch for the tutorial repo and install the Awesome_Gallery module.
2. Try to reconnect, you get and error with following traceback: ```... File "/home/odoo/work/odoo/addons/web/models/ir_ui_view.py", line 14, in <dictcomp> 'icon': _view_info[type_]['icon'], KeyError: 'gallery' ```
3. Also the "tree" view seems to not be supported anymore in 18.0 and is replaced with "list".
4. Try applying the first step of solution 6.1 from the origin/18.0-solutions branch. The error persists and you cannot do the tutorial.

After this commit:
====

The module can be installed without errors, and you can proceed with the tutorial without issues. Note: The 18.0-solutions branch should be updated with the new v18 tutorial, which now focuses on the Contact app instead of the Awesome_Tshirt app.

task-xxxx