### PR TITLE
[ADD] event_tickets_limit: enforce max ticket limit per registration

### DIFF
--- a/event_ticket_maxlimit/__init__.py
+++ b/event_ticket_maxlimit/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/event_ticket_maxlimit/__manifest__.py
+++ b/event_ticket_maxlimit/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Event Ticket Limit",
+    "version": "1.0",
+    'summary': 'Adds a ticket limit per registration in event module',
+    "category": "Event/ Event Ticket Limit",
+    "description": """
+            Adds a ticket limit per registration in `event.event.ticket`.
+            Set `tickets_per_registration` to define the limit (0 for no limit).
+    """,
+    "depends": ["base", "event", "website_event"],
+    "data": [
+        "views/event_ticket_view.xml",
+        "views/event_registration_website_view.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/event_ticket_maxlimit/models/__init__.py
+++ b/event_ticket_maxlimit/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import event_ticket

--- a/event_ticket_maxlimit/models/event_ticket.py
+++ b/event_ticket_maxlimit/models/event_ticket.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class EventTicket(models.Model):
+    _inherit = "event.event.ticket"
+
+    tickets_per_registration = fields.Integer(
+        string="Tickets per Registration",
+        help="Number of tickets per registration. 0 means 9 ticket per registration.",
+    )
+
+    @api.constrains('tickets_per_registration')
+    def _check_ticket_pre_registration(self):
+        for record in self:
+            if record.tickets_per_registration < 0:
+                raise ValidationError(_("Ticket per registration cannot be negative."))

--- a/event_ticket_maxlimit/views/event_registration_website_view.xml
+++ b/event_ticket_maxlimit/views/event_registration_website_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="modal_ticket_registration" name="modal_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+        <xpath expr="//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_registration" t-value="(ticket.tickets_per_registration or 9) + 1"/>
+        </xpath>
+
+        <xpath expr="//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event,seats_max_registration)</attribute>
+        </xpath>
+
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_registration" t-value="(tickets.tickets_per_registration or 9) + 1"/>
+        </xpath>
+
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event,seats_max_registration)</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/event_ticket_maxlimit/views/event_ticket_view.xml
+++ b/event_ticket_maxlimit/views/event_ticket_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_event_ticket_view_tree_from_event_inherit_module_name" model="ir.ui.view">
+        <field name="name">event.event.ticket.view.list.inherit</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <field name="tickets_per_registration"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Implemented a restriction on the maximum number of tickets allowed per registration.
- Inherited `event.event.ticket` to introduce a `tickets_per_registration` field.
- Updated the ticket booking logic using view inheritance with XPath.

task-4598888