### PR TITLE
[ADD] sale_pricelist_price: display original book price on sale & invoice lines

### DIFF
--- a/sale_pricelist_price/__init__.py
+++ b/sale_pricelist_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_pricelist_price/__manifest__.py
+++ b/sale_pricelist_price/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Pricelist Price",
+    "description": "Client will have the ability to see the original price(book price) on sale order and incoice line.",
+    "depends": ["sale_management"],
+    "data": [
+        "views/sale_order_views.xml",
+        "views/account_move_views.xml"
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/sale_pricelist_price/models/__init__.py
+++ b/sale_pricelist_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move_line
+from . import sale_order_line

--- a/sale_pricelist_price/models/account_move_line.py
+++ b/sale_pricelist_price/models/account_move_line.py
@@ -1,0 +1,17 @@
+from odoo import api, fields, models
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(string="Book Price", compute="_compute_book_price")
+
+    @api.depends("product_id", "quantity", "move_id.invoice_line_ids")
+    def _compute_book_price(self):
+        for line in self:
+            pricelist = line.move_id.invoice_line_ids.sale_line_ids.order_id.pricelist_id
+            if pricelist:
+                line.book_price = pricelist._get_product_price(
+                    line.product_id, line.quantity, line.product_uom_id
+                )
+            else:
+                line.book_price = line.product_id.lst_price

--- a/sale_pricelist_price/models/sale_order_line.py
+++ b/sale_pricelist_price/models/sale_order_line.py
@@ -1,0 +1,16 @@
+from odoo import api, fields, models
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(string="Book Price", compute="_compute_book_price")
+
+    @api.depends('product_id', 'product_uom_qty', 'order_id')
+    def _compute_book_price(self):
+        for line in self:
+            if line.product_id and line.order_id.pricelist_id:
+                line.book_price = line.order_id.pricelist_id._get_product_price(
+                    line.product_id, line.product_uom_qty, line.product_uom
+                )
+            else:
+                line.book_price = line.product_id.lst_price

--- a/sale_pricelist_price/views/account_move_views.xml
+++ b/sale_pricelist_price/views/account_move_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.order.form.inherit.sale.pricelist.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='quantity']" position="before">
+                <field name="book_price" readonly="1" column_invisible="parent.move_type != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_pricelist_price/views/sale_order_views.xml
+++ b/sale_pricelist_price/views/sale_order_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.sale.pricelist.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="before">
+                <field name="book_price" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added a computed field on Sales Order Lines and Account Move Lines to display the original pricelist price ("Book Price").
- Implemented logic to compute the price based on the selected pricelist, product, and quantity.
- Updated the Invoice Lines list view to show the "Book Price" field (customer invoices only).
- Updated the Sales Order Lines list view to include the "Book Price" field.

Task-4599519