### PR TITLE
[ADD] sale_product_kit: create custom module which sell product as a kit

### DIFF
--- a/sale_product_kit/__init__.py
+++ b/sale_product_kit/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_product_kit/__manifest__.py
+++ b/sale_product_kit/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': "Sale Product Kit",
+    'description': """
+        This custom module add a function to odoo to sell products as a kit, but not using a BOM or the manufacturing module
+    """,
+    'author': "Dhruv Godhani",
+    'installable': True,
+    'depends': ['sale_management'],
+    'data': [
+        "security/ir.model.access.csv",
+        "views/product_template_views.xml",
+        "views/sale_order_views.xml",
+        "wizard/product_sub_wizard_views.xml",
+        "report/sale_order_invoice_report.xml",
+        "report/sale_order_portal_report.xml",
+        "report/sale_order_report.xml",
+    ],
+    'license': 'LGPL-3',
+    'category': 'Sales',
+}

--- a/sale_product_kit/models/__init__.py
+++ b/sale_product_kit/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import sale_order_line
+from . import sale_order

--- a/sale_product_kit/models/product_template.py
+++ b/sale_product_kit/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    is_kit = fields.Boolean()
+    sub_product_ids = fields.Many2many('product.product', string='Sub Products')

--- a/sale_product_kit/models/sale_order.py
+++ b/sale_product_kit/models/sale_order.py
@@ -1,0 +1,6 @@
+from odoo import fields, models
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    print_in_report = fields.Boolean()

--- a/sale_product_kit/models/sale_order_line.py
+++ b/sale_product_kit/models/sale_order_line.py
@@ -1,0 +1,27 @@
+from odoo import fields, models
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+    
+    is_kit_visible = fields.Boolean(related="product_template_id.is_kit")
+    kit_main_product_id = fields.Many2one("sale.order.line")
+
+    def action_open_wizard(self):
+        return {
+            'type'      : 'ir.actions.act_window',
+            'name'      : f'Product: {self.product_id.name}',
+            'res_model' : 'product.sub.wizard',
+            'view_type' : 'form',
+            'view_mode' : 'form',
+            'target'    : 'new',
+            'context': {
+                'product_template_id': self.product_template_id.id,
+                'sale_order_line_id': self.id
+            }
+        }
+
+    def unlink(self):
+        for line in self:
+            if not line.kit_main_product_id:
+                self.search([('kit_main_product_id','=',line.id)]).filtered(lambda l: l not in self).unlink()
+        return super(SaleOrderLine, self).unlink()

--- a/sale_product_kit/report/sale_order_invoice_report.xml
+++ b/sale_product_kit/report/sale_order_invoice_report.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <template id="report_invoice_document_inherit_kit" inherit_id="account.report_invoice_document">
+        <xpath expr="//table[@name='invoice_line_table']/tbody/t/tr" position="attributes">
+            <attribute name="t-if">not any(line.sale_line_ids.mapped('kit_main_product_id')) or any(line.sale_line_ids.mapped('kit_main_product_id') and line.sale_line_ids.mapped('order_id.print_in_report'))</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_product_kit/report/sale_order_portal_report.xml
+++ b/sale_product_kit/report/sale_order_portal_report.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="sale_portal_templates_report_inherited" inherit_id="sale.sale_order_portal_content">
+        <xpath expr="//table[@id='sales_order_table']/tbody/t/tr" position="attributes">
+            <attribute name="t-if">(sale_order.print_in_report) or (not line.kit_main_product_id)</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_product_kit/report/sale_order_report.xml
+++ b/sale_product_kit/report/sale_order_report.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="sale_order_document_report_inherited" inherit_id="sale.report_saleorder_document">
+        <xpath expr="//tbody/t/tr" position="attributes">
+            <attribute name="t-if">(doc.print_in_report) or (not line.kit_main_product_id)</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_product_kit/security/ir.model.access.csv
+++ b/sale_product_kit/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+sale_product_kit.access_product_sub_wizard,access_product_sub_wizard,sale_product_kit.model_product_sub_wizard,base.group_user,1,1,1,1
+sale_product_kit.access_product_sub_wizard_line,access_product_sub_wizard_line,sale_product_kit.model_product_sub_wizard_line,base.group_user,1,1,1,1

--- a/sale_product_kit/views/product_template_views.xml
+++ b/sale_product_kit/views/product_template_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.inherit.sale.product.kit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="sale.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_policy']" position="after">
+                <field name="is_kit" invisible="type != 'consu'"/>
+                <field name="sub_product_ids" widget="many2many_tags" invisible="not is_kit"/>
+            </xpath>
+        </field>
+    </record> 
+</odoo>

--- a/sale_product_kit/views/sale_order_views.xml
+++ b/sale_product_kit/views/sale_order_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_form_inherit_sale_product_kit" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.product.kit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_template_id']" position="after">
+                <button type="object" name="action_open_wizard" string="Add Kit" 
+                        class="btn btn-primary" 
+                        invisible="not is_kit_visible or state in ('sale')"/>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/list" position="attributes">
+                <attribute name="decoration-warning">kit_main_product_id</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_template_id']" position="attributes">
+                <attribute name="readonly">kit_main_product_id</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="attributes">
+                <attribute name="readonly">kit_main_product_id</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']" position="attributes">
+                <attribute name="readonly">kit_main_product_id</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='order_line']/list/field[@name='tax_id']" position="attributes">
+                <attribute name="readonly">kit_main_product_id</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="print_in_report" string="Print in report?"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_product_kit/wizard/__init__.py
+++ b/sale_product_kit/wizard/__init__.py
@@ -1,0 +1,2 @@
+from . import product_sub_wizard
+from . import product_sub_line_wizard

--- a/sale_product_kit/wizard/product_sub_line_wizard.py
+++ b/sale_product_kit/wizard/product_sub_line_wizard.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+class ProductSubWizardLine(models.TransientModel):
+    _name = "product.sub.wizard.line"
+    _description = "Sub Product Line"
+
+    wizard_id = fields.Many2one("product.sub.wizard", string="Wizard")
+    product_id = fields.Many2one("product.product", string="Product", required=True)
+    quantity = fields.Float(string="Quantity", required=True, default=1.0)
+    price = fields.Float(string="Price", required=True)

--- a/sale_product_kit/wizard/product_sub_wizard.py
+++ b/sale_product_kit/wizard/product_sub_wizard.py
@@ -1,0 +1,100 @@
+from odoo import api, fields, models
+
+class ProductSubWizard(models.TransientModel):
+    _name = "product.sub.wizard"
+    _description = "Wizard to manage sub-products"
+
+    product_id = fields.Many2one('product.product', string="Product", required=True)
+    line_ids = fields.One2many('product.sub.wizard.line', 'wizard_id', string="Sub Products")
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        sale_order_line_id = self.env.context.get('sale_order_line_id')
+
+        if sale_order_line_id:
+            sale_order_line = self.env['sale.order.line'].browse(sale_order_line_id)
+            sale_order = sale_order_line.order_id
+            product = sale_order_line.product_id.product_tmpl_id
+            
+            existing_wizard = self.env['product.sub.wizard'].search([('product_id', '=', product.id)])
+            sale_order_product_ids = {line.product_id.id for line in sale_order.order_line}
+            unique_product_ids = set()
+
+            # Combine both operations in a single list comprehension
+            sub_products = []
+            
+            # Add existing sub-products first
+            for line in existing_wizard.line_ids:
+                if line.product_id.id not in unique_product_ids and line.product_id.id in sale_order_product_ids:
+                    sub_products.append((0, 0, {
+                        'product_id': line.product_id.id,
+                        'quantity': line.quantity,
+                        'price': line.price,
+                    }))
+                    unique_product_ids.add(line.product_id.id)
+            
+            # Add default sub-products
+            for sub_product in product.sub_product_ids:
+                if sub_product.id not in sale_order_product_ids and sub_product.id not in unique_product_ids:
+                    sub_products.append((0, 0, {
+                        'product_id': sub_product.id,
+                        'quantity': 1,
+                        'price': sub_product.list_price,
+                    }))
+                    unique_product_ids.add(sub_product.id)
+
+            res.update({
+                'product_id': product.id,
+                'line_ids': sub_products
+            })
+
+        return res
+
+    def action_confirm_sub_products(self):
+        sale_order_line_id = self.env.context.get('sale_order_line_id')
+        sale_order_line = self.env['sale.order.line'].browse(sale_order_line_id)
+
+        if not sale_order_line:
+            return False
+        
+        sub_product_total = sum(sub_product.price * sub_product.quantity for sub_product in self.line_ids)
+        sale_order = sale_order_line.order_id
+        
+        existing_sub_lines = sale_order.order_line.filtered(lambda l: l.kit_main_product_id.id == sale_order_line.id)
+        existing_sub_product_map = {line.product_id.id: line for line in existing_sub_lines}
+
+        # Create a batch of new lines to add
+        sub_product_lines = []
+        for sub_product in self.line_ids:
+            if sub_product.product_id.id not in existing_sub_product_map:
+                sub_product_lines.append(({
+                    'order_id': sale_order.id, 
+                    'product_id': sub_product.product_id.id,
+                    'product_uom_qty': sub_product.quantity,
+                    'price_unit': 0,
+                    'kit_main_product_id': sale_order_line.id,
+                    'sequence': sale_order_line.sequence
+                }))
+
+        if sub_product_lines:
+            self.env['sale.order.line'].create(sub_product_lines)
+        
+        # Update existing sub-product lines in a single operation
+        for sub_product in self.line_ids:
+            if sub_product.product_id.id in existing_sub_product_map:
+                existing_sub_product_map[sub_product.product_id.id].write({
+                    'product_uom_qty': sub_product.quantity,
+                    'price_unit': 0,
+                })
+        
+        # Update wizard
+        product_id = sale_order_line.product_id.product_tmpl_id.id
+        existing_wizard = self.env['product.sub.wizard'].search([('product_id', '=', product_id)])
+        existing_wizard.line_ids = self.line_ids
+
+        # Update price
+        sale_order_line.price_unit = sub_product_total
+
+        return True
+

--- a/sale_product_kit/wizard/product_sub_wizard_views.xml
+++ b/sale_product_kit/wizard/product_sub_wizard_views.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <record id="view_product_sub_wizard_form" model="ir.ui.view">
+        <field name="name">product.sub.wizard.form</field>
+        <field name="model">product.sub.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Product">
+                <h3>Sub Products</h3>
+                <field name="line_ids" >
+                    <list editable="bottom" create="0" delete="0">
+                        <field name="product_id"/>
+                        <field name="quantity"/>
+                        <field name="price"/>
+                    </list>
+                </field>
+                <footer>
+                    <button name="action_confirm_sub_products" class="btn-primary" type="object" string="Confirm" ></button>
+                    <button special="cancel" string="Cancel"></button>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Sell Product as a Kit
- Add a Is Kit option in the Product Form.
- When a user adds a product that has a kit, the Add Kit button shown.
- When the user clicks the button, a wizard will open and show the kit's sub-products.
- The user can change the price and quantity, and after clicking the Confirm button the sub-products will appear in the order line.
- The user can later edit the sub-products by reopening the wizard.
- Add a Print in Report button.
- If enabled, Subproducts will appear in the Sale Order Report and Invoice Report.

task-4595871