### PR TITLE
[ADD] appointment_filter: implemented filters in the website_appointment

### DIFF
--- a/appointment_filter/__init__.py
+++ b/appointment_filter/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/appointment_filter/__manifest__.py
+++ b/appointment_filter/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "appointment_filter",
+    "description": "An extension module of website appointment module which helps to filter data",
+    "summary": "Enhancing User Experience by adding filters in website view",
+    "depends": ["website_appointment","appointment_account_payment"],
+    "author": "Vedant Pandey (vpan)",
+    "category": "Website",
+    "version": "1.0",
+    "data": [
+        "views/appointment_filter_template.xml"
+    ],
+    "installable": True,
+    "license":"LGPL-3",
+}

--- a/appointment_filter/controllers/__init__.py
+++ b/appointment_filter/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import appointment_filters

--- a/appointment_filter/controllers/appointment_filters.py
+++ b/appointment_filter/controllers/appointment_filters.py
@@ -1,0 +1,61 @@
+from odoo import http
+from odoo.http import request
+from odoo.addons.website_appointment.controllers.appointment import WebsiteAppointment
+
+
+class WebsiteAppointmentFiltered(WebsiteAppointment):
+
+    @http.route()
+    def appointment_type_index(self, page=1, **kwargs):
+        available_domain = self._appointment_website_domain()
+        extra_domain = []
+
+        filters = [
+            {
+                "label": "appointment_type",
+                "value": "online",
+                "condition": ("location_id", "=", False)
+            },
+            {
+                "label": "appointment_type",
+                "value": "offline",
+                "condition": ("location_id", "!=", False)
+            },
+            {
+                "label": "payment_step",
+                "value": "required",
+                "condition": ("has_payment_step", "=", True)
+            },
+            {
+                "label": "payment_step",
+                "value": "not_required",
+                "condition": ("has_payment_step", "=", False)
+            },
+            {
+                "label": "schedule_based_on",
+                "value": "users",
+                "condition": ("schedule_based_on", "=", "users")
+            },
+            {
+                "label": "schedule_based_on",
+                "value": "resources",
+                "condition": ("schedule_based_on", "=", "resources")
+            },
+        ]
+        for filter in filters:
+            if kwargs.get(filter["label"]) == filter["value"]:
+                extra_domain.append(filter["condition"])
+
+        if kwargs.get("search"):
+            extra_domain.append(("name", "ilike", kwargs["search"]))
+
+        final_domain = available_domain + extra_domain
+        appointments = request.env["appointment.type"].sudo().search(final_domain)
+
+        values = self._prepare_appointments_cards_data(
+            appointment_types=appointments,
+            page=page,
+            **kwargs  
+        )
+
+        return request.render("website_appointment.appointments_cards_layout", values)

--- a/appointment_filter/views/appointment_filter_template.xml
+++ b/appointment_filter/views/appointment_filter_template.xml
@@ -1,0 +1,36 @@
+<odoo>
+    <template id="appointment_page_with_filters" inherit_id="website_appointment.website_calendar_index_topbar">
+        <xpath expr="//h4" position="after">
+            <div class="dropdown">
+                <button class="btn btn-outline-primary dropdown-toggle" type="button" id="selectType" data-bs-toggle="dropdown" aria-expanded="false">
+                    Type
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="selectType">
+                    <li><a class="dropdown-item" href="/appointment">All</a></li>
+                    <li><a class="dropdown-item" href="/appointment?appointment_type=online">Online</a></li>
+                    <li><a class="dropdown-item" href="/appointment?appointment_type=offline">Offline</a></li>
+                </ul>
+            </div>
+            <div class="dropdown">
+                <button class="btn btn-outline-primary dropdown-toggle" type="button" id="hasPayment" data-bs-toggle="dropdown" aria-expanded="false">
+                    Payment Step
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="selectType">
+                    <li><a class="dropdown-item" href="/appointment">All</a></li>
+                    <li><a class="dropdown-item" href="/appointment?payment_step=required">Paid</a></li>
+                    <li><a class="dropdown-item" href="/appointment?payment_step=not_required">Unpaid</a></li>
+                </ul>
+            </div>
+            <div class="dropdown">
+                <button class="btn btn-outline-primary dropdown-toggle" type="button" id="hasPayment" data-bs-toggle="dropdown" aria-expanded="false">
+                    Based On
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="selectType">
+                    <li><a class="dropdown-item" href="/appointment">All</a></li>
+                    <li><a class="dropdown-item" href="/appointment?schedule_based_on=users">Users</a></li>
+                    <li><a class="dropdown-item" href="/appointment?schedule_based_on=resources">Resources</a></li>
+                </ul>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
### Steps to reproduce:

- Install appointment_filter module (depends on enterprise module website_appointment)
- Go to website, click on appointment
- There are 3 drop down menus with title 'Type', 'Payment Step', 'Based On'

1. Type filter will have 3 options 'All', 'Online', 'Offline'

- Clicking 'All' will display all appointments
- Clicking 'Online' will display only online appointments
- Clicking 'Offline' will display only offline appointments

2. Payment Step filter will have 3 options 'All', 'Paid', 'Unpaid'

- Clicking 'All' will display all appointments
- Clicking 'Paid' will display only those appointments which are paid
- Clicking 'Unpaid' will display only those appointments which are unpaid

3. Based On filter will have 3 options 'All', 'Users', 'Resources'

- Clicking 'All' will display all appointments
- Clicking 'Users' will display only those appointments which are schedule based on Users
- Clicking 'Resources' will display only those appointments which are schedule based on Resources

### Purpose of Changes

Previously, the website_appointment module lacked filtering options,
which ruins the user experience, in order to enhance the user experience

### Changes

We added three new filters:
Appointment Type – Filter by Online/Offline appointments.
Payment Step – Show appointments that require payment or not.
Schedule Based On – Filter by Users or Resources.

Task-4600005