### PR TITLE
[ADD] point_of_sale_second_uom: added second uom for cashier in pos

### DIFF
--- a/point_of_sale_second_uom/__init__.py
+++ b/point_of_sale_second_uom/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/point_of_sale_second_uom/__manifest__.py
+++ b/point_of_sale_second_uom/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "Point of Sale Second UoM",
+    "version": "1.0",
+    "summary": " provide second uom functionality",
+    "description": """
+        Add second UoM for the products in pos
+    """,
+    "author": "Odoo",
+    'auto_install': True,
+    'data': [
+        'views/product_view.xml'
+    ],
+    "license": "LGPL-3",
+    "depends": ["point_of_sale"],
+    "assets": {
+        "point_of_sale._assets_pos": [
+            "point_of_sale_second_uom/static/src/**/*",
+        ],
+    },
+}

--- a/point_of_sale_second_uom/models/__init__.py
+++ b/point_of_sale_second_uom/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/point_of_sale_second_uom/models/product_template.py
+++ b/point_of_sale_second_uom/models/product_template.py
@@ -1,0 +1,30 @@
+from odoo import models,fields,api
+
+class ProductTemplate(models.Model):
+    _inherit = ['product.template']
+
+    def _get_default_second_uom(self):
+        return self.env.ref('uom.product_uom_dozen')
+
+    uom_category_id = fields.Many2one('uom.category', string='UoM Category', related="uom_id.category_id")
+    second_uom_id = fields.Many2one(string="Second UoM", comodel_name="uom.uom", help="It helps in choosing product in second UoM", domain="[('category_id', '=', uom_category_id), ('id', '!=', uom_id)]", default=_get_default_second_uom, required=True)
+
+    @api.onchange('uom_id')
+    def _onchange_uom_id(self):
+        """
+        Update second_uom default value dynamically whenever uom_id changes.
+        """
+        if self.uom_id:
+            domain = [('category_id', '=', self.uom_id.category_id.id), ('id', '!=', self.uom_id.id)]
+            second_uom_id = self.env['uom.uom'].search(domain, limit=1)
+            self.second_uom_id = second_uom_id.id if second_uom_id else False
+        else:
+            self.second_uom = False
+
+class ProductProduct(models.Model):
+    _name = 'product.product'
+    _inherit = ['product.product', 'pos.load.mixin']
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return super()._load_pos_data_fields(config_id) + ['second_uom_id']

--- a/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/add_quantity_button.js
+++ b/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/add_quantity_button.js
@@ -1,0 +1,33 @@
+import { patch } from "@web/core/utils/patch";
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { AddQuantityDialog } from "./dialog/add_quantity_dialog";
+import { useService } from "@web/core/utils/hooks";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useState } from "@odoo/owl";
+
+patch(ControlButtons.prototype, {
+    setup() {
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+    },
+    get currentOrder() {
+        return this.pos.get_order();
+    },
+    get product(){
+        return this.pos.selectedOrder.get_selected_orderline().product_id
+    },
+    onAddQuantity() {
+        const second_uom = this.product.second_uom_id.name
+        const primary_factor = this.product.uom_id.factor
+        const secondary_factor = this.product.second_uom_id.factor
+        this.env.services.dialog.add(AddQuantityDialog, {
+            second_uom,
+            confirm: (quantity) => {
+                this.pos.selectedOrder.get_selected_orderline().set_quantity(quantity*(primary_factor/secondary_factor))
+            },
+            close: () => {
+                console.log("Dialog discarded");
+            },
+        });
+    },
+});

--- a/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/add_quantity_button.xml
+++ b/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/add_quantity_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_addquantity.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//SelectPartnerButton" position="before">
+        <button t-if="!currentOrder?.is_empty() and pos.get_order()?.uiState.selected_orderline_uuid" t-attf-class="{{buttonClass}}" t-on-click="onAddQuantity">
+            Add Quantity
+        </button>
+    </xpath>
+    </t>
+</templates>

--- a/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/dialog/add_quantity_dialog.js
+++ b/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/dialog/add_quantity_dialog.js
@@ -1,0 +1,30 @@
+import { _t } from "@web/core/l10n/translation";
+import { Dialog } from "@web/core/dialog/dialog";
+import { Component } from "@odoo/owl";
+
+export class AddQuantityDialog extends Component {
+    static template = "pos.AddQuantityDialog";
+    static components = {
+        Dialog,
+    };
+    static props = {
+        confirm: Function,
+        close: Function,
+        second_uom: {type: String, optional: true},
+    };
+    setup() {
+        this.state = {
+            quantity: 1,
+        };
+    }
+    get quantity1() {
+        return this.state.quantity;
+    }
+    confirm() {
+        this.props.confirm(this.quantity1);
+        this.props.close();
+    }
+    close() {
+        this.props.close();
+    }
+}

--- a/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/dialog/add_quantity_dialog.xml
+++ b/point_of_sale_second_uom/static/src/app/screens/product_screen/control_buttons/add_quantity_button/dialog/add_quantity_dialog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="pos.AddQuantityDialog">
+        <Dialog size="'sm'" title="'Enter Quantity - in ' + props.second_uom">
+            <div class="mb-3">
+                <label for="quantityInput" class="form-label">Quantity</label>
+                <input id="quantityInput" type="number" class="form-control" t-model="state.quantity" min="1" />
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="confirm">
+                    Confirm
+                </button>
+                <button class="btn btn-secondary" t-on-click="close">
+                    Discard
+                </button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/point_of_sale_second_uom/views/product_view.xml
+++ b/point_of_sale_second_uom/views/product_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='pos_categ_ids']" position="after">
+                <field name="second_uom_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- added second_uom_id field in point of sale section of product form
- added functionality for second_uom_id to only select uom of same category as primary uom except for the value selected in primary uom
- added 'Add Quantity' button in pos
- added dialog for 'Add Quantity' button which take input in second uom and on confirm button pressed, it convert second uom into primary uom and update value in orderline
Task Id: 4595712