### PR TITLE
[ADD] product_kit: add sub product kit

### DIFF
--- a/product_kit/__init__.py
+++ b/product_kit/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/product_kit/__manifest__.py
+++ b/product_kit/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Product kit",
+    "depends": ["base", "sale_management"],
+    "author": "Amit Gangani",
+    "category": "Product/Product kit",
+    "data": [
+        "security/ir.model.access.csv",
+        "report/sale_order_portal_inherit.xml",
+        "report/sale_order_report_inherit.xml",
+        "wizard/sub_product_wizard_views.xml",
+        "views/product_template_form_inherit.xml",
+        "views/sale_order_form_inherit.xml"
+    ],
+    "installable": True,
+    "application": True,
+    "license": "LGPL-3", 
+}

--- a/product_kit/models/__init__.py
+++ b/product_kit/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import sale_order_line
+from . import sale_order

--- a/product_kit/models/product_template.py
+++ b/product_kit/models/product_template.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    is_kit = fields.Boolean()
+    sub_product_ids = fields.Many2many(comodel_name='product.product', string="Sub Products", required=True, domain=[('is_kit', '!=', True)])
+    

--- a/product_kit/models/sale_order.py
+++ b/product_kit/models/sale_order.py
@@ -1,0 +1,6 @@
+from odoo import models, fields
+
+class SaleOrder(models.Model):
+    _inherit='sale.order'    
+    
+    print_in_report=fields.Boolean(string="Print in report?")

--- a/product_kit/models/sale_order_line.py
+++ b/product_kit/models/sale_order_line.py
@@ -1,0 +1,27 @@
+from odoo import fields, models, api
+from odoo.exceptions import UserError, ValidationError
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    is_kit_product = fields.Boolean(related="product_template_id.is_kit")
+    parent_line_id = fields.Many2one(comodel_name='sale.order.line', name="Linked kit product line", ondelete="cascade", domain="[('order_id', '=', order_id)]")
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_all_sub_product_lines(self):
+        for line in self:
+            if line.product_id.is_kit:
+                linked_lines = self.env['sale.order.line'].filtered(lambda line: line.parent_line_id.id == self.parent_line_id.id)
+                for linked_line in linked_lines:
+                    linked_line.unlink()
+
+    def action_open_kit_wizard(self):
+        return {
+            'name': f"Product: {self.product_id.name}",
+            'type': 'ir.actions.act_window',
+            'res_model': 'sub.product.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+        }
+    
+   

--- a/product_kit/report/sale_order_portal_inherit.xml
+++ b/product_kit/report/sale_order_portal_inherit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+     <template id="sale_portal_templates_report_inherited" inherit_id="sale.sale_order_portal_content">
+        <xpath expr="//table[@id='sales_order_table']/tbody/t/tr" position="attributes">
+            <attribute name="t-if">(sale_order.print_in_report) or (line.price_unit != 0)</attribute>
+        </xpath>
+     </template>
+</odoo>

--- a/product_kit/report/sale_order_report_inherit.xml
+++ b/product_kit/report/sale_order_report_inherit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+     <template id="sale_order_document_report_inherited" inherit_id="sale.report_saleorder_document">
+        <xpath expr="//tbody/t/tr" position="attributes">
+            <attribute name="t-if">(line.price_unit != 0) or (doc.print_in_report) </attribute> 
+        </xpath>
+     </template>
+</odoo>

--- a/product_kit/security/ir.model.access.csv
+++ b/product_kit/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sub_product_wizard,access.sub.product.wizard,model_sub_product_wizard,base.group_user,1,1,1,1
+access_sub_product_line_wizard,access.sub.product.line.wizard,model_sub_product_line_wizard,base.group_user,1,1,1,1

--- a/product_kit/views/product_template_form_inherit.xml
+++ b/product_kit/views/product_template_form_inherit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_template_form_inherit_kit" model="ir.ui.view">
+        <field name="name">product.template.form.inherit.kit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_general']" position="inside">
+                <field name="is_kit" string="Is Kit"/>
+                <field name="sub_product_ids" widget="many2many_tags" invisible="is_kit==False" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_kit/views/sale_order_form_inherit.xml
+++ b/product_kit/views/sale_order_form_inherit.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form_inherited" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list" position="attributes">
+                <attribute name="decoration-warning" add="(parent_line_id)" separator="or"/>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_template_id']" position="attributes">
+                <attribute name="readonly">parent_line_id</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_id']" position="attributes">
+                <attribute name="readonly">parent_line_id</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="attributes">
+                <attribute name="readonly">parent_line_id</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']" position="attributes">
+                <attribute name="readonly">parent_line_id</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='tax_id']" position="attributes">
+                <attribute name="readonly">parent_line_id</attribute>
+            </xpath>
+            
+
+            <xpath expr="//field[@name='product_template_id']" position="after">
+                <button name="action_open_kit_wizard" string="Kit" type="object" class="btn-secondary" invisible="not is_kit_product or state in ('sale')"/>
+            </xpath>
+
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="print_in_report"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/product_kit/wizard/__init__.py
+++ b/product_kit/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sub_product_wizard

--- a/product_kit/wizard/sub_product_wizard.py
+++ b/product_kit/wizard/sub_product_wizard.py
@@ -1,0 +1,107 @@
+from odoo import _, Command, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SubProductWizard(models.TransientModel):
+    _name = 'sub.product.wizard'
+
+    sale_order_line_id = fields.Many2one(comodel_name='sale.order.line', required=True, ondelete="cascade")
+    product_id = fields.Many2one(related='sale_order_line_id.product_id', required=True)
+    line_ids = fields.One2many(comodel_name='sub.product.line.wizard', inverse_name='sub_product_wizard_id', string="Sub Products", required=True)
+    
+    @api.model
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
+        
+        sale_order_line_id = self.env.context.get('active_id')
+        sale_order_line = self.env['sale.order.line'].browse(sale_order_line_id)
+        product = sale_order_line.product_id
+
+        line_data = []
+        existing_wizard = self.env['sub.product.wizard'].search([('sale_order_line_id', '=', sale_order_line_id)])
+
+        if existing_wizard:
+            for line in existing_wizard.line_ids:
+                line_data.append((4, line.id, 0))  # Linking existing records
+        else:
+            for sub_product in product.sub_product_ids:
+                line_data.append((0, 0, {
+                    'product_id': sub_product.id,
+                    'quantity': 1,
+                    'price_unit': sub_product.lst_price,  # Fixed field name
+                }))
+
+        defaults.update({
+            'sale_order_line_id': sale_order_line_id,
+            'line_ids': line_data,  
+        })
+
+        return defaults
+
+
+    def action_confirm(self):
+        self.ensure_one()
+
+        # Ensure at least one sub-product is selected
+        if not any(self.line_ids.mapped('quantity')):
+            raise UserError("You must select at least 1 sub-product to purchase the kit product.")
+
+
+        sale_order = self.sale_order_line_id.order_id 
+        
+        existing_sub_lines = {} 
+        filtered_lines = self.env['sale.order.line'].search([
+            ('parent_line_id', '=', self.sale_order_line_id.id),
+            ('order_id', '=', sale_order.id)
+        ])
+
+        for line in filtered_lines:
+            existing_sub_lines[line.product_id.id] = line 
+
+        total_price = 0.0 
+
+        for wizard_line in self.line_ids:
+            sub_product_id = wizard_line.product_id.id
+
+            if sub_product_id in existing_sub_lines:
+                # If sub-product exists, update its quantity (price remains 0)
+                existing_line = existing_sub_lines[sub_product_id]
+                existing_line.write({
+                    'product_uom_qty': wizard_line.quantity,
+                    'price_unit': 0.0,  
+                    'price_subtotal': 0.0, 
+                })
+            else:
+                # If sub-product is new, create a new sale order line
+                new_line = self.env['sale.order.line'].create({
+                    'order_id': sale_order.id,
+                    'product_id': sub_product_id,
+                    'product_uom_qty': wizard_line.quantity,
+                    'price_unit': 0.0,  
+                    'price_subtotal': 0.0,  
+                    'parent_line_id': self.sale_order_line_id.id,
+                })
+                existing_sub_lines[sub_product_id] = new_line  
+
+            total_price += wizard_line.quantity * wizard_line.price_unit
+
+        # Update only the main kit product price
+        self.sale_order_line_id.update({
+            'price_unit': total_price, 
+            'price_subtotal': total_price, 
+        })
+
+        return True
+
+class SubProductLineWizard(models.TransientModel):
+    _name = 'sub.product.line.wizard'
+    _sql_constraints = [
+        ('check_quantity', "CHECK(quantity >= 0)", "The quantity cannot be negative."),
+        ('check_price_unit', "CHECK(price_unit >= 0.0)", "The unit price cannot be negative.")
+    ]
+
+    product_id = fields.Many2one(comodel_name='product.product', required=True, ondelete='cascade')
+    sub_product_wizard_id = fields.Many2one(comodel_name='sub.product.wizard', required=True, ondelete='cascade')
+
+    quantity = fields.Integer(string="Quantity", required=True, default=1)
+    price_unit = fields.Float(string="Unit Price", required=True)

--- a/product_kit/wizard/sub_product_wizard_views.xml
+++ b/product_kit/wizard/sub_product_wizard_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_kit_view_form" model="ir.ui.view">
+        <field name="name">product.kit.wizard.form</field>
+        <field name="model">sub.product.wizard</field> 
+        <field name="arch" type="xml">
+           <form string="form_view">
+                <h3>Sub Products</h3>
+                <field name="line_ids" >
+                    <list editable="bottom" create="false">
+                        <field name="product_id"></field>
+                        <field name="quantity"></field>
+                        <field name="price_unit"></field>
+                    </list>
+                </field>
+                <footer>
+                    <button name="action_confirm" type="object" string="Confirm" class='btn btn-primary' />
+                    <button special="cancel" string="Cancel"/>
+                </footer>
+           </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add a Kit option in the Product Form.
- When a user adds a product that has a kit, show Kit button.
- When the user clicks the button, a wizard will open
- And show the kit's sub-products.
- The user can change the price, and after clicking the Confirm button
- The sub-products will appear in the order line.
- The user can later edit the sub-products by reopening the wizard.
- Add a Print in Report button.
- If enabled, subproducts will appear in the SaleOrder Report and Invoice Report