### PR TITLE
[ADD] modular_type: added new modular type field

### DIFF
--- a/modular_type/__init__.py
+++ b/modular_type/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import wizard

--- a/modular_type/__manifest__.py
+++ b/modular_type/__manifest__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "modular_type",
+    "summary": "Manage modular types in manufacturing orders and sales orders",
+    "description": """
+    This module allows you to define and manage modular types for products in the manufacturing process. 
+    With this module, you can:
+    - Set multiplication factors for manufacturing order components based on sales order lines.
+    - Manage different modular types for each product, ensuring flexibility in production processes.
+    - Automatically adjust quantities of components based on modular type and the corresponding sales order.
+    """,
+    "author": "Odoo",
+    "website": "https://www.odoo.com",
+    "version": "1.0",
+    "depends": ["base","product","mrp","sale"],
+    "license": "LGPL-3",
+    "data": [
+        "security/ir.model.access.csv",
+        "wizard/modular_type_wizard_views.xml",
+        "views/product_template_views.xml",
+        "views/bom_line_views.xml",
+        "views/slaes_order_line_views.xml",
+        "views/mrp_production_line_views.xml"
+    ],
+}

--- a/modular_type/models/__init__.py
+++ b/modular_type/models/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import modular_type
+from . import mrp_bom
+from . import mrp_bom_line
+from . import product_template
+from . import sale_order
+from . import stock_move

--- a/modular_type/models/modular_type.py
+++ b/modular_type/models/modular_type.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ModularType(models.Model):
+    _name = "modular.types"
+    _description = "Modular Types"
+
+    name = fields.Char("Modular Type")
+    quantity_multiplier = fields.Integer("Multiplier", default=0)
+    color = fields.Integer("color", default=0)

--- a/modular_type/models/mrp_bom.py
+++ b/modular_type/models/mrp_bom.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class MrpBom(models.Model):
+    _inherit = "mrp.bom"
+
+    modular_type_id = fields.Many2one(
+        "mrp.bom.line", related='bom_line_ids.modular_type_id')

--- a/modular_type/models/mrp_bom_line.py
+++ b/modular_type/models/mrp_bom_line.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class MrpBomLine(models.Model):
+    _inherit = 'mrp.bom.line'
+
+    modular_type_id = fields.Many2one(
+        'modular.types',
+        string="Modular Type",
+        domain="[('id', 'in', available_modular_type_ids)]",
+        help="The modular type for this BOM line",
+    )
+    available_modular_type_ids = fields.Many2many(
+        'modular.types', compute='_compute_available_modular_types',
+        string="Available Modular Types"
+    )
+
+    @api.depends('product_id')
+    def _compute_available_modular_types(self):
+        for line in self:
+            if line.product_id:
+                line.available_modular_type_ids = line.parent_product_tmpl_id.modular_types
+            else:
+                line.available_modular_type_ids = False

--- a/modular_type/models/product_template.py
+++ b/modular_type/models/product_template.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    modular_types = fields.Many2many(comodel_name="modular.types")

--- a/modular_type/models/sale_order.py
+++ b/modular_type/models/sale_order.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    has_modular_type = fields.Boolean(
+        string="Has Modular Type",
+        compute="_compute_has_modular_type",
+        store=True
+    )
+
+    @api.depends("product_id")
+    def _compute_has_modular_type(self):
+        for line in self:
+            if line.product_id:
+                line.has_modular_type = bool(
+                    line.product_id.product_tmpl_id.modular_types)

--- a/modular_type/models/stock_move.py
+++ b/modular_type/models/stock_move.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    modular_type_id = fields.Many2one(
+        "modular.types", 
+        string="Modular Type",
+        compute="_compute_modular_type",
+        store=True
+    )
+    multiplied_product_uom_qty = fields.Float(
+        'Multiplied Demand',
+        compute="_compute_multiplied_product_uom_qty",
+        inverse="_inverse_multiplied_product_uom_qty",
+        store=True
+    )
+
+    @api.depends("product_id", "raw_material_production_id")
+    def _compute_modular_type(self):
+        for move in self:
+            move.modular_type_id = False
+            if move.product_id and move.raw_material_production_id:
+                bom = move.raw_material_production_id.bom_id
+                if bom:
+                    bom_line = self.env["mrp.bom.line"].search([
+                        ("bom_id", "=", bom.id),
+                        ("product_id", "=", move.product_id.id)
+                    ], limit=1)
+
+                    if bom_line and bom_line.modular_type_id:
+                        move.modular_type_id = bom_line.modular_type_id.id
+
+    @api.depends('product_id', 'modular_type_id')
+    def _compute_multiplied_product_uom_qty(self):
+        for move in self:
+            bom = self.env['mrp.bom.line'].search(
+                [('product_tmpl_id', '=', move.product_id.product_tmpl_id.id)], limit=1)
+            if move.product_id and move.modular_type_id:
+                move.multiplied_product_uom_qty = move.modular_type_id.quantity_multiplier * bom.product_qty
+                print("hello", move.multiplied_product_uom_qty,
+                      move.modular_type_id.quantity_multiplier, bom.product_qty, move.product_id.name)
+            elif move.product_id and not move.modular_type_id: 
+                print("hello 1", move.multiplied_product_uom_qty, move.product_id.name)
+                move.multiplied_product_uom_qty = move.product_uom_qty
+    
+    def _inverse_multiplied_product_uom_qty(self):
+        for move in self:
+            if move.product_id and move.modular_type_id:
+                if move.modular_type_id.quantity_multiplier:
+                    move.product_uom_qty = move.multiplied_product_uom_qty / \
+                        move.modular_type_id.quantity_multiplier
+                else:
+                    move.product_uom_qty = move.multiplied_product_uom_qty
+            else:
+                move.product_uom_qty = move.multiplied_product_uom_qty

--- a/modular_type/security/ir.model.access.csv
+++ b/modular_type/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+modular_type.access_modular_types,access_modular_types,modular_type.model_modular_types,base.group_user,1,1,1,1
+modular_type.access_modular_type_wizard,access_modular_type_wizard,modular_type.model_modular_type_wizard,base.group_user,1,1,1,1

--- a/modular_type/views/bom_line_views.xml
+++ b/modular_type/views/bom_line_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="mrp_bom_view_form" model="ir.ui.view">
+            <field name="name">bom.line.view.form.inherit.moular.type</field>
+            <field name="model">mrp.bom</field>
+            <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='components']//field[@name='attachments_count']" position="after">
+                    <field name="modular_type_id" options="{'no_create': True}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/modular_type/views/mrp_production_line_views.xml
+++ b/modular_type/views/mrp_production_line_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mrp_production_view_form" model="ir.ui.view">
+        <field name="name">modular.types.view.form</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='components']//field[@name='product_uom_qty']" position="before">
+                <field name="modular_type_id" readonly="1"/>
+            </xpath>
+            <xpath expr="//page[@name='components']//field[@name='product_uom_qty']" position="replace">
+                <field name="multiplied_product_uom_qty" string="To Consume"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/modular_type/views/product_template_views.xml
+++ b/modular_type/views/product_template_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+    <record id="product_template_view_form" model="ir.ui.view">
+      <field name="name">product.template.view.form.inherit.moular.type</field>
+      <field name="model">product.template</field>
+      <field name="inherit_id" ref="product.product_template_form_view"/>
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='product_tooltip']" position="after">
+          <field name="modular_types" widget="many2many_tags" options="{'color_field': 'color'}"/>
+        </xpath>
+      </field>
+    </record>
+  </data>
+</odoo>

--- a/modular_type/views/slaes_order_line_views.xml
+++ b/modular_type/views/slaes_order_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">modular.type.view.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_template_id']" position="after">
+               <button name="%(action_modular_type_wizard)d" type="action" icon="fa-flask" invisible="not has_modular_type"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/modular_type/wizard/__init__.py
+++ b/modular_type/wizard/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import modular_type_wizard

--- a/modular_type/wizard/modular_type_wizard.py
+++ b/modular_type/wizard/modular_type_wizard.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ModularTypesWizard(models.TransientModel):
+    _name = "modular.type.wizard"
+    _description = "Wizard to set Modular Types"
+
+    modular_types = fields.Many2many(
+        "modular.types",
+        string="Modular Types"
+    )
+
+    def default_get(self, fields_list):
+        res = super(ModularTypesWizard, self).default_get(fields_list)
+        active_id = self._context.get("active_id")
+
+        if active_id:
+            order_line = self.env["sale.order.line"].browse(active_id)
+
+            if order_line.product_id:
+                modular_types = order_line.product_id.product_tmpl_id.modular_types
+                res["modular_types"] = [(6, 0, modular_types.ids)]
+
+        return res

--- a/modular_type/wizard/modular_type_wizard_views.xml
+++ b/modular_type/wizard/modular_type_wizard_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_modular_type_wizard" model="ir.actions.act_window">
+        <field name="name">Set Modular Types</field>
+        <field name="res_model">modular.type.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <record id="modular_type_wizard_view" model="ir.ui.view">
+        <field name="name">modular.type.wizard.view</field>
+        <field name="model">modular.type.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Set Modular Types" >
+                <group>
+                    <field name="modular_types" nolabel="1">
+                        <list create="0" editable="bottom">
+                            <field name="name" readonly="1"/>
+                            <field name="quantity_multiplier"/>
+                        </list>
+                    </field>
+                </group>
+                <footer>
+                    <button string="Add" class="btn-primary" special="save"/>
+                    <button string="Cancel" class="btn-default" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
### **Steps to Reproduce**  

1. Install the **modular_type** module.  
2. Install Purchase module and setup Automatic MO generate flow.
3. Create at least **two modular types** (e.g., "Material" and "Size") in Product Page.  
4. Navigate to **Manufacturing > Bill of Materials (BoM)** and create a BoM for the product.  
5. Go to **Sales > Quotations** and create a new Sale Order.  
6. Add the configured product to the Sale Order and click on flask icon to assign values to Types and confirm it.  
9. Verify that a **Manufacturing Order (MO)** is automatically created based on the BoM.  
10. Ensure that the generated MO follows the correct **modular type calculations** as expected.  

---

### **Purpose of the Development**:
The goal of this development is to introduce a feature that allows modular types to be used effectively in Manufacturing Orders (MO) through seamless integration with Sales Orders (SO). Specifically, this change aims to:
- Allow internal users to assign modular types to products and define their respective values, ensuring these values are propagated through the manufacturing process.
- Customize component quantities in the Manufacturing Order based on the modular type values assigned in the Sales Order line. For example, if a user sets the Sections value to 6 on a Sales Order line, all component lines in the MO with the "Sections" modular type will be multiplied by 6.  

---

### **Changes**  
To solve this,introducing a new **modular_type** feature that:  
- Allows **internal users** to assign modular types and values to products.  
- Enables seamless **BoM integration**, ensuring accurate calculations based on assigned modular types.  
- Added flask icon to sales order view
---

**Task:** #4603278  