### PR TITLE
[IMP] pos_salesperson_assignment: enable salesperson selection on POS bill screen

### DIFF
--- a/pos_salesperson_assignment/__init__.py
+++ b/pos_salesperson_assignment/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_salesperson_assignment/__manifest__.py
+++ b/pos_salesperson_assignment/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': "POS Salesperson Assignment",
+    'description': """
+    Able to select salesperson(employee) on POS (billing screen).
+    """,
+    'version': '1.0',
+    'depends': ['point_of_sale', 'pos_hr'],
+    'author': "Prince Beladiya",
+    'license': 'LGPL-3',
+    'installable': True,
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_salesperson_assignment/static/src/**/*',
+        ],
+    },
+    'data': [
+        'views/pos_order_view.xml'
+    ]
+}

--- a/pos_salesperson_assignment/models/__init__.py
+++ b/pos_salesperson_assignment/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_order
+from . import pos_session

--- a/pos_salesperson_assignment/models/pos_order.py
+++ b/pos_salesperson_assignment/models/pos_order.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    sales_person_id = fields.Many2one(
+        comodel_name='hr.employee',
+        string="Salesperson",
+        help="Employee responsible for the sale"
+    )

--- a/pos_salesperson_assignment/models/pos_session.py
+++ b/pos_salesperson_assignment/models/pos_session.py
@@ -1,0 +1,13 @@
+from odoo import api, models
+
+
+class PosSession(models.Model):
+    """Inherit the pos.session to load the data of hr.employee model"""
+    _inherit = 'pos.session'
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        """load the data to the pos.config.models"""
+        data = super()._load_pos_data_models(config_id)
+        data.append("hr.employee")
+        return data

--- a/pos_salesperson_assignment/static/src/app/generic_components/order_widget/order_widget.js
+++ b/pos_salesperson_assignment/static/src/app/generic_components/order_widget/order_widget.js
@@ -1,0 +1,9 @@
+import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderWidget, {
+    props: {
+        ...OrderWidget.props,
+        sales_person: { type: String, optional: true },
+    }
+});

--- a/pos_salesperson_assignment/static/src/app/generic_components/order_widget/order_widget.js
+++ b/pos_salesperson_assignment/static/src/app/generic_components/order_widget/order_widget.js
@@ -1,9 +1,8 @@
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
-import { patch } from "@web/core/utils/patch";
 
-patch(OrderWidget, {
-    props: {
+export class SalespersonOrderWidget extends OrderWidget {
+    static props = {
         ...OrderWidget.props,
         sales_person: { type: String, optional: true },
-    }
-});
+    };
+}

--- a/pos_salesperson_assignment/static/src/app/generic_components/order_widget/order_widget.xml
+++ b/pos_salesperson_assignment/static/src/app/generic_components/order_widget/order_widget.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.OrderWidget" t-inherit="point_of_sale.OrderWidget" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='props.lines?.length']/div[1]" position="before">
+            <div class="order-sales-person text-break mb-1 ms-1">
+                <h5>
+                    <t t-if="props.sales_person">
+                        Sales Person: <t t-esc="props.sales_person"/>
+                    </t>
+                </h5>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/pos_salesperson_assignment/static/src/app/models/pos_order.js
+++ b/pos_salesperson_assignment/static/src/app/models/pos_order.js
@@ -1,8 +1,10 @@
 import { PosOrder } from "@point_of_sale/app/models/pos_order";
-import { patch } from "@web/core/utils/patch";
+import { registry } from "@web/core/registry";
 
-patch(PosOrder.prototype, {
+export class SalespersonPosOrder extends PosOrder {
     setSalesPerson(sales_person) {
         this.update({ sales_person_id: sales_person })
     }
-})
+}
+
+registry.category("pos_available_models").add(PosOrder.pythonModel, SalespersonPosOrder, { force: true });

--- a/pos_salesperson_assignment/static/src/app/models/pos_order.js
+++ b/pos_salesperson_assignment/static/src/app/models/pos_order.js
@@ -1,0 +1,12 @@
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrder.prototype, {
+    setSalesPerson(sales_person) {
+        this.update({ sales_person_id: sales_person })
+    },
+
+    getSalesPerson() {
+        return this.sales_person_id
+    }
+})

--- a/pos_salesperson_assignment/static/src/app/models/pos_order.js
+++ b/pos_salesperson_assignment/static/src/app/models/pos_order.js
@@ -4,9 +4,5 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrder.prototype, {
     setSalesPerson(sales_person) {
         this.update({ sales_person_id: sales_person })
-    },
-
-    getSalesPerson() {
-        return this.sales_person_id
     }
 })

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/control_buttons.js
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/control_buttons.js
@@ -1,0 +1,10 @@
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { SelectSalespersonButton } from "./select_salesperson_button/select_salesperson_button";
+import { patch } from "@web/core/utils/patch";
+
+patch(ControlButtons, {
+    components: {
+        ...ControlButtons.components,
+        SelectSalespersonButton,
+    }
+});

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/control_buttons.js
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/control_buttons.js
@@ -1,10 +1,9 @@
 import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { SelectSalespersonButton } from "./select_salesperson_button/select_salesperson_button";
-import { patch } from "@web/core/utils/patch";
 
-patch(ControlButtons, {
-    components: {
-        ...ControlButtons.components,
-        SelectSalespersonButton,
-    }
-});
+export class SalespersonControlButtons extends ControlButtons {
+    static components = { 
+        ...ControlButtons.components, 
+        SelectSalespersonButton 
+    };
+}

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/control_buttons.xml
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/control_buttons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath
+            expr="//button[@t-if='!props.showRemainingButtons and !ui.isSmall and props.onClickMore']"
+            position="before">
+                <SelectSalespersonButton/>
+        </xpath>
+    </t>
+</templates>

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.js
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.js
@@ -1,25 +1,22 @@
 import { Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { useService } from "@web/core/utils/hooks";
-import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
-import { _t } from "@web/core/l10n/translation";
 import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
 
 export class SelectSalespersonButton extends Component {
     static template = "pos_salesperson_assignment.SelectSalespersonButton";
-    static props = {};
 
     setup() {
         this.pos = usePos();
         this.dialog = useService("dialog");
+        this.order = this.pos.get_order();
     }
 
-    _prepareEmployeeList(currentSalesPerson) {
-        const allEmployees = this.pos.models['hr.employee'].filter(
-            (employee) => employee.id !== currentSalesPerson
-        );
-
-        const employeeList = allEmployees.map((employee) => {
+    _prepareEmployeeList() {
+        const employeeList = this.pos.models['hr.employee'].map((employee) => {
             return {
                 id: employee.id,
                 item: employee,
@@ -31,41 +28,33 @@ export class SelectSalespersonButton extends Component {
         return employeeList;
     }
 
-    async onClick() {
-        const order = this.pos.get_order();
-        if (!order || order.lines.length <= 0) {
-            return;
-        }
-    
-        const employeesList = this._prepareEmployeeList(order.getSalesPerson()?.id);
+    async onClick() {    
+        const employeesList = this._prepareEmployeeList();
     
         if (!employeesList.length) {
+            this.dialog.add(ConfirmationDialog, {
+                title: _t("No Salespersons Available"),
+                body: _t("There are no available salespersons to assign."),
+                confirmText: _t("OK"),
+            });
             return;
         }
     
-        let sales_person = await makeAwaitable(this.dialog, SelectionPopup, {
+        const sales_person = await makeAwaitable(this.dialog, SelectionPopup, {
             title: _t("Select Sales Person"),
             list: employeesList
         });
     
-        if (!sales_person) {
-            return;
-        }
-        
-        order.setSalesPerson(sales_person);
+        if (sales_person) {
+            this.order.setSalesPerson(sales_person);
+        }        
     }
 
-    async onRemove() {
-        const order = this.pos.get_order();
-        if (!order || !order.sales_person_id) {
-            return;
-        }
-
-        order.setSalesPerson(false);
+    onRemove() {
+        this.order.setSalesPerson(false);
     }
     
     get salesperson() {
-        const order = this.pos.get_order();
-        return order.sales_person_id;
+        return this.order.sales_person_id;
     }
 }

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.js
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.js
@@ -1,0 +1,71 @@
+import { Component } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useService } from "@web/core/utils/hooks";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+import { _t } from "@web/core/l10n/translation";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+
+export class SelectSalespersonButton extends Component {
+    static template = "pos_salesperson_assignment.SelectSalespersonButton";
+    static props = {};
+
+    setup() {
+        this.pos = usePos();
+        this.dialog = useService("dialog");
+    }
+
+    _prepareEmployeeList(currentSalesPerson) {
+        const allEmployees = this.pos.models['hr.employee'].filter(
+            (employee) => employee.id !== currentSalesPerson
+        );
+
+        const employeeList = allEmployees.map((employee) => {
+            return {
+                id: employee.id,
+                item: employee,
+                label: employee.name,
+                isSelected: false
+            }
+        })
+
+        return employeeList;
+    }
+
+    async onClick() {
+        const order = this.pos.get_order();
+        if (!order || order.lines.length <= 0) {
+            return;
+        }
+    
+        const employeesList = this._prepareEmployeeList(order.getSalesPerson()?.id);
+    
+        if (!employeesList.length) {
+            return;
+        }
+    
+        let sales_person = await makeAwaitable(this.dialog, SelectionPopup, {
+            title: _t("Select Sales Person"),
+            list: employeesList
+        });
+    
+        if (!sales_person) {
+            return;
+        }
+        
+        order.setSalesPerson(sales_person);
+    }
+
+    async onRemove() {
+        const order = this.pos.get_order();
+        if (!order || !order.sales_person_id) {
+            return;
+        }
+
+        order.setSalesPerson(false);
+    }
+    
+    get salesperson() {
+        const order = this.pos.get_order();
+        return order.sales_person_id;
+    }
+}

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.xml
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.SelectSalespersonButton">
+        <button
+            class="set-salesperson btn btn-light text-truncate btn-lg lh-lg w-auto">
+                <div t-if="salesperson" class="d-flex justify-content-between align-items-center">
+                    <div class="text-truncate text-action" t-on-click="onClick">
+                        <t t-esc="salesperson.name"/>
+                    </div>
+                    <i class="fa fa-close" style="padding-left: 8px" t-on-click="onRemove"/>
+                </div>
+                <t t-else="">
+                    <div t-on-click="onClick">
+                        <i class="fa fa-user"/> Salesperson
+                    </div>
+                </t>
+        </button>
+    </t>
+</templates>

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.xml
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/control_buttons/select_salesperson_button/select_salesperson_button.xml
@@ -9,11 +9,11 @@
                     </div>
                     <i class="fa fa-close" style="padding-left: 8px" t-on-click="onRemove"/>
                 </div>
-                <t t-else="">
-                    <div t-on-click="onClick">
+                <div t-else="">
+                    <div t-on-click="onClick" class="text-truncate">
                         <i class="fa fa-user"/> Salesperson
                     </div>
-                </t>
+                </div>
         </button>
     </t>
 </templates>

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/order_summary/order_summary.js
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/order_summary/order_summary.js
@@ -1,0 +1,9 @@
+import { SalespersonOrderWidget } from "../../../generic_components/order_widget/order_widget";
+import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
+
+export class SalespersonOrderSummary extends OrderSummary {
+    static components = {
+        ...OrderSummary.components,
+        OrderWidget: SalespersonOrderWidget,
+    };
+}

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/order_summary/order_summary.xml
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/order_summary/order_summary.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson_assignment.OrderSummary"
+        t-inherit="point_of_sale.OrderSummary"
+        t-inherit-mode="extension">
+            <xpath expr="//OrderWidget" position="attributes">
+                <attribute name="sales_person">currentOrder.sales_person_id?.name</attribute>
+            </xpath>
+    </t>
+</templates>

--- a/pos_salesperson_assignment/static/src/app/sceens/product_screen/product_screen.js
+++ b/pos_salesperson_assignment/static/src/app/sceens/product_screen/product_screen.js
@@ -1,0 +1,14 @@
+import { SalespersonControlButtons } from "./control_buttons/control_buttons";
+import { SalespersonOrderSummary } from "./order_summary/order_summary";
+import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
+import { registry } from "@web/core/registry";
+
+export class CustomProductScreen extends ProductScreen {
+    static components = {
+        ...ProductScreen.components,
+        ControlButtons: SalespersonControlButtons,
+        OrderSummary: SalespersonOrderSummary
+    };
+}
+
+registry.category("pos_screens").add("ProductScreen", CustomProductScreen, { force: true });

--- a/pos_salesperson_assignment/views/pos_order_view.xml
+++ b/pos_salesperson_assignment/views/pos_order_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_order_tree_view_inherit_pos_salesperson_assignment" model="ir.ui.view">
+        <field name="name">view.pos.order.tree.view.inherit.pos.salesperson.assignment</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="sales_person_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_pos_pos_form_view_inherit_pos_salesperson_assignment" model="ir.ui.view">
+        <field name="name">view.pos.pos.form.view.inherit.pos.salesperson.assignment</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+        <field name="arch" type="xml">
+            <field name="fiscal_position_id" position="after">
+                <field name="sales_person_id" readonly="1"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
1. Load hr.employee model into POS for salesperson selection.
2. Add sales_person_id field to pos.order to store the assigned salesperson.
3. Patch OrderWidget to display the selected salesperson in the order summary.
4. Patch PosOrder to manage salesperson assignment and access.
5. Introduce a control button on the billing screen to select, change, or remove the salesperson.
6. Display salesperson information in the form and list views of POS orders.

Task - 4600010