### PR TITLE
[IMP] Sale : Add Zero Stock Blockage Field

### DIFF
--- a/sale_zero_stock_blockage/__init__.py
+++ b/sale_zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_zero_stock_blockage/__manifest__.py
+++ b/sale_zero_stock_blockage/__manifest__.py
@@ -1,0 +1,17 @@
+{
+
+    'name' : "Sales zero stock blockage",
+    'version' : "1.0",
+    'category': 'Sales/Sales',
+    'description': """
+        This module add zero stock blockage feature in sale module.
+    """,
+    'depends': [
+        'sale',
+        'sales_team'
+    ],
+    'data': [
+        'views/sale_order_views.xml'
+    ],
+    'license': 'LGPL-3'
+}

--- a/sale_zero_stock_blockage/__manifest__.py
+++ b/sale_zero_stock_blockage/__manifest__.py
@@ -7,7 +7,7 @@
         This module add zero stock blockage feature in sale module.
     """,
     'depends': [
-        'sale',
+        'sale_management',
         'sales_team'
     ],
     'data': [

--- a/sale_zero_stock_blockage/models/__init__.py
+++ b/sale_zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_zero_stock_blockage/models/sale_order.py
+++ b/sale_zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,19 @@
+from odoo import api, exceptions, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(string="Zero Stock Approval")
+    group_check = fields.Boolean(compute='_group_check')
+
+    def _group_check(self):
+        if self.env.user.has_group('sales_team.group_sale_manager'):
+            self.group_check = True
+        else:
+            self.group_check = False
+
+    def action_confirm(self):
+        if not self.zero_stock_approval:
+            raise exceptions.ValidationError("You can not confirm this sales order because zero stock blocklist is not allowed")
+        return super().action_confirm()

--- a/sale_zero_stock_blockage/models/sale_order.py
+++ b/sale_zero_stock_blockage/models/sale_order.py
@@ -5,15 +5,13 @@ class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     zero_stock_approval = fields.Boolean(string="Zero Stock Approval")
-    group_check = fields.Boolean(compute='_group_check')
+    is_sales_manager = fields.Boolean(compute='_is_sales_manager')
 
-    def _group_check(self):
-        if self.env.user.has_group('sales_team.group_sale_manager'):
-            self.group_check = True
-        else:
-            self.group_check = False
-
+    def _is_sales_manager(self):
+        for sale_order in self:
+            sale_order.is_sales_manager = sale_order.env.user.has_group('sales_team.group_sale_manager')
+        
     def action_confirm(self):
         if not self.zero_stock_approval:
-            raise exceptions.ValidationError("You can not confirm this sales order because zero stock blocklist is not allowed")
+            raise exceptions.ValidationError("You can not confirm this sales order because zero stock blocklist is not enable")
         return super().action_confirm()

--- a/sale_zero_stock_blockage/views/sale_order_views.xml
+++ b/sale_zero_stock_blockage/views/sale_order_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="sale_order_form_view" model="ir.ui.view">
+        <field name="name">sale.order.form.view.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='order_details']" position="inside">
+                <field name="zero_stock_approval" readonly="not group_check"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_zero_stock_blockage/views/sale_order_views.xml
+++ b/sale_zero_stock_blockage/views/sale_order_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='order_details']" position="inside">
-                <field name="zero_stock_approval" readonly="not group_check"/>
+                <field name="zero_stock_approval" readonly="not is_sales_manager"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[IMP] sale: zero stock blockage boolean filed added

In this commit
1.  sale order can be confirm if zero stock blockage field is set
2.  this field is readonly for all groups except administrator
3.  add one filed to handle this condition

task-4605851