### PR TITLE
[FIX] README.md: Fixing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Odoo tutorials
 
 This repository hosts the code for the bases of the modules used in the
-[official Odoo tutorials](https://www.odoo.com/documentation/lastest/developer/tutorials.html).
+[official Odoo tutorials](https://www.odoo.com/documentation/latest/developer/tutorials.html).
 
 It has 3 branches for each Odoo version: one for the bases, one for the
 [Discover the JS framework](https://www.odoo.com/documentation/latest/developer/tutorials/discover_js_framework.html)
 tutorial's solutions, and one for the
-[Master the Odoo web framework](https://www.odoo.com/documentation/lastest/developer/tutorials/master_odoo_web_framework.html)
+[Master the Odoo web framework](https://www.odoo.com/documentation/latest/developer/tutorials/master_odoo_web_framework.html)
 tutorial's solutions. For example, `17.0`, `17.0-discover-js-framework-solutions` and
 `17.0-master-odoo-web-framework-solutions`.


### PR DESCRIPTION
There are 2 typos in the README.md that lead to broken links.