### PR TITLE
[IMP] sale: add zero stock approval for sale order confirmation

### DIFF
--- a/sale_zero_stock_approval/__init__.py
+++ b/sale_zero_stock_approval/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_zero_stock_approval/__manifest__.py
+++ b/sale_zero_stock_approval/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Sale Zero Stock Approval',
+    'version': '1.0',
+    'summary': 'Allows approval of zero stock sales orders',
+    'author': 'smjo-odoo',
+    'depends': ['sale_management', 'stock'],
+    'data': ['views/sale_order_view.xml',],
+    'installable': True,
+    'application': False,
+    'auto_install': True,
+    'license': 'LGPL-3'
+}

--- a/sale_zero_stock_approval/models/__init__.py
+++ b/sale_zero_stock_approval/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_zero_stock_approval/models/sale_order.py
+++ b/sale_zero_stock_approval/models/sale_order.py
@@ -1,0 +1,17 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(string="Zero Stock Approval", help="If True, the sales manager can confirm the sale order even if stock is unavailable.")
+
+    #override the action_confirm method in sale.order model
+    def action_confirm(self):
+        for order in self:
+            if not order.zero_stock_approval:
+                for line in order.order_line:
+                    available_qty = line.product_id.qty_available
+                    if available_qty <= 0 :
+                        raise UserError("Cannot confirm Sale Order because the product has 0 available quantity")
+        return super().action_confirm()

--- a/sale_zero_stock_approval/views/sale_order_view.xml
+++ b/sale_zero_stock_approval/views/sale_order_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form_inherit_zero_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.zero.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
-Added a new boolean field 'zero_stock_approval' in the sale.order model
 to allow sales manager to confirm sale order even when product  is unavailable.
-Overrode the action_confirm method to prevent order confirmation to raise error
 if any ordered product has zero available quantity unless zero_stock_approval
 enabled.
-Extended the sale order form view to include the zero_stock_approval field.