### PR TITLE
[ADD] event_ticket_limit:  restricts the maximum number of tickets a user can book per registration.

### DIFF
--- a/event_ticket_limit/__init__.py
+++ b/event_ticket_limit/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/event_ticket_limit/__manifest__.py
+++ b/event_ticket_limit/__manifest__.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Event Ticket Booking Limit",
+    "version": "1.0",
+    "author": "Ayush",
+    "summary": "Restricts the maximum number of tickets a user can book per registration.",
+    "category": "Tutorials/Event Ticket Limit",
+    "depends": ["event", "website_event"],
+    "data": [
+        "views/event_ticket_views.xml",
+        "views/event_templates_page_registration.xml"
+    ],
+    "installable": True,
+    "application": False,
+    "license": "LGPL-3"
+}

--- a/event_ticket_limit/models/__init__.py
+++ b/event_ticket_limit/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import event_ticket

--- a/event_ticket_limit/models/event_ticket.py
+++ b/event_ticket_limit/models/event_ticket.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class EventTemplateTicket(models.Model):
+    _inherit = "event.type.ticket"
+
+    max_tickets_per_registration = fields.Integer(
+        string="Max Tickets Per Registration",
+        default=9,
+        help="Define the maximum number of tickets allowed per registration. Between 1-9"
+    )
+
+    _sql_constraints = [
+        (
+            "check_max_tickets_per_registration",
+            "CHECK(max_tickets_per_registration > 0 AND max_tickets_per_registration < 10)",
+            "The maximum tickets per registration must be between 1-9."
+        )
+    ]

--- a/event_ticket_limit/views/event_templates_page_registration.xml
+++ b/event_ticket_limit/views/event_templates_page_registration.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="limit_ticket_registrations" inherit_id="website_event.modal_ticket_registration">
+        <!-- if event have multiple ticket type -->
+        <xpath expr="//t[@t-set='seats_max']" position="after">
+            <t t-set="seats_max" t-value="min(seats_max, ticket.max_tickets_per_registration + 1)" />
+        </xpath>
+
+        <!-- If event have single ticket type -->
+        <xpath expr="//div[hasclass('o_wevent_registration_single')]//t[@t-set='seats_max']" position="after">
+            <t t-set="seats_max" t-value="min(seats_max, tickets.max_tickets_per_registration + 1)" />
+        </xpath>
+    </template>
+</odoo>

--- a/event_ticket_limit/views/event_ticket_views.xml
+++ b/event_ticket_limit/views/event_ticket_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="event_type_ticket_limit_ticket_registration_list" model="ir.ui.view">
+        <field name="name">event.type.ticket.limit.ticket.registration.list</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='seats_taken']" position="after">
+                <field name="max_tickets_per_registration" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Introduced a new field to store the maximum number of tickets a person can book per registration.
- This allows for dynamic configuration of the ticket limit instead of a fixed value which was 9.
Task: [4573739](https://www.odoo.com/odoo/project/18468/tasks/4573739)