### PR TITLE
[ADD] add_pricelist_price: added book_price field to Sale Order and Invoice line

### DIFF
--- a/add_pricelist_price/__init__.py
+++ b/add_pricelist_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/add_pricelist_price/__manifest__.py
+++ b/add_pricelist_price/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Add Pricelist Price",
+    "description": """
+        Add Pricelist Price
+    """,
+    "depends": ["sale_management"],
+    "data": [
+        "views/account_move_line_view.xml",
+        "views/sale_order_line_view.xml",
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/add_pricelist_price/models/__init__.py
+++ b/add_pricelist_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move_line
+from . import sale_order_line

--- a/add_pricelist_price/models/account_move_line.py
+++ b/add_pricelist_price/models/account_move_line.py
@@ -1,0 +1,21 @@
+from odoo import api, fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(string="Book Price", compute="_compute_book_price")
+
+    @api.depends("product_id", "quantity", "sale_line_ids.order_id.pricelist_id")
+    def _compute_book_price(self):
+        for line in self:
+            sale_order = line.sale_line_ids.order_id
+            pricelist = sale_order.pricelist_id if sale_order else None
+            if pricelist:
+                line.book_price = pricelist._get_product_price(
+                    line.product_id,
+                    line.quantity,
+                    line.product_uom_id,
+                )
+            else:
+                line.book_price = line.product_id.lst_price

--- a/add_pricelist_price/models/sale_order_line.py
+++ b/add_pricelist_price/models/sale_order_line.py
@@ -1,0 +1,22 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(string="Book Price", compute="_compute_book_price")
+
+    @api.depends("product_id", "product_uom_qty", "order_id.pricelist_id")
+    def _compute_book_price(self):
+        for line in self:
+            if line.product_id and line.order_id.pricelist_id:
+                pricelist = line.order_id.pricelist_id
+                product = line.product_id
+                price = pricelist._get_product_price(
+                    product,
+                    quantity=line.product_uom_qty,
+                    uom=line.product_uom,
+                )
+                line.book_price = price if price else line.product_id.lst_price
+            else:
+                line.book_price = line.product_id.lst_price

--- a/add_pricelist_price/views/account_move_line_view.xml
+++ b/add_pricelist_price/views/account_move_line_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Invoice Line View -->
+    <record id="view_invoice_form_inherit_book_price" model="ir.ui.view">
+        <field name="name">account.move.line.form.book.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='quantity']" position="before">
+                <field name="book_price" readonly="1" column_invisible="parent.move_type != 'out_invoice'" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/add_pricelist_price/views/sale_order_line_view.xml
+++ b/add_pricelist_price/views/sale_order_line_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Sales Order Line View -->
+    <record id="view_order_form_inherit_book_price" model="ir.ui.view">
+        <field name="name">sale.order.line.form.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="before">
+                <field name="book_price" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Add Pricelist Price 

    - Added `book_price` field to Sale Order Line and Account Move Line models.
    - Computed `book_price` using `_get_product_price` based on the sales order pricelist.
    - Updated views to display `book_price` in both Sale Order and Invoice lines.
    - Ensured proper model inheritance and field dependencies.

Task Id: 4599399