### PR TITLE
[ADD] sale_zero_stock_approval:  Add zero stock validation for sales orders

### DIFF
--- a/sale_zero_stock_approval/__init__.py
+++ b/sale_zero_stock_approval/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_zero_stock_approval/__init__.py
+++ b/sale_zero_stock_approval/__init__.py
@@ -1,1 +1,3 @@
+# -*- coding: utf-8 -*-
+
 from . import models

--- a/sale_zero_stock_approval/__manifest__.py
+++ b/sale_zero_stock_approval/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': 'Sale Zero Stock Approval',
+    'version': '1.0',
+    'category': 'Sales',
+    'author': 'Maan Patel',
+    'summary': 'Adds zero stock approval feature to sale orders',
+    'description': """
+        This module adds a zero stock approval feature to sale orders.
+        - Allows sales administrators to approve orders with zero stock
+        - Read-only for sales users
+    """,
+    'depends': ['sale'],
+    'data': ['views/sale_order_view.xml',],
+    'installable': True,
+    'application': False,
+    'auto_install': True,
+    'license': 'LGPL-3'
+}

--- a/sale_zero_stock_approval/__manifest__.py
+++ b/sale_zero_stock_approval/__manifest__.py
@@ -9,8 +9,8 @@
         - Allows sales administrators to approve orders with zero stock
         - Read-only for sales users
     """,
-    'depends': ['sale'],
-    'data': ['views/sale_order_view.xml',],
+    'depends': ['sale_management'],
+    'data': ['views/sale_order_view.xml'],
     'installable': True,
     'application': False,
     'auto_install': True,

--- a/sale_zero_stock_approval/__manifest__.py
+++ b/sale_zero_stock_approval/__manifest__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 {
     'name': 'Sale Zero Stock Approval',
     'version': '1.0',

--- a/sale_zero_stock_approval/models/__init__.py
+++ b/sale_zero_stock_approval/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_zero_stock_approval/models/__init__.py
+++ b/sale_zero_stock_approval/models/__init__.py
@@ -1,1 +1,3 @@
+# -*- coding: utf-8 -*-
+
 from . import sale_order

--- a/sale_zero_stock_approval/models/sale_order.py
+++ b/sale_zero_stock_approval/models/sale_order.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -18,17 +20,10 @@ class SaleOrder(models.Model):
     def action_confirm(self):
         for order in self:
             has_zero_stock = False
-
-            if not order.order_line:
-                if not order.zero_stock_approval:
-                    raise UserError(_('Cannot confirm empty order without approval.'))
-
             for line in order.order_line:
                 if line.product_uom_qty <= 0:
                     has_zero_stock = True
                     break
-
             if has_zero_stock and not order.zero_stock_approval:
                 raise UserError(_('Cannot confirm order with zero stock products without approval.'))
-
         return super().action_confirm()

--- a/sale_zero_stock_approval/models/sale_order.py
+++ b/sale_zero_stock_approval/models/sale_order.py
@@ -1,0 +1,34 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(string='Approval', copy=False)
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if not self.env.user.has_group('sales_team.group_sale_manager'):
+            if 'zero_stock_approval' in res:
+                res['zero_stock_approval']['readonly'] = True
+        return res
+
+    def action_confirm(self):
+        for order in self:
+            has_zero_stock = False
+
+            if not order.order_line:
+                if not order.zero_stock_approval:
+                    raise UserError(_('Cannot confirm empty order without approval.'))
+
+            for line in order.order_line:
+                if line.product_uom_qty <= 0:
+                    has_zero_stock = True
+                    break
+
+            if has_zero_stock and not order.zero_stock_approval:
+                raise UserError(_('Cannot confirm order with zero stock products without approval.'))
+
+        return super().action_confirm()

--- a/sale_zero_stock_approval/views/sale_order_view.xml
+++ b/sale_zero_stock_approval/views/sale_order_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="view_order_form_inherit_zero_stock" model="ir.ui.view">
+    <record id="view_order_form" model="ir.ui.view">
         <field name="name">sale.order.form.inherit.zero.stock</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>

--- a/sale_zero_stock_approval/views/sale_order_view.xml
+++ b/sale_zero_stock_approval/views/sale_order_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form_inherit_zero_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.zero.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
• Created new module 'sale_zero_stock_approval' for managing zero stock sales 
• Added boolean field 'zero_stock_approval' in sale.order model 
• Implemented readonly access control for Sales Users 
• Added field visibility control for Sales Administrator group only 
• Added validation check during sale order confirmation for zero stock products 
• Created inherited view to display approval checkbox in sale order form 
• Prevented copying of approval status when duplicating orders

Task-4595236