### PR TITLE
[ADD] book_price: Display 'Book Price' on Sales Order and Invoice Lines

### DIFF
--- a/book_price/__init__.py
+++ b/book_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/book_price/__manifest__.py
+++ b/book_price/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "book price",
+    "summary": "Add Pricelist Price (khup)",
+    "description": "Add Pricelist Price (khup)",
+    "version": "0.1",
+    "depends": ["account", "sale"],
+    "auto_install": True,
+    "license": "AGPL-3",
+     "data": [
+        'security/ir.model.access.csv',
+        'views/account_move_line_views.xml',
+        'views/sale_order_views.xml'
+    ],
+}

--- a/book_price/models/__init__.py
+++ b/book_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move_line
+from . import sale_order_line

--- a/book_price/models/account_move_line.py
+++ b/book_price/models/account_move_line.py
@@ -1,0 +1,11 @@
+from odoo import models, fields, api
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(string='Book Price', compute='_compute_book_price')
+
+    @api.depends("product_id.lst_price" , "quantity")
+    def _compute_book_price(self):
+        for record in self:
+            record.book_price = record.product_id.lst_price * record.quantity

--- a/book_price/models/sale_order_line.py
+++ b/book_price/models/sale_order_line.py
@@ -1,0 +1,11 @@
+from odoo import api, fields, models
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(string='Book Price', compute='_compute_book_price')
+
+    @api.depends("product_id.lst_price" , "product_uom_qty")
+    def _compute_book_price(self):
+        for record in self:
+            record.book_price = record.product_id.lst_price * record.product_uom_qty

--- a/book_price/security/ir.model.access.csv
+++ b/book_price/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_account_move_line,access_account_move_line,model_account_move_line,base.group_user,1,1,1,1

--- a/book_price/views/account_move_line_views.xml
+++ b/book_price/views/account_move_line_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="book_price" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/book_price/views/sale_order_views.xml
+++ b/book_price/views/sale_order_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="inherit_view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.inherit.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="before">
+                <field name="book_price" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Added a computed field book_price to Sales Order Lines and Account Move Lines to
display the original product price ('Book Price') based on the selected
product and quantity

Updated Sales Order Lines list view to include the new 'Book Price' field.

Updated Invoice Lines list view (customer invoices only) to include the new 'Book Price' field.