### PR TITLE
[ADD] sale_warranty:  introduce warranty management

### DIFF
--- a/sale_warranty/__init__.py
+++ b/sale_warranty/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import wizard

--- a/sale_warranty/__manifest__.py
+++ b/sale_warranty/__manifest__.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Sale Warranty",
+    "version": "1.0",
+    "author": "Ayush",
+    "summary": "Add warranty to products!",
+    "category": "Tutorials/Sale Warranty",
+    "depends": ["product", "sale_management"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_views.xml",
+        "views/product_warranty_views.xml",
+        "views/sale_menus.xml",
+        "views/sale_order_views.xml",
+        "wizard/sale_order_warranty_views.xml"
+    ],
+    "installable": True,
+    "license": "LGPL-3"
+}

--- a/sale_warranty/models/__init__.py
+++ b/sale_warranty/models/__init__.py
@@ -1,0 +1,6 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_warranty
+from . import product_template
+from . import sale_order
+from . import sale_order_line

--- a/sale_warranty/models/product_template.py
+++ b/sale_warranty/models/product_template.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    is_warranty_available = fields.Boolean(
+        string="Is Warranty Available?",
+        default=False,
+        help="Whether a warranty can be added to this product in the sales order."
+    )

--- a/sale_warranty/models/product_warranty.py
+++ b/sale_warranty/models/product_warranty.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ProductWarranty(models.Model):
+    _name = "product.warranty"
+    _description = "Product Warranty"
+
+    name = fields.Char(string="Name", required=True)
+    duration = fields.Integer(string="Duration (Years)", required=True, help="The duration of the warranty in years.")
+    percent = fields.Float(string="Warranty Price Percentage", required=True,
+                           help="Percentage of the product price that will be charged as the warranty price.")
+    product_id = fields.Many2one(comodel_name="product.product", string="Product", required=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for record in records:
+            record.product_id.sale_ok = False
+            record.product_id.purchase_ok = False
+            record.product_id.type = "service"
+        return records

--- a/sale_warranty/models/sale_order.py
+++ b/sale_warranty/models/sale_order.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    show_warranty_wizard = fields.Boolean(store=False, compute="_compute_show_warranty_wizard")
+
+    @api.depends("order_line.product_id")
+    def _compute_show_warranty_wizard(self):
+        for order in self:
+            order.show_warranty_wizard = any(
+                order_line.product_id.is_warranty_available for order_line in order.order_line
+            )
+
+    def action_open_warranty_wizard(self):
+        self.ensure_one()
+        return {
+            "name": _("Add Warranty"),
+            "type": "ir.actions.act_window",
+            "res_model": "sale.order.warranty",
+            "view_mode": "form",
+            "target": "new",
+        }

--- a/sale_warranty/models/sale_order_line.py
+++ b/sale_warranty/models/sale_order_line.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    warranty_line_ids = fields.One2many(
+        comodel_name="sale.order.line",
+        inverse_name="warranty_parent_line_id",
+        help="Lines representing warranties associated with this product line."
+    )
+    warranty_parent_line_id = fields.Many2one(
+        comodel_name="sale.order.line",
+        ondelete="cascade",
+        help="The original product line that this warranty line covers."
+    )

--- a/sale_warranty/security/ir.model.access.csv
+++ b/sale_warranty/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_order_warranty,access sale.order.warranty,model_sale_order_warranty,base.group_user,1,1,1,1
+access_sale_order_warranty_line,access sale.order.warranty.line,model_sale_order_warranty_line,base.group_user,1,1,1,1
+access_product_warranty,product.warranty,model_product_warranty,base.group_user,1,1,1,1

--- a/sale_warranty/views/product_views.xml
+++ b/sale_warranty/views/product_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_form_view_inherit_sale_warranty" model="ir.ui.view">
+        <field name="name">product.template.form.view.inherit.sale.warranty</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='sale']" position="after">
+                <group>
+                    <field name="is_warranty_available" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_warranty/views/product_warranty_views.xml
+++ b/sale_warranty/views/product_warranty_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_warranty_list_view" model="ir.ui.view">
+        <field name="name">product.warranty.list.view</field>
+        <field name="model">product.warranty</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="name" width="300px" />
+                <field name="product_id" width="300px" />
+                <field name="duration" />
+                <field name="percent" />
+            </list>
+        </field>
+    </record>
+    <record id="action_sale_warranty_config" model="ir.actions.act_window">
+        <field name="name">Warranty Configuration</field>
+        <field name="res_model">product.warranty</field>
+        <field name="view_mode">list</field>
+    </record>
+</odoo>

--- a/sale_warranty/views/sale_menus.xml
+++ b/sale_warranty/views/sale_menus.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <menuitem id="menu_sale_warranty_configuration"
+        action="action_sale_warranty_config"
+        parent="sale.menu_sale_config" />
+</odoo>

--- a/sale_warranty/views/sale_order_views.xml
+++ b/sale_warranty/views/sale_order_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_form_inherit_sale_warranty" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.sale.warranty</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='so_button_below_order_lines']" position="inside">
+                <button string="Add A Warranty"
+                    name="action_open_warranty_wizard"
+                    type="object"
+                    class="btn-primary"
+                    invisible="not show_warranty_wizard" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_warranty/wizard/__init__.py
+++ b/sale_warranty/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order_warranty

--- a/sale_warranty/wizard/sale_order_warranty.py
+++ b/sale_warranty/wizard/sale_order_warranty.py
@@ -1,0 +1,61 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command, _, api, fields, models
+
+
+class SaleOrderWarranty(models.TransientModel):
+    _name = "sale.order.warranty"
+    _description = "Warranty Wizard"
+
+    sale_order_id = fields.Many2one(comodel_name="sale.order", required=True, ondelete="cascade")
+    wizard_line_ids = fields.One2many(comodel_name="sale.order.warranty.line", inverse_name="wizard_id")
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        sale_order_id = self.env.context.get("active_id")
+        sale_order_lines = self.env["sale.order"].browse(sale_order_id).order_line
+        wizard_line_values = []
+        for line in sale_order_lines:
+            if line.product_id.is_warranty_available and not line.warranty_line_ids:
+                wizard_line_values.append({"order_line_id": line.id, "product_id": line.product_id.id})
+        res["wizard_line_ids"] = [Command.clear()] + [Command.create(vals) for vals in wizard_line_values]
+        res["sale_order_id"] = sale_order_id
+        return res
+
+    def action_add_warranty(self):
+        order_lines = []
+        for warranty_line in self.wizard_line_ids:
+            if not warranty_line.product_warranty_id:
+                continue
+            order_lines.append({
+                'order_id': self.sale_order_id.id,
+                'product_id': warranty_line.product_warranty_id.product_id.id,
+                'price_unit': warranty_line.order_line_id.price_unit * warranty_line.product_warranty_id.percent / 100,
+                'name': _(f"Extended Warranty\nWarranty For Product: {warranty_line.order_line_id.product_id.name}\nEnd Date: {warranty_line.end_date}"),
+                'warranty_parent_line_id': warranty_line.order_line_id.id
+            })
+        if len(order_lines) > 0:
+            self.env['sale.order.line'].create(order_lines)
+
+
+class SaleOrderWarrantyLine(models.TransientModel):
+    _name = "sale.order.warranty.line"
+    _description = "Warranty Wizard Line"
+
+    wizard_id = fields.Many2one(comodel_name="sale.order.warranty", required=True, ondelete="cascade")
+    order_line_id = fields.Many2one(comodel_name="sale.order.line", required=True, ondelete="cascade")
+    product_id = fields.Many2one(comodel_name="product.product")
+    product_warranty_id = fields.Many2one(comodel_name="product.warranty")
+    end_date = fields.Date(string="Warranty End Date", compute="_compute_end_date")
+
+    @api.depends("product_warranty_id")
+    def _compute_end_date(self):
+        for record in self:
+            if record.product_warranty_id:
+                record.end_date = fields.Date.add(
+                    fields.Date.context_today(record=record),
+                    years=record.product_warranty_id.duration
+                )
+            else:
+                record.end_date = None

--- a/sale_warranty/wizard/sale_order_warranty_views.xml
+++ b/sale_warranty/wizard/sale_order_warranty_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="sale_order_line_warranty_wizard_form" model="ir.ui.view">
+        <field name="name">sale.order.line.warranty.wizard.form</field>
+        <field name="model">sale.order.warranty</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <field name="sale_order_id" invisible="True" />
+                    <field name="wizard_line_ids">
+                        <list editable="bottom" create="False">
+                            <field name="product_id" readonly="True" />
+                            <field name="order_line_id" column_invisible="True" />
+                            <field name="product_warranty_id" options="{'no_create': True}" />
+                            <field name="end_date" width="150px" readonly="True" />
+                        </list>
+                    </field>
+                </sheet>
+                <footer>
+                    <button type="object" string="Add" name="action_add_warranty" class="btn btn-primary" data-hotkey="q" />
+                    <button special="cancel" string="Discard" class="btn btn-secondary" data-hotkey="x" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added a new option 'Is Warranty Available?' in the product form. If enabled, a warranty can be added to the product in a sales order. 
- Introduced 'Warranty Configuration' in the sales configuration menu:
  - Allows selecting a product to use as a warranty (e.g., Extended Warranty).
  - Lets users define the warranty duration in years.
  - Enables setting the warranty price as a percentage of the product's price. 
- Added an 'Add A Warranty' button in the sales order:
  - Visible only when a product with an available warranty is added to the order
  - Clicking the button opens a 'Warranty Wizard', allowing users to select a warranty for the products. 
- When a warranty is added:
  - The configured warranty product (e.g., Extended Warranty) is automatically added to the order.
  - The warranty price is calculated based on the percent of product price, percent defined in warranty configuration
  - The warranty product description displays the warranty expiration date.

Task: [4582413](https://www.odoo.com/odoo/project/18468/tasks/4582413)