### PR TITLE
[ADD] supplier_portal, event_ticket_limit: add module for supplier portal, event ticket restriction

### DIFF
--- a/event_ticket_limit/__init__.py
+++ b/event_ticket_limit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_ticket_limit/__manifest__.py
+++ b/event_ticket_limit/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Event Ticket Limit",
+    "category": "Event/ Event Ticket Limit",
+    "summary": """
+The purpose of this module is to implement a functionality for limiting the number of tickets per registration.
+You can limit the number of tickets per registration by setting the tickets_per_registration field in the event.event.ticket model.
+If value is set to 0, then there is no limit on the number of tickets per registration.
+""",
+    "version": "1.0",
+    "depends": ["base_setup", "event", "website_event"],
+    "data": [
+        "views/event_tickets_views.xml",
+        "views/event_registration_website_view.xml",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+    "auto_install": True,
+}

--- a/event_ticket_limit/models/__init__.py
+++ b/event_ticket_limit/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_ticket

--- a/event_ticket_limit/models/event_ticket.py
+++ b/event_ticket_limit/models/event_ticket.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class EventTicket(models.Model):
+    _inherit = "event.event.ticket"
+
+    tickets_per_registration = fields.Integer(
+        string="Tickets per Registration",
+        help="Number of tickets per registration. 0 means unlimited.",
+    )

--- a/event_ticket_limit/views/event_registration_website_view.xml
+++ b/event_ticket_limit/views/event_registration_website_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="modal_ticket_registration" name="modal_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+        <xpath expr="//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_registration" t-value="ticket.tickets_per_registration+1 if ticket.tickets_per_registration else 10"/>
+        </xpath>
+
+        <xpath expr="//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event,seats_max_registration)</attribute>
+        </xpath>
+
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_registration" t-value="tickets.tickets_per_registration+1 if tickets.tickets_per_registration else 10"/>
+        </xpath>
+
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event,seats_max_registration)</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/event_ticket_limit/views/event_tickets_views.xml
+++ b/event_ticket_limit/views/event_tickets_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_event_ticket_view_tree_from_event_inherit_module_name" model="ir.ui.view">
+        <field name="name">event.event.ticket.view.list.inherit</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <field name="tickets_per_registration" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_warranty/__init__.py
+++ b/product_warranty/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/product_warranty/__manifest__.py
+++ b/product_warranty/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "Product Warranty",
+    "version": "1.0",
+    "category": "Sales/Warranty",
+    "summary": "Add warranty information to products and display it on sale order lines.",
+    "description": """
+This module provides functionality to manage product warranties.
+Users can define warranties for products and see warranty details in sale order lines.
+""",
+    "license": "AGPL-3",
+    "depends": ["base", "sale_management"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_template_views.xml",
+        "views/product_warranty_config_views.xml",
+        "views/product_warranty_config_menu.xml",
+        "views/sale_order_views.xml",
+        "wizard/product_warranty_wizard_view.xml",
+    ],
+    "auto_install": True,
+}

--- a/product_warranty/models/__init__.py
+++ b/product_warranty/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import sale_order
+from . import warranty_config

--- a/product_warranty/models/product_template.py
+++ b/product_warranty/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    is_warranty_product = fields.Boolean("Is Warranty Product")

--- a/product_warranty/models/sale_order.py
+++ b/product_warranty/models/sale_order.py
@@ -1,0 +1,34 @@
+from odoo import api, Command, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def action_open_warranty_wizard(self):
+        return {
+            "name": "Add Warranty",
+            "type": "ir.actions.act_window",
+            "res_model": "product.warranty.wizard",
+            "view_mode": "form",
+            "target": "new",
+        }
+
+    @api.onchange("order_line")
+    def _onchange_order_line(self):
+        super()._onchange_order_line()
+        deleted_product_template_ids = []
+        for line in self.order_line:
+            # Find each products that is not in Sale Order currently
+            if (
+                line.linked_line_id.id
+                and line.linked_line_id.id not in self.order_line.ids
+            ):
+                deleted_product_template_ids.append(line.linked_line_id.id)
+
+        linked_line_ids_to_delete = self.order_line.search(
+            [("linked_line_id", "in", deleted_product_template_ids)]
+        )
+        self.order_line = [
+            Command.unlink(linked_line_id)
+            for linked_line_id in linked_line_ids_to_delete.ids
+        ]

--- a/product_warranty/models/warranty_config.py
+++ b/product_warranty/models/warranty_config.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+
+class ProductWarrantyConfig(models.Model):
+    _name = "product.warranty.config"
+    _description = "Product Warranty Configuration"
+
+    name = fields.Char(string="Name", required=True)
+    product_template_id = fields.Many2one(
+        "product.template", string="Product", required=True
+    )
+    percentage = fields.Float(string="Percentage", required=True)
+    years = fields.Integer(string="Years", required=True)
+
+    _sql_constraints = [
+        ("name_uniq", "unique (name)", "Two Waranties can not be of same name"),
+    ]

--- a/product_warranty/security/ir.model.access.csv
+++ b/product_warranty/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+product_warranty.access_product_warranty_config,access_product_warranty_config,product_warranty.model_product_warranty_config,base.group_user,1,1,1,1
+product_warranty.access_prodcut_warranty_wizard,access_prodcut_warranty_wizard,product_warranty.model_product_warranty_wizard,base.group_user,1,1,1,1
+product_warranty.access_product_warranty_wizard_line,access_product_warranty_wizard_line,product_warranty.model_product_warranty_wizard_line,base.group_user,1,1,1,1

--- a/product_warranty/views/product_template_views.xml
+++ b/product_warranty/views/product_template_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_template_form_view_inherit_product_warranty" model="ir.ui.view">
+        <field name="name">product.template.view.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='upsell']" position="after">
+                <group string="Warranty">
+                    <field name="is_warranty_product" />
+                </group>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/product_warranty/views/product_warranty_config_menu.xml
+++ b/product_warranty/views/product_warranty_config_menu.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="product_warranty_config_menu" name="Warranty Config" action="product_warranty.product_warranty_config_action" parent="sale.prod_config_main" sequence="10"/>
+</odoo>

--- a/product_warranty/views/product_warranty_config_views.xml
+++ b/product_warranty/views/product_warranty_config_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_warranty_config_action" model="ir.actions.act_window">
+        <field name="name">Warranty Config</field>
+        <field name="res_model">product.warranty.config</field>
+        <field name="view_mode">list</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Define new warranty
+            </p>
+        </field>
+    </record>
+
+    <record id="product_warranty_config_view_list" model="ir.ui.view">
+        <field name="name">product.warranty.config.view.tree</field>
+        <field name="model">product.warranty.config</field>
+        <field name="arch" type="xml">
+            <list string="Warranty Config" sample="1" editable="bottom">
+                <field name="name" />
+                <field name="product_template_id" />
+                <field name="percentage" />
+                <field name="years" />
+            </list>
+        </field>
+    </record>
+
+</odoo>

--- a/product_warranty/views/sale_order_views.xml
+++ b/product_warranty/views/sale_order_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form_inherit_product_warranty" model="ir.ui.view">
+        <field name="name">sale.order.view.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='so_button_below_order_lines']" position="inside">
+                <button string="Add Warranty" name="action_open_warranty_wizard" type="object" class="btn btn-secondary"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/product_warranty/wizard/__init__.py
+++ b/product_warranty/wizard/__init__.py
@@ -1,0 +1,2 @@
+from . import product_warranty_wizard
+from . import product_warranty_wizard_line

--- a/product_warranty/wizard/product_warranty_wizard.py
+++ b/product_warranty/wizard/product_warranty_wizard.py
@@ -1,0 +1,52 @@
+from odoo import api, Command, fields, models
+
+
+class WarrantyWizard(models.TransientModel):
+    _name = "product.warranty.wizard"
+    _description = "Warranty Selection Wizard"
+
+    sale_order_id = fields.Many2one("sale.order", string="Sale Order")
+    line_ids = fields.One2many(
+        "product.warranty.wizard.line", "wizard_id", string="Warranty Lines"
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        sale_order = self.env["sale.order"].browse(self.env.context.get("active_id"))
+        warranty_lines = []
+
+        for line in sale_order.order_line.filtered(
+            lambda line: line.product_template_id
+            and line.product_template_id.is_warranty_product
+        ):
+            warranty_lines.append(
+                Command.create(
+                    {
+                        "sale_order_line_id": line.id,
+                        "warranty_config_id": False,
+                    }
+                )
+            )
+        res["sale_order_id"] = sale_order.id
+        res["line_ids"] = warranty_lines
+        return res
+
+    def apply_warranty(self):
+        for line in self.line_ids:
+            product = self.env["product.template"].browse(line.product_template_id.id)
+            if line.warranty_config_id:
+                self.env["sale.order.line"].create(
+                    {
+                        "order_id": self.sale_order_id.id,
+                        "product_template_id": line.warranty_config_id.product_template_id.id,
+                        "name": "Extended Warranty of %d Years - %s"
+                        % (line.warranty_config_id.years, product.name),
+                        "product_uom_qty": 1,
+                        "linked_line_id": line.sale_order_line_id.id,
+                        "price_unit": (line.warranty_config_id.percentage / 100)
+                        * line.sale_order_line_id.price_subtotal,
+                    }
+                )
+
+        return {"type": "ir.actions.act_window_close"}

--- a/product_warranty/wizard/product_warranty_wizard_line.py
+++ b/product_warranty/wizard/product_warranty_wizard_line.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo import models, fields, api
+
+
+class WarrantyWizardLine(models.TransientModel):
+    _name = "product.warranty.wizard.line"
+    _description = "Warranty Wizard Line"
+
+    wizard_id = fields.Many2one("product.warranty.wizard", string="Wizard")
+    sale_order_line_id = fields.Many2one("sale.order.line", string="Sale Order Line")
+    product_template_id = fields.Many2one(
+        "product.template", string="Product", compute="_compute_product_template_id"
+    )
+    warranty_config_id = fields.Many2one(
+        "product.warranty.config", string="Warranty Type"
+    )
+    date_end = fields.Date(string="Date End", compute="_compute_date_end")
+
+    @api.depends("warranty_config_id.years")
+    def _compute_date_end(self):
+        for line in self:
+            line.date_end = datetime.today() + relativedelta(
+                years=line.warranty_config_id.years
+            )
+
+    @api.depends("sale_order_line_id")
+    def _compute_product_template_id(self):
+        for line in self:
+            if line.sale_order_line_id:
+                line.product_template_id = line.sale_order_line_id.product_template_id
+            else:
+                line.product_template_id = False

--- a/product_warranty/wizard/product_warranty_wizard_view.xml
+++ b/product_warranty/wizard/product_warranty_wizard_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_warranty_wizard_form" model="ir.ui.view">
+        <field name="name">product.warranty.wizard.form</field>
+        <field name="model">product.warranty.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Add Warranty" nolabel="1">
+                <sheet>
+                    <group>
+                        <field name="sale_order_id" invisible="1"/>
+                        <field name="line_ids">
+                            <list editable="bottom" delete="0" create="0">
+                                <field name="sale_order_line_id" optional="hide"/>
+                                <field name="product_template_id" readonly="1"/>
+                                <field name="warranty_config_id" options="{'no_create': True}"/>
+                                <field name="date_end" readonly="1"/>
+                            </list>
+                        </field>
+                    </group>
+                    <footer>
+                        <button string="Apply" type="object" name="apply_warranty" class="btn-primary"/>
+                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/supplier_portal/__init__.py
+++ b/supplier_portal/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/supplier_portal/__manifest__.py
+++ b/supplier_portal/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Supplier Portal",
+    "category": "Website/Supplier_Portal",
+    "summary": "Supplier portal for uploading documents",
+    "version": "1.0",
+    "depends": ["base_setup", "website", "account"],
+    "data": ["views/supplier_portal_template.xml", "views/supplier_website.xml"],
+    "installable": True,
+    "auto_install": True,
+    "license": "AGPL-3",
+}

--- a/supplier_portal/controllers/__init__.py
+++ b/supplier_portal/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/supplier_portal/controllers/main.py
+++ b/supplier_portal/controllers/main.py
@@ -1,0 +1,54 @@
+import base64
+
+from odoo import http
+from odoo.addons.portal.controllers.portal import CustomerPortal
+from odoo.http import request
+
+
+class SupplierPortal(CustomerPortal):
+    @http.route(["/my/upload_documents"], type="http", auth="user", website=True)
+    def upload_documents(self, **kwargs):
+        return request.render(
+            "supplier_portal.supplier_portal_template",
+        )
+
+    @http.route(["/my/upload_documents/submit"], type="http", auth="user", website=True)
+    def upload_documents_submit(self, **kwargs):
+        bill = (
+            request.env["account.move"]
+            .sudo()
+            .create(
+                {
+                    "move_type": "in_invoice",
+                    "partner_id": request.env.user.partner_id.id,
+                    "company_id": int(kwargs.get("company")),
+                }
+            )
+        )
+
+        request.env["ir.attachment"].sudo().create(
+            {
+                "res_id": bill.id,
+                "res_model": "account.move",
+                "name": "Invoice PDF",
+                "datas": base64.b64encode(kwargs.get("upload_pdf").read()),
+                "type": "binary",
+                "mimetype": "application/pdf",
+            }
+        )
+
+        request.env["ir.attachment"].sudo().create(
+            {
+                "res_id": bill.id,
+                "res_model": "account.move",
+                "name": "Invoice XML",
+                "datas": base64.b64encode(kwargs.get("upload_xml").read()),
+                "type": "binary",
+                "mimetype": "application/xml",
+            }
+        )
+
+        return request.render(
+            "supplier_portal.generic_message_template",
+            {"success_message": "Documents uploaded successfully."},
+        )

--- a/supplier_portal/views/supplier_portal_template.xml
+++ b/supplier_portal/views/supplier_portal_template.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="supplier_portal_template" name="Supplier Upload Documents">
+        <t t-call="website.layout">
+            <div class="container my-5">
+                <div class="row justify-content-center">
+                    <div class="col-md-8">
+                        <div class="card shadow">
+                            <div class="card-header bg-primary text-white text-center">
+                                <h4>Bill Details</h4>
+                            </div>
+                            <div class="card-body">
+                                <form action="/my/upload_documents/submit" method="post" enctype="multipart/form-data" class="needs-validation">
+                                    <div class="mb-3">
+                                        <label for="company" class="form-label">Company:</label>
+                                        <select class="form-select" id="company" name="company" required="true">
+                                            <t t-foreach="request.env.user.company_ids" t-as="company">
+                                                <option t-att-value="company.id" t-esc="company.name"></option>
+                                            </t>
+                                        </select>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="upload_pdf" class="form-label">Upload PDF</label>
+                                        <input type="file" id="upload_pdf" name="upload_pdf" class="form-control" required="true"/>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="upload_xml" class="form-label">Upload XML File</label>
+                                        <input type="file" id="upload_xml" name="upload_xml" class="form-control" required="true" />
+                                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                    </div>
+                                    <div class="text-center">
+                                        <button type="submit" class="btn btn-primary px-4">
+                                            <i class="fa fa-upload me-2"></i>Submit</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+
+    <template id="generic_message_template" name="Generic Message Template">
+        <t t-call="website.layout">
+            <div class="container mt-5">
+                <!-- Success Message -->
+                <t t-if="success_message">
+                    <div class="alert alert-success text-center" role="alert">
+                        <t t-esc="success_message" />
+                    </div>
+                </t>
+
+                <!-- Error Message -->
+                <t t-if="error_message">
+                    <div class="alert alert-danger text-center" role="alert">
+                        <t t-esc="error_message" />
+                    </div>
+                </t>
+
+                <!-- Back to Dashboard Button -->
+                <div class="text-center mt-4">
+                    <a href="/my" class="btn btn-primary">
+                        <i class="fa fa-home"></i> Back to Dashboard
+                    </a>
+                </div>
+            </div>
+        </t>
+    </template>
+
+</odoo>

--- a/supplier_portal/views/supplier_website.xml
+++ b/supplier_portal/views/supplier_website.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="menu_upload_documents" model="website.menu">
+        <field name="name">Upload Documents</field>
+        <field name="url">/my/upload_documents</field>
+        <field name="parent_id" ref="website.main_menu"/>
+        <field name="sequence" type="int">60</field>
+        <field name="group_ids" eval="[(6, 0, [ref('base.group_portal')])]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- Implement a supplier portal that allows vendors to upload their bills. Vendors will be able to view the companies they are associated with and upload bills in both PDF and XML formats. 
- Once the documents are successfully uploaded, a new draft vendor bill will be created in the backend.
**Task - 4496581**

- Added a module to limit the number of tickets a user can book per registration.
- A new field has been introduced in the list view; if this field is set to 0, it indicates that there is no limit on the number of tickets per registration.
- All previous restrictions will remain in effect.
**Task - 4500439**

- Add a module that adds warranty as a product in sale order line. Users can configure generic warranty configurations from sales-> menu -> product -> Warranty Config.
- Whenever there is a warranty product in our sales order lines we can click on add warranty button in view and a wizard will open from which we can add type of warranty we configured in warranty config view.
- We can mark product as warranty product in product template form view's sales section. Also warranty can be seen as sales order line in print report too. 
**Task - 4504888**

