### PR TITLE
[IMP] sale: add 'Zero Stock Approval' boolean field in Sale Order

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    "name": "Zero Stock Blockage",
+    "author" : "sabj",
+    "description": "Adds Zero Stock Approval boolean field in Sale Order",
+    "depends": ["sale"],
+    "data": ["views/sale_order_view.xml"],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import  fields, models, api
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(string="Zero Stock Approval")
+    zero_stock_readonly = fields.Boolean(compute="_compute_zero_stock_readonly")
+
+    @api.depends("zero_stock_approval")
+    def _compute_zero_stock_readonly(self):
+        for record in self:
+            record.zero_stock_readonly = (
+                self.env.user.has_group("sales_team.group_sale_salesman") and
+                not self.env.user.has_group("sales_team.group_sale_manager")
+            )
+
+    def action_confirm(self):
+        for order in self:
+            if not order.zero_stock_approval:
+                raise UserError("You need Zero Stock Approval to confirm this sale order.")
+        return super().action_confirm()

--- a/zero_stock_blockage/views/sale_order_view.xml
+++ b/zero_stock_blockage/views/sale_order_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval" readonly="zero_stock_readonly"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added a new boolean field Zero Stock Approval in Sale Order.
- If enabled, then only sale order is confirm.
- The field is read-only for users in the Sales/User group.
- Only Sales/Administrator can modify the field.

task-4603888