### PR TITLE
[ADD] product_pricelist: Book price added in Sale Order Line

### DIFF
--- a/product_pricelist/__init__.py
+++ b/product_pricelist/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_pricelist/__manifest__.py
+++ b/product_pricelist/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': "Book Price (Pricelist Price)",
     'version': '1.0',
-    'depends': ['base', 'sale_management'],
+    'depends': ['sale_management'],
     'author': "ppch",
     'category': 'Category',
     'description': """

--- a/product_pricelist/__manifest__.py
+++ b/product_pricelist/__manifest__.py
@@ -1,11 +1,12 @@
 {
-    'name': "Book Price Pricelist",
+    'name': "Book Price (Pricelist Price)",
     'version': '1.0',
-    'depends': ['base', 'sale_management', 'account'],
+    'depends': ['base', 'sale_management'],
     'author': "ppch",
     'category': 'Category',
     'description': """
-    Book Price on Sales order line and accunt move line
+    Book Price (Pricelist Price) on sales order lines and invoice lines
+    which will be used to compare between Book Price (Pricelist Price) and manually adjusted price on the lines
     """,
     'license': "LGPL-3",
     'data': [

--- a/product_pricelist/__manifest__.py
+++ b/product_pricelist/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': "Book Price Pricelist",
+    'version': '1.0',
+    'depends': ['base', 'sale_management', 'account'],
+    'author': "ppch",
+    'category': 'Category',
+    'description': """
+    Book Price on Sales order line and accunt move line
+    """,
+    'license': "LGPL-3",
+    'data': [
+        'views/sale_order_line_views.xml',
+        'views/account_move_line_views.xml',
+    ],
+    'installable': True,
+}

--- a/product_pricelist/__manifest__.py
+++ b/product_pricelist/__manifest__.py
@@ -6,7 +6,8 @@
     'category': 'Category',
     'description': """
     Book Price (Pricelist Price) on sales order lines and invoice lines
-    which will be used to compare between Book Price (Pricelist Price) and manually adjusted price on the lines
+    which will be used to compare between Book Price (Pricelist Price) and
+    manually adjusted price on the lines.
     """,
     'license': "LGPL-3",
     'data': [

--- a/product_pricelist/models/__init__.py
+++ b/product_pricelist/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move_line
+from . import sale_order_line

--- a/product_pricelist/models/account_move_line.py
+++ b/product_pricelist/models/account_move_line.py
@@ -4,13 +4,19 @@ from odoo import api, fields, models
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    book_price = fields.Float(
-        string="Book Price",
-        compute="_compute_book_price",
-        store=True
-    )
+    book_price = fields.Float(string="Book Price", compute="_compute_book_price", store=True)
 
     @api.depends('product_id', 'quantity', 'move_id.invoice_origin')
     def _compute_book_price(self):
-        pass
-        #define
+        for record in self:
+            if not record.product_id:
+                record.book_price = 0.0
+                continue
+
+            sale_order = self.env['sale.order'].search([('name', '=', record.move_id.invoice_origin)], limit=1)
+            if sale_order:
+                record.book_price = sale_order.pricelist_id._get_product_price(
+                    record.product_id, record.quantity
+                ) * record.quantity
+            else:
+                record.book_price = record.product_id.lst_price * record.quantity

--- a/product_pricelist/models/account_move_line.py
+++ b/product_pricelist/models/account_move_line.py
@@ -1,0 +1,16 @@
+from odoo import api, fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(
+        string="Book Price",
+        compute="_compute_book_price",
+        store=True
+    )
+
+    @api.depends('product_id', 'quantity', 'move_id.invoice_origin')
+    def _compute_book_price(self):
+        pass
+        #define

--- a/product_pricelist/models/account_move_line.py
+++ b/product_pricelist/models/account_move_line.py
@@ -8,12 +8,13 @@ class AccountMoveLine(models.Model):
 
     @api.depends('product_id', 'quantity', 'move_id.invoice_origin')
     def _compute_book_price(self):
+        sale_orders = {so.name: so for so in self.env['sale.order'].search([('name', 'in', self.mapped('move_id.invoice_origin'))])}
         for record in self:
             if not record.product_id:
                 record.book_price = 0.0
                 continue
 
-            sale_order = self.env['sale.order'].search([('name', '=', record.move_id.invoice_origin)], limit=1)
+            sale_order = sale_orders.get(record.move_id.invoice_origin)
             if sale_order:
                 record.book_price = sale_order.pricelist_id._get_product_price(
                     record.product_id, record.quantity

--- a/product_pricelist/models/account_move_line.py
+++ b/product_pricelist/models/account_move_line.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    book_price = fields.Float(string="Book Price", compute="_compute_book_price", store=True)
+    book_price = fields.Float(string="Book Price", compute='_compute_book_price')
 
     @api.depends('product_id', 'quantity', 'move_id.invoice_origin')
     def _compute_book_price(self):

--- a/product_pricelist/models/account_move_line.py
+++ b/product_pricelist/models/account_move_line.py
@@ -4,20 +4,4 @@ from odoo import api, fields, models
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    book_price = fields.Float(string="Book Price", compute='_compute_book_price')
-
-    @api.depends('product_id', 'quantity', 'move_id.invoice_origin')
-    def _compute_book_price(self):
-        sale_orders = {so.name: so for so in self.env['sale.order'].search([('name', 'in', self.mapped('move_id.invoice_origin'))])}
-        for record in self:
-            if not record.product_id:
-                record.book_price = 0.0
-                continue
-
-            sale_order = sale_orders.get(record.move_id.invoice_origin)
-            if sale_order:
-                record.book_price = sale_order.pricelist_id._get_product_price(
-                    record.product_id, record.quantity
-                ) * record.quantity
-            else:
-                record.book_price = record.product_id.lst_price * record.quantity
+    book_price = fields.Float(related='sale_line_ids.book_price')

--- a/product_pricelist/models/sale_order_line.py
+++ b/product_pricelist/models/sale_order_line.py
@@ -4,16 +4,19 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    book_price = fields.Float(
-        string="Book Price",
-        compute="_compute_book_price",
-        store=True
-    )
+    book_price = fields.Float(string="Book Price", compute="_compute_book_price", store=True)
 
-    @api.depends('product_id', 'product_uom_qty')
+    @api.depends('product_id', 'product_uom_qty', 'order_id.pricelist_id')
     def _compute_book_price(self):
         for record in self:
             if not record.product_id:
                 record.book_price = 0.0
+                continue
+
+            pricelist = record.order_id.pricelist_id if record.order_id else None
+            if pricelist:
+                record.book_price = pricelist._get_product_price(
+                    record.product_id, record.product_uom_qty
+                ) * record.product_uom_qty
             else:
-                record.book_price = record._get_pricelist_price() * record.product_uom_qty
+                record.book_price = record.product_id.lst_price * record.product_uom_qty

--- a/product_pricelist/models/sale_order_line.py
+++ b/product_pricelist/models/sale_order_line.py
@@ -17,6 +17,6 @@ class SaleOrderLine(models.Model):
             if pricelist:
                 record.book_price = pricelist._get_product_price(
                     record.product_id, record.product_uom_qty
-                ) * record.product_uom_qty
+                )
             else:
-                record.book_price = record.product_id.lst_price * record.product_uom_qty
+                record.book_price = record.product_id.lst_price

--- a/product_pricelist/models/sale_order_line.py
+++ b/product_pricelist/models/sale_order_line.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(
+        string="Book Price",
+        compute="_compute_book_price",
+        store=True
+    )
+
+    @api.depends('product_id', 'product_uom_qty')
+    def _compute_book_price(self):
+        for record in self:
+            if not record.product_id:
+                record.book_price = 0.0
+            else:
+                record.book_price = record._get_pricelist_price() * record.product_uom_qty

--- a/product_pricelist/models/sale_order_line.py
+++ b/product_pricelist/models/sale_order_line.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    book_price = fields.Float(string="Book Price", compute="_compute_book_price", store=True)
+    book_price = fields.Float(string="Book Price", compute='_compute_book_price')
 
     @api.depends('product_id', 'product_uom_qty', 'order_id.pricelist_id')
     def _compute_book_price(self):

--- a/product_pricelist/views/account_move_line_views.xml
+++ b/product_pricelist/views/account_move_line_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//notebook//page//field[@name='invoice_line_ids']//list//field[@name='quantity']" position="before">
-                <field name="book_price" readonly="True" column_invisible="context.get('move_id.move_type') != 'out_inovice'"/>
+                <field name="book_price" readonly="True" column_invisible="context.get('default_move_type') != 'out_invoice'"/>
             </xpath>
         </field>
     </record>

--- a/product_pricelist/views/account_move_line_views.xml
+++ b/product_pricelist/views/account_move_line_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//notebook//page//field[@name='invoice_line_ids']//list//field[@name='quantity']" position="before">
-                <field name="book_price" readonly="True"/>
+                <field name="book_price" readonly="True" column_invisible="context.get('move_id.move_type') != 'out_inovice'"/>
             </xpath>
         </field>
     </record>

--- a/product_pricelist/views/account_move_line_views.xml
+++ b/product_pricelist/views/account_move_line_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="account_move_form_inherite_book_price" model="ir.ui.view">
+    <record id="account_move_form_inherit_book_price" model="ir.ui.view">
         <field name="name">account.move.form.inherite.book.price</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>

--- a/product_pricelist/views/account_move_line_views.xml
+++ b/product_pricelist/views/account_move_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_move_form_inherite_book_price" model="ir.ui.view">
+        <field name="name">account.move.form.inherite.book.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//field[@name='invoice_line_ids']//list//field[@name='quantity']" position="before">
+                <field name="book_price" readonly="True"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_pricelist/views/sale_order_line_views.xml
+++ b/product_pricelist/views/sale_order_line_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="sale_order_form_inherite_book_price" model="ir.ui.view">
+    <record id="sale_order_form_inherit_book_price" model="ir.ui.view">
         <field name="name">sale.order.form.inherite.book.price</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>

--- a/product_pricelist/views/sale_order_line_views.xml
+++ b/product_pricelist/views/sale_order_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_form_inherite_book_price" model="ir.ui.view">
+        <field name="name">sale.order.form.inherite.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//list//field[@name='product_uom_qty']" position="before">
+                <field name="book_price" readonly="True"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Models and views are inherited of sale order line and account move line
- Defined _compute_book_price function which will be depends on product_id,
  quantity and pricelist whenever mentioned field will change on that time 
  based on condition book_price will be calculated
- Book price is only visible in customer invoices.
- In account_move_line set book_price as related field
- Instead of displayed book_price for all quantity changed to for only 1 quantity

task - 4602859