### PR TITLE
[IMP] event_ticket_limit : enforced maximum ticket limit per registration

### DIFF
--- a/event_ticket_limit/__init__.py
+++ b/event_ticket_limit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_ticket_limit/__manifest__.py
+++ b/event_ticket_limit/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': "Event Ticket Limit",
+    'version': "1.0",
+    'description': """
+        Module for limiting the number of tickets that can be booked in single registration.
+    """,
+    'depends': ['base_setup', 'event' , 'website_event'],
+    'category': "Marketing/Events",
+    'author': "Himilsinh Sindha (hisi)",
+    'website': "https://www.odoo.com/app/events",
+    'data': [
+        'views/event_ticket_views.xml',
+        'views/event_templates_page_registration.xml',
+    ],
+    'license': "LGPL-3",
+    'installable': True,
+    'auto_install': True,
+}

--- a/event_ticket_limit/__manifest__.py
+++ b/event_ticket_limit/__manifest__.py
@@ -4,11 +4,12 @@
     'description': """
         Module for limiting the number of tickets that can be booked in single registration.
     """,
-    'depends': ['base_setup', 'event' , 'website_event'],
+    'depends': ['event' , 'website_event'],
     'category': "Marketing/Events",
     'author': "Himilsinh Sindha (hisi)",
     'website': "https://www.odoo.com/app/events",
     'data': [
+        'views/event_views.xml',
         'views/event_ticket_views.xml',
         'views/event_templates_page_registration.xml',
     ],

--- a/event_ticket_limit/models/__init__.py
+++ b/event_ticket_limit/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_ticket

--- a/event_ticket_limit/models/__init__.py
+++ b/event_ticket_limit/models/__init__.py
@@ -1,1 +1,2 @@
+from . import event
 from . import event_ticket

--- a/event_ticket_limit/models/event.py
+++ b/event_ticket_limit/models/event.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class EventEvent(models.Model):
+    _inherit = "event.event"
+
+    default_tickets_per_registration = fields.Integer(
+        string="Default Tickets per Registration",
+        default=10,
+        help="Defines the maximum number of tickets per registration.",
+        required=True
+    )

--- a/event_ticket_limit/models/event_ticket.py
+++ b/event_ticket_limit/models/event_ticket.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class EventTicket(models.Model):
+    _inherit = 'event.event.ticket'
+
+    maximum_tickets_per_registration = fields.Integer(
+        string="Maximum Tickets Per Registration",
+        help="Define the maximum numbers of tickets allowed to book per registration."
+    )

--- a/event_ticket_limit/views/event_templates_page_registration.xml
+++ b/event_ticket_limit/views/event_templates_page_registration.xml
@@ -1,22 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="modal_ticket_registration" name="modal_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+    <template id="modal_ticket_registration" name="Modal Ticket Registration"
+        inherit_id="website_event.modal_ticket_registration">
 
-        <!-- Replace the logic that calculates the maximum number of tickets allowed per registration at the ticket level -->
+        <!-- For Multiple Ticket Types -->
         <xpath expr="//t[@t-set='seats_max_ticket']" position="replace">
-            <t t-set="seats_max_ticket" 
-               t-value="(not ticket.seats_limited or ticket.seats_available &gt; ticket.maximum_tickets_per_registration) 
-                        and ticket.maximum_tickets_per_registration 
-                        or ticket.seats_available + 1"/>
+            <t t-set="seats_max_ticket"
+                t-value="(not ticket.seats_limited or ticket.seats_available > ticket.maximum_tickets_per_registration)
+                        and ticket.maximum_tickets_per_registration + 1
+                        or ticket.seats_available + 1" />
         </xpath>
 
-        <!-- Replace the logic that calculates the maximum number of tickets allowed per registration at the event level -->
         <xpath expr="//t[@t-set='seats_max_event']" position="replace">
-            <t t-set="seats_max_event" 
-               t-value="(not event.seats_limited or event.seats_available &gt; ticket.maximum_tickets_per_registration) 
-                        and ticket.maximum_tickets_per_registration 
-                        or event.seats_available + 1"/>
+            <t t-set="seats_max_event"
+                t-value="(not event.seats_limited or event.seats_available > ticket.maximum_tickets_per_registration)
+                        and ticket.maximum_tickets_per_registration + 1
+                        or event.seats_available + 1" />
         </xpath>
 
+        <!-- For Single Ticket Type -->
+        <xpath expr="//div[contains(@class, 'o_wevent_registration_single_select')]"
+            position="replace">
+            <div class="o_wevent_registration_single_select w-auto ms-auto">
+                <select t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)"
+                    class="d-inline w-auto form-select">
+
+                    <!--
+                        Compute the maximum number of tickets a user can register for a specific ticket type.
+                        - If ticket limits are not set, allow 'maximum_tickets_per_registration' tickets.
+                        - If limited, ensure the maximum does not exceed available seats.
+                    -->
+                    <t t-set="seats_max_ticket"
+                        t-value="(not tickets or not tickets.seats_limited or tickets.seats_available > tickets.maximum_tickets_per_registration)
+                                and tickets.maximum_tickets_per_registration + 1
+                                or tickets.seats_available + 1" />
+
+                    <!--
+                        Compute the maximum number of tickets a user can register for the event as a whole.
+                        - If no seat limits, allow 'maximum_tickets_per_registration' tickets.
+                        - If limited, ensure the max does not exceed event seat availability.
+                    -->
+                    <t t-set="seats_max_event"
+                        t-value="(not event.seats_limited or event.seats_available > tickets.maximum_tickets_per_registration)
+                                and tickets.maximum_tickets_per_registration + 1
+                                or event.seats_available + 1" />
+
+                    <!--
+                        Determine the final max selectable tickets:
+                        - If ticket-specific, take the minimum of 'seats_max_ticket' and 'seats_max_event'.
+                        - Otherwise, use the event-wide default or available seats.
+                    -->
+                    <t t-set="seats_max"
+                        t-value="min(seats_max_ticket, seats_max_event) if tickets
+                                else min(event.default_tickets_per_registration, event.seats_available) + 1" />
+
+                    <t t-foreach="range(0, seats_max)" t-as="nb">
+                        <option t-out="nb" t-att-selected="nb == 1 and 'selected'" />
+                    </t>
+                </select>
+            </div>
+        </xpath>
     </template>
 </odoo>

--- a/event_ticket_limit/views/event_templates_page_registration.xml
+++ b/event_ticket_limit/views/event_templates_page_registration.xml
@@ -2,20 +2,15 @@
 <odoo>
     <template id="modal_ticket_registration" name="Modal Ticket Registration"
         inherit_id="website_event.modal_ticket_registration">
-
         <!-- For Multiple Ticket Types -->
         <xpath expr="//t[@t-set='seats_max_ticket']" position="replace">
             <t t-set="seats_max_ticket"
-                t-value="(not ticket.seats_limited or ticket.seats_available &gt; ticket.maximum_tickets_per_registration)
-                        and ticket.maximum_tickets_per_registration + 1
-                        or ticket.seats_available + 1" />
+                t-value="min(ticket.seats_available, ticket.maximum_tickets_per_registration) + 1 if ticket and ticket.seats_limited else ticket.maximum_tickets_per_registration + 1" />
         </xpath>
 
         <xpath expr="//t[@t-set='seats_max_event']" position="replace">
             <t t-set="seats_max_event"
-                t-value="(not event.seats_limited or event.seats_available &gt; ticket.maximum_tickets_per_registration)
-                        and ticket.maximum_tickets_per_registration + 1
-                        or event.seats_available + 1" />
+                t-value="min(event.seats_available, ticket.maximum_tickets_per_registration) + 1 if ticket and event.seats_limited else ticket.maximum_tickets_per_registration + 1" />
         </xpath>
 
         <!-- For Single Ticket Type -->
@@ -25,34 +20,23 @@
                 <select t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)"
                     class="d-inline w-auto form-select">
 
-                    <t t-set="ticket_limit" t-value="(tickets.maximum_tickets_per_registration if tickets else event.default_tickets_per_registration) + 1"/>
+                    <t t-set="ticket_limit"
+                        t-value="(tickets.maximum_tickets_per_registration if tickets else event.default_tickets_per_registration)" />
 
-                    <!--
-                        Compute the maximum number of tickets a user can register for a specific ticket type.
-                        - If ticket limits are not set, allow 'maximum_tickets_per_registration' tickets.
-                        - If limited, ensure the maximum does not exceed available seats.
-                    -->
+                    <!-- Compute max tickets per user: allow 'ticket_limit' if no limits, else cap at available seats. -->
                     <t t-set="seats_max_ticket"
-                        t-value="min(tickets.seats_available + 1, ticket_limit) if tickets and tickets.seats_limited + 1 else ticket_limit" />
+                        t-value="min(tickets.seats_available, ticket_limit) + 1 if tickets and tickets.seats_limited else ticket_limit + 1" />
 
-                    <!--
-                        Compute the maximum number of tickets a user can register for the event as a whole.
-                        - If no seat limits, allow 'maximum_tickets_per_registration' tickets.
-                        - If limited, ensure the max does not exceed event seat availability.
-                    -->
+                    <!-- Compute max tickets per user for the event: allow 'ticket_limit' if no limits, else cap at available event seats. -->
                     <t t-set="seats_max_event"
-                        t-value="min(event.seats_available + 1, ticket_limit) if tickets and event.seats_limited + 1 else ticket_limit" />
+                        t-value="min(event.seats_available, ticket_limit) +1 if tickets and event.seats_limited else ticket_limit + 1" />
 
-                    <!--
-                        Determine the final max selectable tickets:
-                        - If ticket-specific, take the minimum of 'seats_max_ticket' and 'seats_max_event'.
-                        - Otherwise, use the event-wide default or available seats.
-                    -->
+                    <!-- Determine final max selectable tickets: use min of 'seats_max_ticket' & 'seats_max_event' if ticket-specific, else default/event seats. -->
                     <t t-set="seats_max"
                         t-value="min(seats_max_ticket, seats_max_event) if tickets
-                                else min(ticket_limit, event.seats_available + 1) if event.seats_limited else ticket_limit" />
+                                else min(ticket_limit, event.seats_available) + 1 if event.seats_limited else ticket_limit + 1" />
 
-                    <t t-foreach="range(0, seats_max)" t-as="nb">
+                    <t t-foreach="range(1, seats_max)" t-as="nb">
                         <option t-out="nb" t-att-selected="nb == 1 and 'selected'" />
                     </t>
                 </select>

--- a/event_ticket_limit/views/event_templates_page_registration.xml
+++ b/event_ticket_limit/views/event_templates_page_registration.xml
@@ -6,14 +6,14 @@
         <!-- For Multiple Ticket Types -->
         <xpath expr="//t[@t-set='seats_max_ticket']" position="replace">
             <t t-set="seats_max_ticket"
-                t-value="(not ticket.seats_limited or ticket.seats_available > ticket.maximum_tickets_per_registration)
+                t-value="(not ticket.seats_limited or ticket.seats_available &gt; ticket.maximum_tickets_per_registration)
                         and ticket.maximum_tickets_per_registration + 1
                         or ticket.seats_available + 1" />
         </xpath>
 
         <xpath expr="//t[@t-set='seats_max_event']" position="replace">
             <t t-set="seats_max_event"
-                t-value="(not event.seats_limited or event.seats_available > ticket.maximum_tickets_per_registration)
+                t-value="(not event.seats_limited or event.seats_available &gt; ticket.maximum_tickets_per_registration)
                         and ticket.maximum_tickets_per_registration + 1
                         or event.seats_available + 1" />
         </xpath>
@@ -25,15 +25,15 @@
                 <select t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)"
                     class="d-inline w-auto form-select">
 
+                    <t t-set="ticket_limit" t-value="(tickets.maximum_tickets_per_registration if tickets else event.default_tickets_per_registration) + 1"/>
+
                     <!--
                         Compute the maximum number of tickets a user can register for a specific ticket type.
                         - If ticket limits are not set, allow 'maximum_tickets_per_registration' tickets.
                         - If limited, ensure the maximum does not exceed available seats.
                     -->
                     <t t-set="seats_max_ticket"
-                        t-value="(not tickets or not tickets.seats_limited or tickets.seats_available > tickets.maximum_tickets_per_registration)
-                                and tickets.maximum_tickets_per_registration + 1
-                                or tickets.seats_available + 1" />
+                        t-value="min(tickets.seats_available + 1, ticket_limit) if tickets and tickets.seats_limited + 1 else ticket_limit" />
 
                     <!--
                         Compute the maximum number of tickets a user can register for the event as a whole.
@@ -41,9 +41,7 @@
                         - If limited, ensure the max does not exceed event seat availability.
                     -->
                     <t t-set="seats_max_event"
-                        t-value="(not event.seats_limited or event.seats_available > tickets.maximum_tickets_per_registration)
-                                and tickets.maximum_tickets_per_registration + 1
-                                or event.seats_available + 1" />
+                        t-value="min(event.seats_available + 1, ticket_limit) if tickets and event.seats_limited + 1 else ticket_limit" />
 
                     <!--
                         Determine the final max selectable tickets:
@@ -52,7 +50,7 @@
                     -->
                     <t t-set="seats_max"
                         t-value="min(seats_max_ticket, seats_max_event) if tickets
-                                else min(event.default_tickets_per_registration, event.seats_available) + 1" />
+                                else min(ticket_limit, event.seats_available + 1) if event.seats_limited else ticket_limit" />
 
                     <t t-foreach="range(0, seats_max)" t-as="nb">
                         <option t-out="nb" t-att-selected="nb == 1 and 'selected'" />

--- a/event_ticket_limit/views/event_templates_page_registration.xml
+++ b/event_ticket_limit/views/event_templates_page_registration.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="modal_ticket_registration" name="modal_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+
+        <!-- Replace the logic that calculates the maximum number of tickets allowed per registration at the ticket level -->
+        <xpath expr="//t[@t-set='seats_max_ticket']" position="replace">
+            <t t-set="seats_max_ticket" 
+               t-value="(not ticket.seats_limited or ticket.seats_available &gt; ticket.maximum_tickets_per_registration) 
+                        and ticket.maximum_tickets_per_registration 
+                        or ticket.seats_available + 1"/>
+        </xpath>
+
+        <!-- Replace the logic that calculates the maximum number of tickets allowed per registration at the event level -->
+        <xpath expr="//t[@t-set='seats_max_event']" position="replace">
+            <t t-set="seats_max_event" 
+               t-value="(not event.seats_limited or event.seats_available &gt; ticket.maximum_tickets_per_registration) 
+                        and ticket.maximum_tickets_per_registration 
+                        or event.seats_available + 1"/>
+        </xpath>
+
+    </template>
+</odoo>

--- a/event_ticket_limit/views/event_ticket_views.xml
+++ b/event_ticket_limit/views/event_ticket_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="event_event_ticket_view_tree_from_event" model="ir.ui.view">
+    <record id="event_event_ticket_view_tree_from_event_inherit_ticket_limit" model="ir.ui.view">
         <field name="name">event.event.ticket.view.list.from.event.inherit</field>
         <field name="model">event.event.ticket</field>
         <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>

--- a/event_ticket_limit/views/event_ticket_views.xml
+++ b/event_ticket_limit/views/event_ticket_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_event_ticket_view_tree_from_event" model="ir.ui.view">
+        <field name="name">event.event.ticket.view.list.from.event.inherit</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='seats_max']" position="after">
+                <field name="maximum_tickets_per_registration" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/event_ticket_limit/views/event_views.xml
+++ b/event_ticket_limit/views/event_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_event_form_inherit" model="ir.ui.view">
+        <field name="name">event.event.form.view.inherit</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='badge_format']" position="before">
+                <field name="default_tickets_per_registration"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this PR:
1. Implemented a restriction using `maximum_tickets_per_registration` to limit the number of tickets a user can book in a single registration.

2. Updated the event registration modal to enforce this limit dynamically based on ticket and event seat availability.

3. Modified QWeb template of website_event to ensure proper validation at the frontend, preventing users from exceeding the defined ticket limit.

task-4602833