### PR TITLE
[ADD] sale_zero_stock_approval: prevent sale order confirmation without approval

### DIFF
--- a/sale_zero_stock_approval/__init__.py
+++ b/sale_zero_stock_approval/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_zero_stock_approval/__manifest__.py
+++ b/sale_zero_stock_approval/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    "name": "Zero stock blockage",
+    "description": "prevent sale order confirmation without approval",
+    "depends": ["sale_management"],
+    "data": [
+        "views/sale_order_views.xml",
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/sale_zero_stock_approval/models/__init__.py
+++ b/sale_zero_stock_approval/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_zero_stock_approval/models/sale_order.py
+++ b/sale_zero_stock_approval/models/sale_order.py
@@ -1,0 +1,18 @@
+from odoo import api, models, fields
+from odoo.exceptions import UserError
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    zero_stock_approval = fields.Boolean(string="Approval")
+    show_approval = fields.Boolean(compute="_compute_show_approval")
+
+    def action_confirm(self):
+        if not self.zero_stock_approval:
+            raise UserError("Can't confirm the order without approval.")
+
+        return super().action_confirm()
+
+    @api.depends_context('uid')
+    def _compute_show_approval(self):
+        self.show_approval = self.env.user.has_group('sales_team.group_sale_manager')

--- a/sale_zero_stock_approval/views/sale_order_views.xml
+++ b/sale_zero_stock_approval/views/sale_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">sale.order.view.form.inherit.zero.stock.approval</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='order_details']" position="inside">
+                <field name="zero_stock_approval" readonly="not show_approval"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
• Created new module 'sale_zero_stock_approval'
• Inherited a sales.order model
• Added boolean field 'zero_stock_approval' in sale.order model
• Implemented readonly access control for Sales Users
• Added validation check during sale order confirmation for products with zero stock
• Created inherited view to display 'zero_stock_approval' field in sale order form

Task-4595236