### PR TITLE
[ADD] website_sale_extended: add extended description for webshop products

### DIFF
--- a/website_sale_extended_desc/__init__.py
+++ b/website_sale_extended_desc/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/website_sale_extended_desc/__manifest__.py
+++ b/website_sale_extended_desc/__manifest__.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Webshop Extended Description",
+    'description': "Adds Extended Description field to view detailed information of product",
+    'version': '1.0',
+    'author': "nmak",
+    'depends': ["website_sale"],
+    'data': [
+        'views/templates.xml',
+        'views/product_views.xml'
+    ],
+    'installable': True,
+    'license': "LGPL-3",
+}

--- a/website_sale_extended_desc/models/__init__.py
+++ b/website_sale_extended_desc/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_template

--- a/website_sale_extended_desc/models/product_template.py
+++ b/website_sale_extended_desc/models/product_template.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+    
+    extended_description_ecommerce = fields.Html(
+        string="Extended eCommerce Description",
+        translate=True,
+        sanitize_attributes=True,
+        sanitize_form=True,
+        exportable=True,
+        readonly=False,
+    )

--- a/website_sale_extended_desc/views/product_views.xml
+++ b/website_sale_extended_desc/views/product_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_product_form_extended_desc" model="ir.ui.view">
+        <field name="name">product.template.form.extended.desc</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='ecom_description']" position="after">
+                <group string="Extended eCommerce Description" name="ecom_extended_description">
+                    <field
+                        name="extended_description_ecommerce"
+                        colspan="2"
+                        nolabel="1"
+                        placeholder="Provide an extended, formatted product description here."
+                    />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/website_sale_extended_desc/views/templates.xml
+++ b/website_sale_extended_desc/views/templates.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="product_extended_description" inherit_id="website_sale.product">
+        <xpath expr="//p[@class='alert alert-warning' and contains(text(), 'This product has no valid combination.')]" position="after">
+            <div t-if="product.extended_description_ecommerce" class="accordion mb-5" id="extendedDescriptionAccordion">
+                <div class="accordion-item">
+                    <h3 class="mb-0 accordion-header">
+                        <button class="accordion-button"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#collapseExtendedDescription"
+                                aria-expanded="true"
+                                aria-controls="collapseExtendedDescription">
+                            More Information
+                        </button>
+                    </h3>
+                    <div id="collapseExtendedDescription" class="accordion-collapse collapse show"
+                         data-bs-parent="#extendedDescriptionAccordion">
+                        <div t-field="product.extended_description_ecommerce" class="border rounded p-3 accordion-body"/>
+                    </div>
+                </div>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Add a formattable extended description field for e-commerce webshop products. Add a collapsable dropdown for showing and hiding the extended description. Make the extended_description_ecommerce field exportable and importable.

task-4589687