### PR TITLE
[ADD] pos_uom_extension: support second UOM selection in POS

### DIFF
--- a/pos_uom_extension/__init__.py
+++ b/pos_uom_extension/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_uom_extension/__manifest__.py
+++ b/pos_uom_extension/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'POS Second Unit of Measure',
+    'depends': ['point_of_sale', 'uom'],
+    'data': [
+        'views/product_template_view.xml',
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_uom_extension/static/src/**/*',
+        ],
+    },
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/pos_uom_extension/models/__init__.py
+++ b/pos_uom_extension/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product
+from . import product_template

--- a/pos_uom_extension/models/product.py
+++ b/pos_uom_extension/models/product.py
@@ -1,0 +1,10 @@
+from odoo import api, models
+
+class Product(models.Model):
+    _inherit = 'product.product'
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        fields = super()._load_pos_data_fields(config_id)
+        fields.extend(['second_uom_id'])
+        return fields

--- a/pos_uom_extension/models/product_template.py
+++ b/pos_uom_extension/models/product_template.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    uom_category_id = fields.Many2one('uom.category', string='UoM Category', related="uom_id.category_id")
+    second_uom_id = fields.Many2one(
+        'uom.uom',
+        string="Second Uom",
+        domain="[('category_id', '=', uom_category_id), ('id', '!=', uom_id)]",
+        context={'create': False},
+        help="Select an existing second UoM from the same category as the main UoM."
+    )

--- a/pos_uom_extension/static/src/overrides/control_buttons/add_quantity_dialog/add_quantity_dialog.js
+++ b/pos_uom_extension/static/src/overrides/control_buttons/add_quantity_dialog/add_quantity_dialog.js
@@ -1,0 +1,35 @@
+import { Dialog } from "@web/core/dialog/dialog";
+import { Component, useRef } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+
+export class AddQuantityDialog extends Component {
+    static template = "pos_uom_extension.AddQuantityDialog";
+    static components = { Dialog };
+    static props = {
+        close: { type: Function },
+        product: { type: Object },
+        secondUomName: {type: String, optional: true},
+    };
+
+    setup(){
+        this.pos = usePos();
+        this.input_qty = useRef("quantityInput");
+        this.uom_ratio = this.computeUomRatio(this.props.product)
+    }
+
+    computeUomRatio(product) {
+        if (product.uom_id && product.second_uom_id) {
+            return product.uom_id.factor / product.second_uom_id.factor;
+        }
+        return 1;
+    }
+    
+    confirm() {
+        const quantity = parseFloat(this.input_qty.el.value);
+        const selectedLine = this.pos.get_order().get_selected_orderline();
+        if (selectedLine) {
+            selectedLine.set_quantity(quantity * this.uom_ratio);
+        }
+        this.props.close(); 
+    }
+}

--- a/pos_uom_extension/static/src/overrides/control_buttons/add_quantity_dialog/add_quantity_dialog.xml
+++ b/pos_uom_extension/static/src/overrides/control_buttons/add_quantity_dialog/add_quantity_dialog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="pos_uom_extension.AddQuantityDialog">
+        <Dialog size="'sm'" header="false">
+            <t t-set-slot="default">
+                <div>
+                    <label for="quantityInput" class="form-label">
+                        Enter Quantity in <b><t t-out="props.secondUomName"/></b>
+                    </label>
+                    <input type="number" min="0" class="form-control" id="quantityInput"
+                        placeholder="Enter quantity" t-ref="quantityInput" />
+                </div>
+            </t>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="confirm">
+                    Confirm
+                </button>
+                <button class="btn btn-secondary" t-on-click="props.close">
+                    Cancel
+                </button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/pos_uom_extension/static/src/overrides/control_buttons/control_buttons.js
+++ b/pos_uom_extension/static/src/overrides/control_buttons/control_buttons.js
@@ -1,0 +1,27 @@
+import { patch } from "@web/core/utils/patch";
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { AddQuantityDialog } from "./add_quantity_dialog/add_quantity_dialog";
+
+patch(ControlButtons.prototype, { 
+    setup(){
+        super.setup();
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+        this.dialog = useService("dialog");
+    },
+
+    get secondUomName(){
+        return this.currentOrder.get_selected_orderline().product_id.second_uom_id?.name;
+    },
+
+    onAddQuantity(){
+        const product = this.currentOrder.get_selected_orderline().get_product();
+        this.dialog.add(AddQuantityDialog, {
+            product,
+            secondUomName: this.secondUomName,
+        });
+    },
+});

--- a/pos_uom_extension/static/src/overrides/control_buttons/control_buttons.xml
+++ b/pos_uom_extension/static/src/overrides/control_buttons/control_buttons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_uom_extension.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//SelectPartnerButton" position="before">
+            <button t-if="!currentOrder?.is_empty() and currentOrder?.uiState.selected_orderline_uuid and secondUomName" t-attf-class="{{buttonClass}}" t-on-click="onAddQuantity">
+                <span>Add Quantity</span>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/pos_uom_extension/views/product_template_view.xml
+++ b/pos_uom_extension/views/product_template_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='pos_categ_ids']" position="after">
+                <field name="second_uom_id" options="{'no_create': True, 'no_create_edit': True}" groups="uom.group_uom"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
After this commit:

- Allow selection of secondary UoM in product form view.
- Display the 'Add Quantity' button in POS when secondary UoM is selected.
- Auto-convert secondary UoM to primary UoM for accurate stock management.
- Enhance user experience with flexible quantity input in POS.