### PR TITLE
Update ir_ui_view.py

### DIFF
--- a/awesome_gallery/models/ir_ui_view.py
+++ b/awesome_gallery/models/ir_ui_view.py
@@ -6,3 +6,10 @@ class View(models.Model):
     _inherit = 'ir.ui.view'
 
     type = fields.Selection(selection_add=[('gallery', "Awesome Gallery")])
+
+    def _get_view_info(self):
+        view_info = super()._get_view_info()
+        view_info.update({
+            'gallery': {'icon': 'fa fa-picture-o'},
+        })
+        return view_info


### PR DESCRIPTION
without overwriting the _get_view_info method, odoo complains about missing "gallery" key in _view_info