### PR TITLE
[ADD] event_ticket_limit: allow configurable ticket limit per registration

### DIFF
--- a/event_ticket_limit/__init__.py
+++ b/event_ticket_limit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_ticket_limit/__manifest__.py
+++ b/event_ticket_limit/__manifest__.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Limit event tickets",
+    'description': "Limits the number of tickets per user registration",
+    'version': '1.0',
+    'author': "nmak",
+    'depends': ["event", "website_event"],
+    'data': [
+        'views/event_ticket_form_view.xml',
+        'views/website_ticket_view.xml'
+    ],
+    'installable': True,
+    'license': "LGPL-3",
+}

--- a/event_ticket_limit/models/__init__.py
+++ b/event_ticket_limit/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_ticket

--- a/event_ticket_limit/models/event_type_ticket.py
+++ b/event_ticket_limit/models/event_type_ticket.py
@@ -1,0 +1,19 @@
+from odoo import models, fields
+
+
+class EventTemplateTicket(models.Model):
+    _inherit = 'event.type.ticket'
+
+    max_tickets_per_registration = fields.Integer(
+        string="Max Tickets Per Registration",
+        default=9,
+        help="Defines the maximum number of tickets allowed per registration (1-9)."
+    )
+    
+    _sql_constraints = [
+        (
+            "check_max_tickets_per_registration",
+            "CHECK(max_tickets_per_registration > 0 AND max_tickets_per_registration <= 10)",
+            "The maximum tickets per registration must be between 1 and 10"
+        )
+    ]

--- a/event_ticket_limit/views/event_ticket_form_view.xml
+++ b/event_ticket_limit/views/event_ticket_form_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="event_ticket_limit_registration_list" model="ir.ui.view">
+        <field name="name">event.ticket.limit.list.view</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='seats_taken']" position="after">
+                 <field name="max_tickets_per_registration" width="205px" string="Max. Tickets Per Registration"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/event_ticket_limit/views/website_ticket_view.xml
+++ b/event_ticket_limit/views/website_ticket_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="limit_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+        <!-- Restrict max ticket selection for events with multiple ticket types -->
+        <xpath expr="//t[@t-set='seats_max']" position="after">
+            <t t-set="seats_max" t-value="min(seats_max, ticket.max_tickets_per_registration + 1)" />
+        </xpath>
+
+        <!-- Restrict max ticket selection for events with a single ticket type -->
+        <xpath expr="//div[hasclass('o_wevent_registration_single')]//t[@t-set='seats_max']" position="after">
+            <t t-set="seats_max" t-value="min(seats_max, tickets.max_tickets_per_registration + 1)" />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Added `max_tickets_per_registration` field to define a per-registration ticket limit.
Replaced the fixed limit of 9 with a dynamic limit based on this field.
Updated ticket selection logic to enforce the new limit. 
Modified the `website_event` UI to display available ticket options accordingly.

task-4589683