### PR TITLE
[ADD] supplier_portal: allow supplier invoice uploads and draft bills

### DIFF
--- a/supplier_portal/__init__.py
+++ b/supplier_portal/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/supplier_portal/__manifest__.py
+++ b/supplier_portal/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Supplier Portal",
+    "summary": "Allow suppliers to upload invoices (PDF & XML) via a portal and create draft bills.",
+    "description": """
+    This module provides a dedicated supplier portal where suppliers can log in and upload their invoices in PDF and XML format. Upon submission, the system automatically creates a draft vendor bill (`account.move`) in Odoo with the uploaded files attached.
+    """,
+    "depends": ["website", "account"],
+    "data": ["views/supplier_portal_website_template.xml"],
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/supplier_portal/controllers/__init__.py
+++ b/supplier_portal/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import supplier_portal_website

--- a/supplier_portal/controllers/supplier_portal_website.py
+++ b/supplier_portal/controllers/supplier_portal_website.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+import base64
+
+from odoo import http
+from odoo.http import request
+
+
+class SupplierPortal(http.Controller):
+    @http.route(["/supplier/upload"], auth="user", type="http", website=True)
+    def supplier_login(self):
+        companies = request.env.user.company_ids
+        return request.render("supplier_portal.supplier_upload_page", {"companies": companies})
+
+    @http.route(["/supplier/submit"], auth="user", type="http", methods=["POST"], website=True)
+    def supplier_invoice_submit(self, **post):
+        try:
+            supplier = request.env.user.partner_id
+            company_id = int(post.get("company"))
+            pdf_invoice = post.get("pdf_invoice")
+            xml_invoice = post.get("xml_invoice")
+            
+            # Create Vendor Bill
+            bill_vals = {
+                "partner_id": supplier.id,
+                "move_type": "in_invoice",
+                "company_id": company_id,
+                "invoice_date": datetime.today(),
+                "state": "draft",
+            }
+        
+            bill = request.env["account.move"].sudo().create(bill_vals)
+
+            for file in [pdf_invoice, xml_invoice]:
+                request.env["ir.attachment"].sudo().create(
+                    {
+                        "name": file.filename,
+                        "res_model": "account.move",
+                        "res_id": bill.id,
+                        "type": "binary",
+                        "datas": base64.b64encode(file.read()),
+                        "mimetype": file.content_type,
+                    }
+                )
+            return request.redirect("/supplier/upload?success=1")
+
+        except Exception as e:
+            return request.redirect(f"/supplier/upload?error={str(e)}")

--- a/supplier_portal/views/supplier_portal_website_template.xml
+++ b/supplier_portal/views/supplier_portal_website_template.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="supplier_upload_page" name="Supplier Login Page">
+        <t t-call="website.layout">
+            <div class="container">
+                <section class="bg-primary text-white text-center py-5">
+                    <h1 class="fw-bold display-4">Supplier Login</h1>
+                </section>
+
+                <t t-if="request.params.get('success')">
+                    <p class="alert alert-success">Your invoice has been submitted successfully.</p>
+                </t>
+                <t t-if="request.params.get('error')">
+                    <p class="alert alert-danger">Please upload both PDF and XML files.</p>
+                    <span><t t-out="request.params.get('error')"/></span>
+                </t>
+                
+                <form action="/supplier/submit/" method="post" enctype="multipart/form-data" class="p-4 bg-white shadow rounded-3">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">
+                            <i class="fa fa-building"></i> Select Organization
+                        </label>
+                        <select name="company" class="form-select border border-primary" required="1">
+                            <option value="" disabled="true" selected="true">Choose your company</option>
+                            <t t-foreach="companies" t-as="company">
+                                <option t-att-value="company.id">
+                                    <t t-esc="company.name"/>
+                                </option>
+                            </t>
+                        </select>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">
+                            <i class="fa fa-file-pdf text-danger"></i> Upload PDF Invoice
+                        </label>
+                        <input type="file" name="pdf_invoice" accept="application/pdf" class="form-control border border-danger" required="1" />
+                        <small class="text-muted">Allowed file type: PDF</small>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">
+                            <i class="fa fa-file-code text-warning"></i> Upload XML Invoice
+                        </label>
+                        <input type="file" name="xml_invoice" accept="text/xml" class="form-control border border-warning" required="1" />
+                        <small class="text-muted">Allowed file type: XML</small>
+                    </div>
+
+                    <div class="d-grid">
+                        <button type="submit" class="btn btn-primary btn-lg shadow-sm">
+                            <i class="fa fa-paper-plane"></i> Submit Invoice
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
In this commit:
 - Introduce a supplier portal where suppliers can log in and submit their invoices.
 - Add a form for suppliers to select their organization and upload PDF/XML invoice files.
 - Implement backend logic to create a draft bill upon submission, associating the uploaded files.
 - Ensure supplier details are pre-filled in the bill while products remain manually configurable.
 - Improve supplier experience by streamlining invoice submission and reducing manual data entry.

Task Id: 4598783