### PR TITLE
[ADD] website_appointment_filters, event_ticket_registration_limit, industry_fsm_clean_service: added modules

### DIFF
--- a/event_ticket_registration_limit/__init__.py
+++ b/event_ticket_registration_limit/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/event_ticket_registration_limit/__manifest__.py
+++ b/event_ticket_registration_limit/__manifest__.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Event Ticket Registration Limit",
+    'category': 'Events/Ticket',
+    'summary': "Restrict the maximum number of tickets that can be booked in a single registration",
+    'description': """
+    A module to add a feature to restrict the maximum number of tickets per registration
+    """,
+    'version': "1.0",
+    'author': "nees",
+    'depends': [
+        'website_event'
+    ],
+    'data': [
+        'views/event_ticket_form_view.xml',
+        'views/website_ticket_view.xml',
+    ],
+    'application': True,
+    'installable': True,
+    'license': "LGPL-3",
+}

--- a/event_ticket_registration_limit/models/__init__.py
+++ b/event_ticket_registration_limit/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import event_ticket

--- a/event_ticket_registration_limit/models/event_ticket.py
+++ b/event_ticket_registration_limit/models/event_ticket.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+class EventTicket(models.Model):
+    _inherit = 'event.event.ticket'
+
+    max_tickets_per_registration = fields.Integer(
+        string="Max Tickets Per Registration",
+        help="Defines the maximum number of tickets allowed per registration. "
+             "Set 0 to ignore this rule set as unlimited."
+    )
+
+    @api.constrains('max_tickets_per_registration')
+    def _check_max_tickets_per_registration(self):
+        for ticket in self:
+            if ticket.max_tickets_per_registration < 0:
+                raise ValidationError(_("Max Tickets Per Registration must be greater than 0."))

--- a/event_ticket_registration_limit/views/event_ticket_form_view.xml
+++ b/event_ticket_registration_limit/views/event_ticket_form_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_ticket_registration_limit" model="ir.ui.view">
+        <field name="name">event.ticket.limit.list.view</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='seats_max']" position="after">
+                <field name="max_tickets_per_registration" string="Max Tickets Limit"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/event_ticket_registration_limit/views/website_ticket_view.xml
+++ b/event_ticket_registration_limit/views/website_ticket_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="limit_ticket_registration" name="modal_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_ticket_registration" t-value="(tickets.max_tickets_per_registration + 1) if tickets.max_tickets_per_registration else 10"/>
+        </xpath>
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event, seats_max_ticket_registration)</attribute>
+        </xpath>
+        <xpath expr="//div//t[@t-set='seats_max']" position="before">
+            <t t-set="seats_max_ticket_registration" t-value="(ticket.max_tickets_per_registration + 1) if ticket.max_tickets_per_registration else 10"/>
+        </xpath>
+        <xpath expr="//div//t[@t-set='seats_max']" position="attributes">
+            <attribute name="t-value">min(seats_max_ticket, seats_max_event, seats_max_ticket_registration)</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//option" position="attributes">
+            <attribute name="t-att-selected">nb == 0 and 'selected'</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/industry_fsm_clean_service/__init__.py
+++ b/industry_fsm_clean_service/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/industry_fsm_clean_service/__manifest__.py
+++ b/industry_fsm_clean_service/__manifest__.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Field Service - Cleaning",
+    'category': 'Services/Field Service',
+    'summary': "Provide trash bin cleaning services on a recurring schedule",
+    'description': """
+    Automated weekly task generation for field service orders, client notification and optimized route planning
+    """,
+    'version': "1.0",
+    'author': "nees",
+    'depends': ['industry_fsm', 'sale_subscription', 'sale_project', 'hr_holidays'],
+    'data': [
+        'views/res_config_settings_views.xml',
+        'data/mail_template_reminder.xml',
+        'data/ir_cron_reminder_data.xml',
+        'views/sale_order_views.xml',
+    ],
+    'assets': {
+        'web.assets_backend_lazy': [
+        'industry_fsm_clean_service/static/src/map_view/map_model.js',
+        ],
+    },
+    'installable': True,
+    'auto_install': True,
+    'license': "OEEL-1",
+}

--- a/industry_fsm_clean_service/data/ir_cron_reminder_data.xml
+++ b/industry_fsm_clean_service/data/ir_cron_reminder_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_fsm_task_reminder" model="ir.cron">
+            <field name="name">Field Service: Reminder Email</field>
+            <field name="model_id" ref="project.model_project_task"/>
+            <field name="state">code</field>
+            <field name="code">model._send_fsm_task_reminders()</field>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="active" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/industry_fsm_clean_service/data/mail_template_reminder.xml
+++ b/industry_fsm_clean_service/data/mail_template_reminder.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="email_template_fsm_reminder" model="mail.template">
+        <field name="name">Field Service: Reminder Email Scheduled</field>
+        <field name="model_id" ref="project.model_project_task"/>
+        <field name="subject">Reminder: Upcoming Service - {{ object.name }}</field>
+        <field name="use_default_to" eval="True"/>
+        <field name="description">Reminder email for scheduled field service tasks.</field>
+        <field name="body_html" type="html">
+<table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;">
+    <tr>
+       <td align="center">
+            <table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">
+                <tbody>
+                    <tr>
+                        <td align="center" style="min-width: 590px;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="590" style="background-color: white; padding: 0px 8px; border-collapse:separate;">
+                                <tr>
+                                    <td valign="middle">
+                                        <t t-set="company" t-value="object.company_id or object.user_id.company_id or user.company_id"/>
+                                        <span style="font-size: 10px;">Field Service Reminder</span><br/>
+                                        <span style="font-size: 20px; font-weight: bold;" t-out="object.name or ''">Scheduled Service</span>
+                                    </td>
+                                    <td valign="middle" align="right" t-if="not company.uses_default_logo">
+                                        <img t-attf-src="/logo.png?company={{ company.id }}" style="width: 80px;" t-att-alt="company.name"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="2" style="text-align:center;">
+                                        <hr width="100%" style="background-color:rgb(204,204,204); border:none; min-height:1px; margin:16px 0px;"/>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center" style="min-width: 590px;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="590" style="background-color: white; padding: 0px 8px;">
+                                <tr>
+                                    <td valign="top" style="font-size: 13px;">
+                                        <t t-set="date_begin" t-value="format_datetime(object.planned_date_begin, tz=object.partner_id.tz, lang_code=object.partner_id.lang)"/>
+                                        <t t-set="date_end" t-value="format_datetime(object.date_deadline, tz=object.partner_id.tz, lang_code=object.partner_id.lang)"/>
+
+                                        Hello <t t-out="object.partner_id.name or 'customer'">customer</t>,<br/><br/>
+
+                                        <t t-if="date_begin and date_end">
+                                            Your <t t-out="object.name or ''">service</t> is scheduled from:
+                                        </t>
+                                        <t t-else="">
+                                            Your <t t-out="object.name or ''">service</t> is scheduled.
+                                        </t>
+
+                                        <br/><br/>
+
+                                        <strong>Service Start Date &amp; Time:</strong><br/>
+                                        <t t-if="date_begin">Date: <t t-out="format_date(object.planned_date_begin)"/><br/></t>
+                                        <t t-if="date_begin">Time: <t t-out="format_time(object.planned_date_begin)"/><br/></t>
+                                        <br/>
+
+                                        <strong>Service End Date &amp; Time:</strong><br/>
+                                        <t t-if="date_end">Date: <t t-out="format_date(object.date_deadline)"/><br/></t>
+                                        <t t-if="date_end">Time: <t t-out="format_time(object.date_deadline)"/><br/></t>
+                                        <br/>
+
+                                        <strong>Preparatory Instructions:</strong><br/>
+                                        - Please ensure all trash bins are empty before the scheduled cleaning.<br/>
+                                        - Place the bins in an accessible location for our cleaning team.<br/>
+                                        - Avoid placing bins near vehicles or other obstacles.<br/>
+                                        - If possible, rinse the bins lightly before the scheduled cleaning to remove loose debris.<br/>
+
+                                        <br/>
+
+                                        If you need to reschedule, please contact us as soon as possible.<br/><br/>
+
+                                        <div style="margin: 16px 0px; text-align: center;">
+                                            <a t-attf-href="{{ object.get_portal_url() }}"
+                                               style="display: inline-block; padding: 10px 30px; text-decoration: none; background-color: #875A7B; color: #fff; border-radius: 5px;">
+                                                View Details
+                                            </a>
+                                        </div>
+
+                                        <br/>
+                                        Best regards,<br/>
+                                        <t t-if="user.signature">
+                                            <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                                        </t>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="text-align:center;">
+                                        <hr width="100%" style="background-color:rgb(204,204,204); border:none; min-height:1px; margin:16px 0px;"/>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center" style="min-width: 590px;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="590" style="font-size: 11px; padding: 0px 8px;">
+                                <tr>
+                                    <td valign="middle" align="left">
+                                        <t t-out="company.name or ''">YourCompany</t>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td valign="middle" align="left" style="opacity: 0.7;">
+                                        <t t-if="company.phone">
+                                            <t t-out="company.phone or ''">+1 650-123-4567</t> |
+                                        </t>
+                                        <t t-if="company.email">
+                                            <a t-attf-href="'mailto:%s' % {{ company.email }}" style="text-decoration:none; color: #454748;"
+                                               t-out="company.email or ''">info@yourcompany.com</a> |
+                                        </t>
+                                        <t t-if="company.website">
+                                            <a t-attf-href="'%s' % {{ company.website }}" style="text-decoration:none; color: #454748;"
+                                               t-out="company.website or ''">http://www.example.com</a>
+                                        </t>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+        </field>
+        <field name="lang">{{ object.partner_id.lang }}</field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+</odoo>

--- a/industry_fsm_clean_service/models/__init__.py
+++ b/industry_fsm_clean_service/models/__init__.py
@@ -1,0 +1,6 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import project_task
+from . import res_config_settings
+from . import sale_order
+from . import sale_order_line

--- a/industry_fsm_clean_service/models/project_task.py
+++ b/industry_fsm_clean_service/models/project_task.py
@@ -1,0 +1,51 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+from odoo import fields, models
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+    _order = 'sequence asc'
+
+    fsm_reminder_sent = fields.Boolean(
+        string="FSM Reminder Sent",
+        default=False,
+        help="Indicates whether a reminder email has been sent for this task.",
+    )
+
+    def _send_fsm_task_reminders(self):
+        """Send reminders to clients X days before the scheduled service date, only if the task is in 'Planned' stage."""
+        config = self.env['ir.config_parameter'].sudo()
+        automated_notifications = (config.get_param('fsm_reminder.automated_client_notification', default='False') == 'True')
+        days_prior = int(config.get_param('fsm_reminder.days_prior', default='0'))
+        email_template_id = int(config.get_param('fsm_reminder.email_template_id', default='0'))
+
+        if not automated_notifications or not email_template_id or days_prior <= 0:
+            return
+
+        email_template = self.env['mail.template'].browse(email_template_id)
+        if not email_template.exists():
+            return
+
+        reminder_date = fields.Date.today() + timedelta(days=days_prior)
+        planned_stage_id = self.env.ref('industry_fsm.planning_project_stage_1').id
+        if not planned_stage_id:
+            return
+
+        tasks = self.env['project.task'].search([
+            ('planned_date_begin', '>=', datetime.combine(reminder_date, datetime.min.time())),
+            ('planned_date_begin', '<', datetime.combine(reminder_date, datetime.max.time())),
+            ('stage_id', '=', planned_stage_id),
+            ('partner_id', '!=', False),
+            ('name', 'ilike', 'Cleaning Services'),
+            ('fsm_reminder_sent', '=', False),
+        ])
+        for task in tasks:
+            email_template.send_mail(task.id, force_send=True)
+            task.fsm_reminder_sent = True
+            task.message_post(
+                body=(
+                    f"Reminder email sent to {task.partner_id.name} for scheduled service!"
+                ),
+                subtype_xmlid='mail.mt_note',
+            )

--- a/industry_fsm_clean_service/models/res_config_settings.py
+++ b/industry_fsm_clean_service/models/res_config_settings.py
@@ -1,0 +1,24 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    automated_client_notification = fields.Boolean(
+        string="Automated Client Notifications",
+        help="Enable automated email reminders for clients before scheduled service.",
+        config_parameter='fsm_reminder.automated_client_notification',
+    )
+    days_prior = fields.Integer(
+        string="Day(s) Prior",
+        help="Specify how many days before the scheduled service the reminder should be sent.",
+        config_parameter='fsm_reminder.days_prior',
+    )
+    email_template_id = fields.Many2one(
+        comodel_name='mail.template',
+        string="Email Template",
+        domain=[('model', '=', 'project.task')],
+        help="Choose an email template for the reminder.",
+        config_parameter='fsm_reminder.email_template_id',
+    )

--- a/industry_fsm_clean_service/models/sale_order.py
+++ b/industry_fsm_clean_service/models/sale_order.py
@@ -1,0 +1,42 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    recurring_task_frequency = fields.Selection([
+        ('weekly', "Weekly"),
+        ('biweekly', "BiWeekly"),
+        ('monthly', "Monthly"),
+        ('preferred_day', "Preferred Day"),
+    ], string="Recurring Task Frequency",
+       default='weekly',
+       help="Defines the frequency at which recurring tasks will be generated for this order.")
+
+    preferred_day = fields.Selection([
+        ('monday', "Monday"),
+        ('tuesday', "Tuesday"),
+        ('wednesday', "Wednesday"),
+        ('thursday', "Thursday"),
+        ('friday', "Friday"),
+        ('saturday', "Saturday"),
+        ('sunday', "Sunday"),
+    ], string="Preferred Day",
+       default='monday',
+       help="If 'Preferred Day' is selected as the frequency, this specifies the preferred day of the week.")
+
+    show_recurring_fields = fields.Boolean(
+        compute='_compute_show_recurring_fields',
+        store=True
+    )
+
+    @api.depends('order_line.product_id', 'order_line.product_id.service_tracking', 'order_line.product_id.project_id.is_fsm')
+    def _compute_show_recurring_fields(self):
+        for order in self:
+            order.show_recurring_fields = any(
+                line.product_id.type == 'service' and
+                line.product_id.service_tracking in ['task', 'task_global_project'] and
+                line.product_id.project_id and line.product_id.project_id.is_fsm
+                for line in order.order_line
+            )

--- a/industry_fsm_clean_service/models/sale_order_line.py
+++ b/industry_fsm_clean_service/models/sale_order_line.py
@@ -1,0 +1,113 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import pytz
+from datetime import datetime, timedelta
+from odoo import models, _
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    def _timesheet_create_task(self, project):
+        """Generate recurring FSM tasks based on sale order settings.
+            :param project: record of project.project in which the task should be created
+            :return task: record of the created task
+        """
+        sale_order = self.order_id
+        if not sale_order.recurring_task_frequency:
+            return super()._timesheet_create_task(project)
+
+        user_tz = pytz.timezone(self.env.user.tz or 'UTC')
+        start_date = sale_order.date_order.astimezone(user_tz)
+        end_datetime = datetime.combine(sale_order.end_date, datetime.max.time()).astimezone(user_tz)
+
+        resource_work_intervals, _ = self.env.user.resource_ids._get_valid_work_intervals(start_date, end_datetime)
+        work_intervals = sorted({
+            (int(interval[2].dayofweek), int(interval[2].hour_from), int(interval[2].hour_to))
+            for _, intervals in resource_work_intervals.items()
+            for interval in intervals
+        })
+
+        service_lines = self.filtered(lambda line: line.product_id.type == 'service' and line.product_id.id)
+        interval_days = {'weekly': 7, 'biweekly': 14, 'monthly': 30}.get(sale_order.recurring_task_frequency, 7)
+
+        created_tasks_map = {}
+        task_values = []
+        end_date = sale_order.end_date or (sale_order.date_order + timedelta(days=interval_days))
+        task_date = sale_order.date_order + timedelta(days=1)
+
+        preferred_weekday = None
+        if sale_order.preferred_day:
+            weekdays_list = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+            preferred_weekday = weekdays_list.index(sale_order.preferred_day)
+
+        while task_date.date() <= end_date:
+            initial_date = task_date
+            task_date = self._get_next_valid_task_date(task_date, work_intervals, preferred_weekday)
+            for line in service_lines:
+                service_id = line.product_id.id
+                key = (task_date.date(), service_id)
+
+                if key not in created_tasks_map and task_date.date() <= end_date:
+                    task_values.append({
+                        'name': f"{sale_order.name} - {line.product_id.name}",
+                        'project_id': project.id,
+                        'sale_line_id': line.id,
+                        'planned_date_begin': task_date,
+                        'date_deadline': task_date + timedelta(hours=1),
+                        'allocated_hours': 1.0,
+                        'description': (line.name.split("\n", 1)[1] if "\n" in line.name else ""),
+                    })
+                    created_tasks_map[key] = True
+
+            task_date = initial_date + timedelta(days=interval_days)
+
+        if task_values:
+            created_tasks = self.env['project.task'].sudo().create(task_values)
+            sale_order.tasks_ids = [(6, 0, created_tasks.ids)]
+
+        return sale_order.tasks_ids
+
+    def _get_next_valid_task_date(self, task_date, work_intervals, preferred_weekday):
+        """Find the next valid workday for task scheduling, avoiding holidays.
+            :param task_date: The date on which the task will be created.
+            :param work_intervals: A set of valid working hours.
+            :param preferred_day: An integer representing the preferred day on which the task should be created.
+            :return: The adjusted task date that meets the specified conditions.
+        """
+        public_holidays = self.env['resource.calendar.leaves'].search([
+            ('resource_id', '=', False),
+            ('company_id', '=', self.env.company.id),
+        ])
+
+        if preferred_weekday is not None:
+            days_to_add = (preferred_weekday - task_date.weekday()) % 7
+            task_date += timedelta(days=days_to_add or 7)
+
+        while True:
+            if any(holiday.date_from.date() <= task_date.date() <= holiday.date_to.date() for holiday in public_holidays):
+                task_date += timedelta(days=1)
+                continue
+
+            if work_intervals:
+                valid_intervals = [
+                    interval
+                    for interval in work_intervals
+                    if task_date.weekday() == interval[0]
+                ]
+                if valid_intervals:
+                    in_valid_interval = any(
+                        hour_from <= task_date.hour < hour_to
+                        for _, hour_from, hour_to in valid_intervals
+                    )
+                    if not in_valid_interval:
+                        hour_from = valid_intervals[0][1]
+                        task_date = task_date.replace(
+                            hour=hour_from, minute=0, second=0, microsecond=0
+                        )
+                    return task_date
+            else:
+                return task_date
+
+            sorted_weekdays = sorted({interval[0] for interval in work_intervals})
+            next_day = min((day for day in sorted_weekdays if day > task_date.weekday()), default=sorted_weekdays[0])
+            task_date += timedelta(days=(next_day - task_date.weekday()) % 7 or 7)

--- a/industry_fsm_clean_service/static/src/map_view/map_model.js
+++ b/industry_fsm_clean_service/static/src/map_view/map_model.js
@@ -1,0 +1,20 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { MapModel } from "@web_map/map_view/map_model";
+
+patch(MapModel.prototype, {
+
+    get canResequence() {
+        if (!this.metaData.defaultOrder || this.metaData.defaultOrder.name !== "sequence") {
+            this.metaData.defaultOrder = { name: "sequence", asc: true };
+        }
+        this.metaData.allowResequence = true;
+        return (
+            this.metaData.defaultOrder &&
+            !this.metaData.fields[this.metaData.defaultOrder.name].readonly &&
+            this.metaData.fields[this.metaData.defaultOrder.name].type === "integer" &&
+            !this.metaData.groupBy?.length
+        );
+    },
+});

--- a/industry_fsm_clean_service/tests/__init__.py
+++ b/industry_fsm_clean_service/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_clean_service

--- a/industry_fsm_clean_service/tests/test_clean_service.py
+++ b/industry_fsm_clean_service/tests/test_clean_service.py
@@ -1,0 +1,136 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import pytz
+from datetime import datetime, timedelta
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+@tagged('post_install', '-at_install')
+class TestCleanService(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company = cls.env.company
+        cls.customer = cls.env['res.partner'].create({'name': 'Test Customer'})
+
+        cls.project = cls.env['project.project'].create({
+            'name': 'Test Project',
+            'partner_id': cls.customer.id,
+        })
+
+        cls.product = cls.env['product.product'].create({
+            'name': "Cleaning Service",
+            'type': 'service',
+            'recurring_invoice': True,
+            'service_tracking': 'task_global_project',
+            'project_id': cls.project.id,
+        })
+
+        cls.plan_month = cls.env['sale.subscription.plan'].create({
+            'name': "Monthly Plan",
+            'billing_period_unit': 'month',
+        })
+
+        cls.sale_order = cls.env['sale.order'].create({
+            'partner_id': cls.customer.id,
+            'plan_id': cls.plan_month.id,
+            'end_date': fields.Date.today() + timedelta(days=30),
+            'recurring_task_frequency': 'weekly',
+        })
+
+        cls.sale_order_line = cls.env['sale.order.line'].create({
+            'order_id': cls.sale_order.id,
+            'product_id': cls.product.id,
+            'product_uom_qty': 1,
+            'price_unit': 100,
+        })
+
+        cls.test_holiday = cls.env['resource.calendar.leaves'].create({
+            'name': "Public Holiday",
+            'company_id': cls.company.id,
+            'date_from': fields.Datetime.today() + timedelta(days=1),
+            'date_to': fields.Datetime.today() + timedelta(days=1, hours=23, minutes=59),
+            'resource_id': False,
+        })
+
+    def test_task_recurrence(self):
+        """Test that tasks are correctly generated for recurring sale orders."""
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        self.assertTrue(tasks, "No task was created from the recurring sale order")
+        for task in tasks:
+            self.assertTrue(task.date_deadline, "Task has no deadline")
+            self.assertLessEqual(task.date_deadline.date(), self.sale_order.end_date, "Task deadline exceeds contract end date")
+            self.assertGreaterEqual(task.date_deadline.date(), self.sale_order.date_order.date(), "Task deadline is before sale order date")
+        for task in tasks:
+            self.assertFalse(
+                self.test_holiday.date_from.date() <= task.date_deadline.date() <= self.test_holiday.date_to.date(),
+                "Task deadline falls within the holiday period"
+            )
+
+    def test_recurring_task_timing(self):
+        """Test that tasks respect the recurring frequency and working schedule."""
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        interval_days = {'weekly': 7, 'biweekly': 14, 'monthly': 30}[self.sale_order.recurring_task_frequency]
+        previous_date = None
+        for task in sorted(tasks, key=lambda t: t.date_deadline):
+            if previous_date:
+                self.assertEqual((task.date_deadline.date() - previous_date).days, interval_days, "Task recurrence interval is incorrect")
+            previous_date = task.date_deadline.date()
+
+    def test_task_scheduling_on_preferred_day(self):
+        """Test that tasks are scheduled on the preferred day when specified."""
+        self.sale_order.write({'preferred_day': 'wednesday'})
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        for task in tasks:
+            self.assertEqual(task.date_deadline.strftime('%A').lower(), 'wednesday', "Task was not scheduled on the preferred day")
+
+    def test_task_creation_without_preferred_day(self):
+        """Test that tasks are created when no preferred day is set."""
+        self.sale_order.write({'preferred_day': False})
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        self.assertTrue(tasks, "Tasks were not created despite having a valid schedule")
+
+    def test_task_timezone_respect(self):
+        """Ensure tasks respect the user's timezone."""
+        user_tz = self.env.user.tz or 'UTC'
+        user_timezone = pytz.timezone(user_tz)
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        for task in tasks:
+            if task.date_deadline:
+                deadline_in_user_tz = task.date_deadline.replace(tzinfo=pytz.utc).astimezone(user_timezone)
+                self.assertEqual(deadline_in_user_tz.tzinfo.zone, user_tz, "Task deadline does not match user timezone")
+            else:
+                self.fail("Task has no deadline set")
+
+    def test_recurring_tasks_only_on_business_days(self):
+        """Ensure tasks are only created on business days."""
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        for task in tasks:
+            self.assertNotEqual(task.date_deadline.weekday(), 5, "Task was scheduled on a Saturday")
+            self.assertNotEqual(task.date_deadline.weekday(), 6, "Task was scheduled on a Sunday")
+
+    def test_task_scheduling_handles_holidays(self):
+        """Ensure tasks are rescheduled if they fall on a holiday."""
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        for task in tasks:
+            self.assertFalse(
+                self.test_holiday.date_from.date() <= task.date_deadline.date() <= self.test_holiday.date_to.date(),
+                "Task was scheduled on a holiday"
+            )
+
+    def test_task_deadlines_with_end_date(self):
+        """Ensure tasks do not get scheduled past the sale order's end date."""
+        self.sale_order.with_user(self.env.ref('base.user_admin')).action_confirm()
+        tasks = self.env['project.task'].search([('project_id', '=', self.project.id)])
+        for task in tasks:
+            self.assertLessEqual(task.date_deadline.date(), self.sale_order.end_date, "Task scheduled past end date")

--- a/industry_fsm_clean_service/views/res_config_settings_views.xml
+++ b/industry_fsm_clean_service/views/res_config_settings_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_inherit_fsm_reminder" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.fsm.reminder</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="industry_fsm.res_config_settings_view_form"/>
+        <field name="priority" eval="80"/>
+        <field name="arch" type="xml">
+            <xpath expr="//block[@id='fsm_tasks_management']" position="inside">
+                <div class="row">
+                    <setting name="automated_client_notification" help="Send automated email reminders to clients before their scheduled service.">
+                    <field name="automated_client_notification"/>
+                </setting>
+                </div>
+                <div class="row" invisible="not automated_client_notification">
+                    <group>
+                        <group>
+                            <field name="days_prior"/>
+                            <field name="email_template_id"/>
+                        </group>
+                    </group>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/industry_fsm_clean_service/views/sale_order_views.xml
+++ b/industry_fsm_clean_service/views/sale_order_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_form_inherit_recurring" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.recurring</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='order_details']" position="inside">
+                <field name="recurring_task_frequency" invisible="not show_recurring_fields"/>
+                <field name="preferred_day" invisible="recurring_task_frequency!='preferred_day' or not show_recurring_fields"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/website_appointment_filters/__init__.py
+++ b/website_appointment_filters/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers

--- a/website_appointment_filters/__manifest__.py
+++ b/website_appointment_filters/__manifest__.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Website Appointment Filters",
+    'category': 'Services/Appointment',
+    'summary': "Added filters on search domain",
+    'description': """
+    A module to add filters in Website View for appointments
+    """,
+    'version': "1.0",
+    'author': "nees",
+    'depends': [
+        'website_appointment',
+        'appointment_account_payment'
+    ],
+    'data': [
+        'views/appointment_filter_templates.xml'
+    ],
+    'application': True,
+    'installable': True,
+    'license':"LGPL-3",
+}

--- a/website_appointment_filters/controllers/__init__.py
+++ b/website_appointment_filters/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import appointment

--- a/website_appointment_filters/controllers/appointment.py
+++ b/website_appointment_filters/controllers/appointment.py
@@ -1,0 +1,44 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.addons.website_appointment.controllers.appointment import WebsiteAppointment
+from odoo.http import request
+
+
+class WebsiteAppointmentFiltersController(WebsiteAppointment):
+    @http.route(['/appointment'], type='http', auth='public', website=True)
+    def appointment_type_index(self, **filters):
+        response = super().appointment_type_index()
+
+        type_mapping = {
+            'online': ('location_id', '=', None),
+            'offline': ('location_id', '!=', None),
+        }
+
+        payment_step_mapping = {
+            'paid': ('has_payment_step', '=', True),
+            'free': ('has_payment_step', '=', False),
+        }
+
+        schedule_mapping = {
+            'users': ('schedule_based_on', '=', 'users'),
+            'resources': ('schedule_based_on', '=', 'resources'),
+        }
+
+        domain = []
+        filters_active = []
+
+        for filter_key, mapping in [
+            ('type', type_mapping),
+            ('payment_step', payment_step_mapping),
+            ('schedule', schedule_mapping),
+        ]:
+            if filter_key in filters and filters[filter_key] in mapping:
+                domain.append(mapping[filters[filter_key]])
+                filters_active.append(f"{filter_key.capitalize()}: {filters[filter_key]}")
+
+        appointment_types = request.env['appointment.type'].search(domain)
+        print_active_filters = ', '.join(filters_active)
+        response.qcontext['appointment_types'] = appointment_types
+        response.qcontext['print_active_filters'] = print_active_filters
+        return response

--- a/website_appointment_filters/views/appointment_filter_templates.xml
+++ b/website_appointment_filters/views/appointment_filter_templates.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="website_filter_buttons" name="Appointment Filter Buttons" inherit_id="website_appointment.website_calendar_index_topbar">
+        <xpath expr="//t[@t-call='website.website_search_box_input']" position="before">
+            <div class="d-flex align-items-center">
+                <div class="dropdown d-none d-lg-block me-3">
+                    <a href="#" role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown" title="Filter by Type">
+                        Type
+                    </a>
+                    <div class="dropdown-menu">
+                        <span t-attf-data-post="/appointment?#{keep_query('*', type='all')}" class="post_link cursor-pointer dropdown-item">All</span>
+                        <span t-attf-data-post="/appointment?#{keep_query('*', type='online')}" class="post_link cursor-pointer dropdown-item text-success">Online</span>
+                        <span t-attf-data-post="/appointment?#{keep_query('*', type='offline')}" class="post_link cursor-pointer dropdown-item text-danger">Offline</span>
+                    </div>
+                </div>
+                <div class="dropdown d-none d-lg-block me-3">
+                    <a href="#" role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown" title="Filter by Payment Step">
+                        Payment Step
+                    </a>
+                    <div class="dropdown-menu">
+                        <span t-attf-data-post="/appointment?#{keep_query('*', payment_step='all')}" class="post_link cursor-pointer dropdown-item">All</span>
+                        <span t-attf-data-post="/appointment?#{keep_query('*', payment_step='paid')}" class="post_link cursor-pointer dropdown-item text-success">Paid</span>
+                        <span t-attf-data-post="/appointment?#{keep_query('*', payment_step='free')}" class="post_link cursor-pointer dropdown-item text-danger">Free</span>
+                    </div>
+                </div>
+                <div class="dropdown d-none d-lg-block me-3">
+                    <a href="#" role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown" title="Filter by Schedule">
+                        Schedule
+                    </a>
+                    <div class="dropdown-menu">
+                        <span t-attf-data-post="/appointment?#{keep_query('*', schedule='all')}" class="post_link cursor-pointer dropdown-item">All</span>
+                        <span t-attf-data-post="/appointment?#{keep_query('*', schedule='users')}" class="post_link cursor-pointer dropdown-item text-primary">Users</span>
+                        <span t-attf-data-post="/appointment?#{keep_query('*', schedule='resources')}" class="post_link cursor-pointer dropdown-item text-secondary">Resources</span>
+                    </div>
+                </div>
+                <a href="/appointment" class="btn btn-danger d-none d-lg-block">
+                    Reset Filters
+                </a>
+            </div>
+        </xpath>
+    </template>
+    <template id="applied_filters" name="Applied Filters" inherit_id="website_appointment.website_calendar_index_topbar">
+        <xpath expr="//div[hasclass('d-flex', 'flex-wrap', 'align-items-center', 'justify-content-between', 'w-100')]" position="after">
+            <t t-if="print_active_filters">
+                <div class="color-white mt-4 mb-2">
+                    <small style="background-color: #5a3c52; color:#ffffff" class="p-3 rounded">
+                        <span t-esc="print_active_filters"/>
+                    </small>
+                </div>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
module: **`website_appointment_filters`**

- Added filters for Type (Online/Offline), Payment Step (Paid/Free), and Schedule (Users/Resources).
- Updated UI with dropdown filters, distinct colors, and a "Reset Filters" button.

**task - 4598894**

---
module: **`event_ticket_registration_limit`**

- Added max_tickets_per_registration (1-9) with validation.
- Enforced ticket limits in the event registration modal.

**task - 4598903**

---

module: **`industry_fsm_clean_service`**

- Automated FSM task creation based on recurring_task_frequency.
- Added email reminders for scheduled cleaning tasks.
- Improved FSM task visualization with web_map integration.

**task - [REVIEW]**
