### PR TITLE
[ADD] event_ticket: add module for limiting event tickets per registr…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.languageServer": "None"
+}

--- a/event_ticket/__init__.py
+++ b/event_ticket/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_ticket/__manifest__.py
+++ b/event_ticket/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    "name": "Ticket Registration",
+    "summary": "Limit events tickets per registration",
+    "description": """ The event module allows event organizers to dynamically allot the number of tickets per registration for the events. """,
+    "depends": ["website_event"],
+    "data": ["views/event_ticket_views.xml" , "views/event_templates_page_registration.xml"],
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/event_ticket/models/__init__.py
+++ b/event_ticket/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_ticket

--- a/event_ticket/models/event_ticket.py
+++ b/event_ticket/models/event_ticket.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class EventTicket(models.Model):
+    _inherit = "event.event.ticket"
+
+    tickets_per_registration = fields.Integer(string="Tickets per Registration")

--- a/event_ticket/views/event_templates_page_registration.xml
+++ b/event_ticket/views/event_templates_page_registration.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="event_ticket_registration" name="Modal for tickets registration" inherit_id="website_event.modal_ticket_registration">
+        <xpath expr="//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_limit" t-value="(ticket.tickets_per_registration > 0 and ticket.tickets_per_registration + 1) or 10"/>
+        </xpath>
+
+        <xpath expr="//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event , seats_max_limit) </attribute>
+        </xpath>
+
+        <xpath expr="//select[@class='d-inline w-auto form-select']//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_limit" t-value="(tickets.tickets_per_registration > 0 and tickets.tickets_per_registration + 1) or 10"/>
+        </xpath>
+
+        <xpath expr="//select[@class='d-inline w-auto form-select']//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event , seats_max_limit) if tickets else seats_max_event </attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/event_ticket/views/event_ticket_views.xml
+++ b/event_ticket/views/event_ticket_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_event_event_ticket_tree_inherit_event_ticket" model="ir.ui.view">
+        <field name="name">event.event.ticket.list.inherit.event.ticket</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <field name="description" position="after">
+                <field name="tickets_per_registration" width="180px"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
…ation

In this commit:
 - inherit "event.event.ticket" model from event module in event_ticket.py file and add a integer field named "tickets_per_registration"
 - inherit list view of event.event.ticket from event module and add ticket field after the description field
 - inherit template containing modal for ticket registration from website_event module in event_ticket module
 - add new variable "seats_max_limit" and set its value by evaluating conditions in single and multi ticket registration form using xpath
 - if the "tickets_per_registration" field is set to 0 then the user will have no limit and can select the default upto 9 tickets
 - if the "tickets_per_registration" field is set to more than 0 then the user can register the minimum from the maximum tickets assigned to that event, tickets_per_registration and maximum tickets assigned to that ticket type