### PR TITLE
[IMP] book_price:  Displaying original Book Price in sells module.

### DIFF
--- a/book_price/__init__.py
+++ b/book_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/book_price/__manifest__.py
+++ b/book_price/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Pricelist Book Price',
+    'version': '1.0',
+    'author': 'Khushi',
+    'summary': 'Added Book Price',
+    'depends': ['sale_management'],
+    'data' : [
+        'views/account_move_line_views.xml',
+        'views/sale_order_line_views.xml'
+    ],
+    'installable' :True,
+    'auto_install':True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/book_price/models/__init__.py
+++ b/book_price/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import account_move_line
+from . import sale_order_line

--- a/book_price/models/account_move_line.py
+++ b/book_price/models/account_move_line.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(
+        string='Book Price',
+        compute='_compute_book_price',
+        store=True,
+        readonly=True,
+        help="Computed book price based on product list price and quantity."
+    )
+
+    @api.depends("product_id", "quantity", "move_id.invoice_line_ids")
+    def _compute_book_price(self):
+         for line in self:
+            if line.product_id and line.move_id and line.move_id.invoice_line_ids:
+                pricelist = line.move_id.invoice_line_ids.sale_line_ids.order_id.pricelist_id
+                if pricelist:
+                    line.book_price = pricelist._get_product_price(
+                        line.product_id, line.quantity, line.product_uom_id
+                    ) * line.quantity
+                else:
+                    line.book_price = line.price_unit * line.quantity
+            else:
+                line.book_price = 0.0

--- a/book_price/models/sale_order_line.py
+++ b/book_price/models/sale_order_line.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(
+        string='Book Price',
+        compute='_compute_book_price',
+        store=True,
+        readonly=True,
+        help="Computed Book Price based on the product's list price and ordered quantity."
+    )
+
+    @api.depends("product_id", "order_id.pricelist_id", "product_uom_qty")
+    def _compute_book_price(self):
+        for line in self:
+            if line.product_id and line.order_id.pricelist_id:
+                price_unit = line.order_id.pricelist_id._get_product_price(
+                    line.product_id, line.product_uom_qty, line.product_uom
+                )
+            else:
+                price_unit = line.product_id.lst_price
+
+            line.book_price = price_unit * line.product_uom_qty

--- a/book_price/tests/__init__.py
+++ b/book_price/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_account_move_line
+from . import test_sale_order_line

--- a/book_price/tests/test_account_move_line.py
+++ b/book_price/tests/test_account_move_line.py
@@ -1,0 +1,24 @@
+from odoo.tests import TransactionCase
+
+
+class TestAccountMoveLine(TransactionCase):
+
+    def test_compute_book_price(self):
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'lst_price': 200.0,
+        })
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.env.ref('base.res_partner_1').id,
+        })
+        move_line = self.env['account.move.line'].create({
+            'move_id': move.id,
+            'product_id': product.id,
+            'quantity': 5,
+        })
+
+        self.assertEqual(
+            move_line.book_price, 1000.0,
+            "Book price should be computed correctly as quantity * list_price."
+        )

--- a/book_price/tests/test_sale_order_line.py
+++ b/book_price/tests/test_sale_order_line.py
@@ -1,0 +1,20 @@
+from odoo.tests import TransactionCase
+
+
+class TestSaleOrderLine(TransactionCase):
+
+    def test_compute_book_price(self):
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'lst_price': 150.0,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env.ref('base.res_partner_1').id,
+        })
+        order_line = self.env['sale.order.line'].create({
+            'order_id': sale_order.id,
+            'product_id': product.id,
+            'product_uom_qty': 4,
+        })
+
+        self.assertEqual(order_line.book_price, 600.0, "Book price should be correctly computed as list_price * quantity.")

--- a/book_price/views/account_move_line_views.xml
+++ b/book_price/views/account_move_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.line.view.form.inherit.book.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="book_price"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/book_price/views/sale_order_line_views.xml
+++ b/book_price/views/sale_order_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.line.view.form.inherit.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list/field[@name='product_uom_qty']" position="before">
+                <field name="book_price"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added Visibility of the original pricelist price i.e Book_price on sales order and invoice lines to compare it with manually adjusted prices.
- The field calculates the price based on the selected pricelist, product, and quantity, and is added to Sales Order Lines  view.
- Invoice Lines tree view (only for customer invoices)
- Computed on Odoo’s standard pricelist mechanism for consistency.
- Added test case to check the pricelist pricing field.

Task-4594892