### PR TITLE
18.0-custom-report-drat

### DIFF
--- a/new_mrp/__manifest__.py
+++ b/new_mrp/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'New Mrp',
+    'version': '1.0',
+    'description': 'Custom MO Delivery Note report without Kit Products(in Inventory)',
+    'depends': ['mrp', 'sale_management'],
+    'data': [
+        'report/report_mo_delivery_note_views.xml',
+        'report/report_mo_delivery_note.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/new_mrp/report/report_mo_delivery_note.xml
+++ b/new_mrp/report/report_mo_delivery_note.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="action_report_mo_delivery_note" model="ir.actions.report">
+            <field name="name">Mo Delivery note</field>
+            <field name="model">stock.picking</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">new_mrp.report_mo_delivery_note</field>
+            <field name="report_file">new_mrp.report_mo_delivery_note</field>
+            <field name="print_report_name">'Mo Delivery Note -- %s - %s' % (object.partner_id.name or '', object.name)</field>
+            <field name="binding_model_id" ref="stock.model_stock_picking" />
+            <field name="binding_type">report</field>
+        </record>
+    </data>
+</odoo>

--- a/new_mrp/report/report_mo_delivery_note_views.xml
+++ b/new_mrp/report/report_mo_delivery_note_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_delivery_document" inherit_id="stock.report_delivery_document" primary="True">
+        <xpath expr="//table[@name='stock_move_table']/tbody/t" position="replace">
+            <t t-set="lines" t-value="o.move_ids.filtered(lambda x: x.product_uom_qty and (not x.bom_line_id or x.bom_line_id.bom_id.type != 'phantom'))" />
+        </xpath>
+    </template>
+    <template id="report_mo_delivery_note">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="new_mrp.report_delivery_document" t-lang="o._get_report_lang()"/>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
[ADD] new_mrp: Implement new.mrp module

This commit includes:
- Added mo_delivery_note report and views (similar to Delivery Slip report but excludes Kit Products).

Task name: Custom Picking report  
Task link:  
https://link.excalidraw.com/readonly/caLMnqPQHAnC8yMdfgVW