### PR TITLE
[ADD] zero_stock_blockage:  Add 'Zero Stock Approval' field with access control

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 {
     'name': "Zero Stock Blockage",
     'description':
@@ -9,6 +11,5 @@
         'views/sale_order_views.xml'
     ],
     'installable': True,
-    'application': True,
     'license': "LGPL-3"
 }

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': "Zero Stock Blockage",
+    'description':
+        "Allow confirmation of the sales order only if it is approved by the manager."
+    ,
+    'category': 'Sales',
+    'depends': ['sale_management'],
+    'data':[
+        'views/sale_order_views.xml'
+    ],
+    'installable': True,
+    'application': True,
+    'license': "LGPL-3"
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -18,7 +18,10 @@ class SaleOrder(models.Model):
         return res
 
     def action_confirm(self):
+        # Loop through each order in the recordset
         for order in self:
-            if not order.zero_stock_approval:
-                raise UserError(_("The order must be approved by a Sales Manager before confirmation."))
+            # Loop through each order line in the order
+            if any(line.product_uom_qty <= 0 for line in order.order_line):
+                if not order.zero_stock_approval:
+                    raise UserError(_('Approval is required to confirm an order containing products with zero stock.'))
         return super().action_confirm()

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from odoo import _,api,fields,models,_
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 
 class SaleOrder(models.Model):
-    _inherit ='sale.order'
+    _inherit = 'sale.order'
 
-    zero_stock_approval = fields.Boolean(string='Approval')
+    zero_stock_approval = fields.Boolean(string='Approval', copy=False)
 
     @api.model
     def fields_get(self, allfields=None, attributes=None):

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from odoo import _,api,fields,models,_
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit ='sale.order'
+
+    zero_stock_approval = fields.Boolean(string='Approval')
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if not self.env.user.has_group('sales_team.group_sale_manager'):
+            if 'zero_stock_approval' in res:
+                res['zero_stock_approval']['readonly'] = True
+        return res
+
+    def action_confirm(self):
+        for order in self:
+            if not order.zero_stock_approval:
+                raise UserError(_("The order must be approved by a Sales Manager before confirmation."))
+        return super().action_confirm()

--- a/zero_stock_blockage/views/sale_order_views.xml
+++ b/zero_stock_blockage/views/sale_order_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <data>
     <record id="view_order_form" model="ir.ui.view">
         <field name="name">sale.order.form.inherit.zero.stock.blockage</field>
         <field name="model">sale.order</field>
@@ -11,5 +10,4 @@
             </xpath>
         </field>
     </record>
-    </data>
 </odoo>

--- a/zero_stock_blockage/views/sale_order_views.xml
+++ b/zero_stock_blockage/views/sale_order_views.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <data>
+    <record id="zero_stock_blockage_view_form" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.zero.stock.blockage</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval" invisible="state in ['cancel', 'sale']"/>
+            </xpath>
+        </field>
+    </record>
+    </data>
+</odoo>

--- a/zero_stock_blockage/views/sale_order_views.xml
+++ b/zero_stock_blockage/views/sale_order_views.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <data>
-    <record id="zero_stock_blockage_view_form" model="ir.ui.view">
+    <record id="view_order_form" model="ir.ui.view">
         <field name="name">sale.order.form.inherit.zero.stock.blockage</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>


### PR DESCRIPTION
• Add boolean field 'Zero Stock Approval' in sale.order model.
• Allow only Sales/Administrators to toggle approval status. 
• Enable sales order confirmation based on approval status. 
  
Task-4599998