### PR TITLE
[IMP] event_ticket_limit: enforce maximum tickets per registration

### DIFF
--- a/event_ticket_limit/__init__.py
+++ b/event_ticket_limit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_ticket_limit/__manifest__.py
+++ b/event_ticket_limit/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': "Event Ticket Limit",
+    'description': """
+    Limit the number of tickets per registration
+    """,
+    'version': '1.0',
+    'depends': ['event', 'website_event'],
+    'author': "Prince Beladiya",
+    'license': 'LGPL-3',
+    'installable': True,
+    'data': [
+        'views/event_ticket_template_views.xml',
+        'views/event_ticket_views.xml',
+        'views/res_config_settings_views.xml'
+    ]
+}

--- a/event_ticket_limit/models/__init__.py
+++ b/event_ticket_limit/models/__init__.py
@@ -1,0 +1,2 @@
+from . import event_event_ticket
+from . import res_config_settings

--- a/event_ticket_limit/models/event_event_ticket.py
+++ b/event_ticket_limit/models/event_event_ticket.py
@@ -1,0 +1,23 @@
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class InheritedEventTicket(models.Model):
+    _inherit = 'event.event.ticket'
+
+    ticket_limit = fields.Integer(
+        string="Ticket Limit",
+        required=True,
+        default=lambda self: self._get_default_ticket_limit()
+    )
+
+    @api.constrains('ticket_limit')
+    def _check_ticket_limit(self):
+        """Ensure ticket limit is greater than 0."""
+        for ticket in self:
+            if ticket.ticket_limit <= 0:
+                raise ValidationError("Ticket limit must be greater than 0.")
+
+    def _get_default_ticket_limit(self):
+        """Fetch the default ticket limit from system parameters."""
+        return int(self.env['ir.config_parameter'].sudo().get_param('event.ticket_limit_default', default=9))

--- a/event_ticket_limit/models/event_event_ticket.py
+++ b/event_ticket_limit/models/event_event_ticket.py
@@ -2,7 +2,7 @@ from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 
-class InheritedEventTicket(models.Model):
+class EventEventTicket(models.Model):
     _inherit = 'event.event.ticket'
 
     ticket_limit = fields.Integer(

--- a/event_ticket_limit/models/res_config_settings.py
+++ b/event_ticket_limit/models/res_config_settings.py
@@ -1,0 +1,18 @@
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    ticket_limit_default = fields.Integer(
+        string="Default Ticket Limit Per Registration",
+        config_parameter="event.ticket_limit_default",
+        default=9
+    )
+
+    @api.constrains('ticket_limit_default')
+    def _check_ticket_limit_default(self):
+        for record in self:
+            if record.ticket_limit_default <= 0:
+                raise ValidationError("The default ticket limit must be greater than 0.")

--- a/event_ticket_limit/views/event_ticket_template_views.xml
+++ b/event_ticket_limit/views/event_ticket_template_views.xml
@@ -1,42 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="modal_ticket_registration" inherit_id="website_event.modal_ticket_registration">
-        <!-- Change the modal view for the ticket registration with multi tickets -->
+        <!-- Multi-ticket registration -->
         <xpath expr="//select[@t-attf-name='nb_register-#{ticket.id}']" position="replace">
-            <select
-                t-if="not ticket.is_expired and ticket.sale_available"
-                t-attf-name="nb_register-#{ticket.id}"
-                class="w-auto form-select">
-                    <t t-set="seats_max_ticket"
-                        t-value="(not ticket.seats_limited or ticket.seats_available &gt; ticket.ticket_limit) and ticket.ticket_limit + 1 or ticket.seats_available + 1"/>
-                    <t t-set="seats_max_event"
-                        t-value="(not event.seats_limited or event.seats_available &gt; ticket.ticket_limit) and ticket.ticket_limit + 1 or event.seats_available + 1"/>
-                    <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event)"/>
-                    <t t-foreach="range(0, seats_max)" t-as="nb">
-                        <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
-                    </t>
+            <div t-if="event.seats_limited and event.seats_max == 0" class="text-danger">
+                <p class="mb-0">No Tickets Available</p>
+            </div>
+            <select t-elif="not ticket.is_expired and ticket.sale_available"
+                t-attf-name="nb_register-#{ticket.id}" class="w-auto form-select">
+                <t t-set="ticket_limit" t-value="ticket.ticket_limit or 9"/>
+
+                <t t-set="max_tickets"
+                    t-value="min(ticket_limit, ticket.seats_available) if ticket.seats_limited else ticket_limit"/>
+                <t t-set="max_event"
+                    t-value="min(ticket_limit, event.seats_max) if event.seats_limited else ticket_limit"/>
+                <t t-set="max_seats" t-value="min(max_tickets, max_event)"/>
+
+                <t t-foreach="range(1, max_seats + 1)" t-as="nb">
+                    <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
+                </t>
             </select>
         </xpath>
-        <!-- Change the modal view for the ticket registration with single tickets -->
+
+        <!-- Single ticket registration -->
         <xpath expr="//div[hasclass('o_wevent_registration_single_select')]" position="replace">
-            <div class="o_wevent_registration_single_select w-auto ms-auto">
-                <select
-                    t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)"
-                    class="d-inline w-auto form-select">
-                        <t t-set="default_ticket_limit"
+            <t t-if="event.seats_limited and event.seats_max == 0">
+                <div class="text-danger">
+                    No Tickets Available
+                </div>
+            </t>
+            <t t-else="">
+                <div class="o_wevent_registration_single_select w-auto ms-auto">
+                    <select t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)"
+                        class="d-inline w-auto form-select">
+                        
+                        <t t-set="default_limit" 
                             t-value="int(request.env['ir.config_parameter'].sudo().get_param('event.ticket_limit_default', 9))"/>
-                        <t t-set="ticket_limit"
-                            t-value="int(tickets.ticket_limit if tickets else default_ticket_limit)"/>
-                        <t t-set="seats_max_ticket" 
-                            t-value="int((not tickets or not tickets.seats_limited or tickets.seats_available > ticket_limit) and ticket_limit or tickets.seats_available)"/>
-                        <t t-set="seats_max_event"
-                            t-value="int((not event.seats_limited or event.seats_available > ticket_limit) and ticket_limit or event.seats_available)"/>
-                        <t t-set="seats_max" t-value="int(min(seats_max_ticket, seats_max_event))"/>
-                        <t t-foreach="range(1, seats_max + 1)" t-as="nb">
+                            
+                        <t t-set="ticket_limit" 
+                            t-value="tickets.ticket_limit if tickets else default_limit"/>
+
+                        <t t-set="max_tickets" 
+                            t-value="min(ticket_limit, tickets.seats_available) if tickets and tickets.seats_limited else ticket_limit"/>
+                        <t t-set="max_event" 
+                            t-value="min(ticket_limit, event.seats_max) if event.seats_limited else ticket_limit"/>
+                        <t t-set="max_seats" t-value="min(max_tickets, max_event)"/>
+
+                        <t t-foreach="range(1, max_seats + 1)" t-as="nb">
                             <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
                         </t>
-                </select>
-            </div>
+                    </select>
+                </div>
+            </t>
         </xpath>
     </template>
 </odoo>

--- a/event_ticket_limit/views/event_ticket_template_views.xml
+++ b/event_ticket_limit/views/event_ticket_template_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="modal_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+        <!-- Change the modal view for the ticket registration with multi tickets -->
+        <xpath expr="//select[@t-attf-name='nb_register-#{ticket.id}']" position="replace">
+            <select
+                t-if="not ticket.is_expired and ticket.sale_available"
+                t-attf-name="nb_register-#{ticket.id}"
+                class="w-auto form-select">
+                    <t t-set="seats_max_ticket"
+                        t-value="(not ticket.seats_limited or ticket.seats_available &gt; ticket.ticket_limit) and ticket.ticket_limit + 1 or ticket.seats_available + 1"/>
+                    <t t-set="seats_max_event"
+                        t-value="(not event.seats_limited or event.seats_available &gt; ticket.ticket_limit) and ticket.ticket_limit + 1 or event.seats_available + 1"/>
+                    <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event)"/>
+                    <t t-foreach="range(0, seats_max)" t-as="nb">
+                        <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
+                    </t>
+            </select>
+        </xpath>
+        <!-- Change the modal view for the ticket registration with single tickets -->
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]" position="replace">
+            <div class="o_wevent_registration_single_select w-auto ms-auto">
+                <select
+                    t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)"
+                    class="d-inline w-auto form-select">
+                        <t t-set="default_ticket_limit"
+                            t-value="int(request.env['ir.config_parameter'].sudo().get_param('event.ticket_limit_default', 9))"/>
+                        <t t-set="ticket_limit"
+                            t-value="int(tickets.ticket_limit if tickets else default_ticket_limit)"/>
+                        <t t-set="seats_max_ticket" 
+                            t-value="int((not tickets or not tickets.seats_limited or tickets.seats_available > ticket_limit) and ticket_limit or tickets.seats_available)"/>
+                        <t t-set="seats_max_event"
+                            t-value="int((not event.seats_limited or event.seats_available > ticket_limit) and ticket_limit or event.seats_available)"/>
+                        <t t-set="seats_max" t-value="int(min(seats_max_ticket, seats_max_event))"/>
+                        <t t-foreach="range(1, seats_max + 1)" t-as="nb">
+                            <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
+                        </t>
+                </select>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/event_ticket_limit/views/event_ticket_views.xml
+++ b/event_ticket_limit/views/event_ticket_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Add ticket_limit field in event.event.ticket model form view -->
+    <record id="event_event_ticket_view_form_inherit_event_ticket_limit" model="ir.ui.view">
+        <field name="name">event.event.ticket.view.form.inherit.event.ticket.limit</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='is_expired']" position="after">
+                <field name="ticket_limit"/>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Add ticket_limit field in event.event.ticket model list view -->
+    <record id="event_event_ticket_view_list_inherit_event_ticket_limit" model="ir.ui.view">
+        <field name="name">event.event.ticket.view.list.inherit.event.ticket.limit</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='end_sale_datetime']" position="after">
+                <field name="ticket_limit"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/event_ticket_limit/views/res_config_settings_views.xml
+++ b/event_ticket_limit/views/res_config_settings_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Add setting option for set default ticket limit in event module -->
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.event.ticket.limit</field>
+            <field name="model">res.config.settings</field>
+            <field name="priority" eval="65"/>
+            <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//block[@name='events_setting_container']" position="inside">
+                    <setting
+                        string="Registration Limit"
+                        help="Set the default max number of tickets a user can purchase per registration">
+                        <div class="content-group">
+                            <div class="row mt8">
+                                <field name="ticket_limit_default" title="Default limit for ticket registration."/>
+                            </div>
+                        </div>
+                    </setting>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
1. Introduced a configuration setting to define the default maximum tickets per registration in events.

2. Updated the event form view to allow users to set a custom ticket limit for each event.

3. Modified the website event registration template to enforce the maximum ticket limit during online registrations.

Task - 4598929