### PR TITLE
[ADD] event:  Added feature to limit number of tickets per registration

### DIFF
--- a/event_limit_registrations/__init__.py
+++ b/event_limit_registrations/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_limit_registrations/__manifest__.py
+++ b/event_limit_registrations/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Limit Registrations in Event',
+    'version': '1.0.0',
+    'depends': ['event'],
+    'installable': True,
+    'application': True,
+    'license': 'LGPL-3',
+    'data': [
+        'views/event_event_views_inherit.xml',
+        'views/event_templates_page_registration_inherit.xml'
+    ],
+}

--- a/event_limit_registrations/models/__init__.py
+++ b/event_limit_registrations/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_ticket

--- a/event_limit_registrations/models/event_ticket.py
+++ b/event_limit_registrations/models/event_ticket.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class EventTicket(models.Model):
+    _inherit = "event.event"
+
+    set_max_ticket = fields.Integer(
+        string="Set Max Registration Limit",
+        default=10,
+        help="Limit number of tickets per registration",
+    )

--- a/event_limit_registrations/views/event_event_views_inherit.xml
+++ b/event_limit_registrations/views/event_event_views_inherit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_event_form_inherit_event" model="ir.ui.view">
+        <field name="name">event.event.view.form.inherit</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/field[@name='tag_ids']" position="before">
+                <field name="set_max_ticket" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/event_limit_registrations/views/event_templates_page_registration_inherit.xml
+++ b/event_limit_registrations/views/event_templates_page_registration_inherit.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <template id="event_ticket_registration" inherit_id="website_event.modal_ticket_registration">
+        <xpath expr="//select[@class='d-inline w-auto form-select']//t[@t-set='seats_max_event']" position="after">
+            <t t-set="custom_max_seat" t-value="event.set_max_ticket+1"/>
+        </xpath>
+        <xpath expr="//select[@class='d-inline w-auto form-select']//t[@t-set='seats_max']" position="replace">
+            <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event, custom_max_seat) if tickets else min(custom_max_seat, seats_max_event+1)"/>
+        </xpath>
+        <xpath expr="//select[@class='w-auto form-select']//t[@t-set='seats_max_event']" position="after">
+            <t t-set="custom_max_seat" t-value="event.set_max_ticket+1"/>
+        </xpath>
+        <xpath expr="//select[@class='w-auto form-select']//t[@t-set='seats_max']" position="replace">
+            <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event, custom_max_seat+1)"/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
With this Commit
================

- Introduced a new field to limit the number of tickets per registration.
- Set the default value of the field to 10.
- Allowed users to modify the value as needed.
- Established the specified value as the maximum number of tickets permitted per registration.