### PR TITLE
[ADD] webshop_extension: added new multilingual html extended description field

### DIFF
--- a/webshop_extension/__init__.py
+++ b/webshop_extension/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/webshop_extension/__manifest__.py
+++ b/webshop_extension/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "webshop_extension",
+    "description": """
+    This module add an extended description field in the website ecommerce application.
+        - added multilingual HTML description field in product template
+        - displays this field in the frontend
+        - enable import/export of this field
+    """,
+    "summary": "Adds extended description field in the website ecommerce application",
+    "author": "Vedant Pandey (vpan)",
+    "version": "1.0",
+    "category": "website",
+    "data": [
+        "views/product_views.xml",
+        "views/product_web_template.xml"
+    ],
+    "depends": ["website_sale"],
+    "installable": True,
+    "license": "LGPL-3"
+}

--- a/webshop_extension/models/__init__.py
+++ b/webshop_extension/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/webshop_extension/models/product_template.py
+++ b/webshop_extension/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    ecommerce_extended_description = fields.Html(string="Ecommerce Extended Description", translate=True)

--- a/webshop_extension/views/product_views.xml
+++ b/webshop_extension/views/product_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.view.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales']//group[@name='sale']" position="after">
+                <group name="ecommerce_extended_description" string="Ecommerce Extended Description">
+                    <field name="ecommerce_extended_description" nolabel="1"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/webshop_extension/views/product_web_template.xml
+++ b/webshop_extension/views/product_web_template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="template_with_extended_description" inherit_id="website_sale.product">
+        <xpath expr="//section[@id='product_detail']" position="inside">
+             <div id="product_extended_description" class="oe_website_sale container my-3 my-lg-4">
+                <t t-if="product.ecommerce_extended_description">
+                    <h2 class="mt-4">Extended Description</h2>
+                    <div class="oe_structure">
+                        <t t-esc="product.ecommerce_extended_description"/>
+                    </div>
+                </t>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
### Steps to reproduce

1. For Internal Users

- Install webshop_extension module (depends on website_sale)
- Open Website > eCommerce > Products
- From Kanban View select any one product it will open the form view of that product 
- In the form view, visit the Sales page under there is one group Extended Description
- In that field you can add description as long as you want
- To enable multi language support User > Preferences > Languages > click on globe icon then add languages you want
- After adding languages, you are able to see EN on clicking it, it will open a pop-up to add description in particular language

**For Portal User it will conditionally render, if the particular product has extended description it will display else it will not display**

 ### Purpose of Changes

- Our webshop contains many products, including technical ones that require extensive descriptions.
- The existing description fields (description_sale and description_ecommerce) are not suitable for long descriptions.

### Changes

- To address this, we are introducing a new extended_description field that:

1. Displays on the product page (for portal users) without affecting the layout.
2. It is editable from the backend (internal users view) for better content management.
3. Supports multiple languages (Danish and Swedish) 
4. This field is also included in import/export functionality

Task-4605780