### PR TITLE
[ADD] sale_zero_stock_approval: create sale_zero_stock_approval module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.languageServer": "None"
+}

--- a/sale_zero_stock_approval/__init__.py
+++ b/sale_zero_stock_approval/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/sale_zero_stock_approval/__manifest__.py
+++ b/sale_zero_stock_approval/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Zero Stock Approval",
+    'summary': 'Approval for sale the product',
+    'author': "krge",
+    'website': "https://www.odoo.com",
+    'category': 'Sales/Sales',
+    'version': '0.1',
+    'depends': ['sale_management'],
+    'installable': True,
+    'data': [
+        'views/sale_order_views.xml'
+    ],
+    'license': 'LGPL-3',
+}

--- a/sale_zero_stock_approval/models/__init__.py
+++ b/sale_zero_stock_approval/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_zero_stock_approval/models/sale_order.py
+++ b/sale_zero_stock_approval/models/sale_order.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(
+        string="Approval",
+        copy=False
+    )
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if not self.env.user.has_group("sales_team.group_sale_manager") and "zero_stock_approval" in res:
+                res["zero_stock_approval"]["readonly"] = True
+        return res
+
+    def action_confirm(self):
+        if not self.zero_stock_approval and not self.env.user.has_group('sales_team.group_sale_manager'):
+            raise UserError(_('Sales order cannot be confirmed unless it is approved'))
+
+        return super().action_confirm()

--- a/sale_zero_stock_approval/views/sale_order_views.xml
+++ b/sale_zero_stock_approval/views/sale_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.zero.stock.approval</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"></field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- inherited sales.order model and added zero_stock_approval boolean field.
- if it is enable then sales user can confirm the order.
- sales user has read-only access.
- sales manager has access to modify it.
- task-4599754