### PR TITLE
[ADD] warranty_extension: introduce warranty selection module

### DIFF
--- a/warranty_extension/__init__.py
+++ b/warranty_extension/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/warranty_extension/__manifest__.py
+++ b/warranty_extension/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Product Warranty',
+    'version': '1.0',
+    'category': 'Sales',
+    'depends': ['sale_management'],
+    'license': 'LGPL-3',
+    'author' : 'Manthan Akbari',
+    'auto_install': True,
+    'data': [
+        'security/ir.model.access.csv',
+        'wizards/warranty_wizard_views.xml',
+        'views/product_template_views.xml',
+        'views/warranty_configuration_views.xml',
+        'views/sale_order_views.xml',
+        'views/warranty_menu.xml',
+    ],
+}

--- a/warranty_extension/models/__init__.py
+++ b/warranty_extension/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import warranty_configuration
+from . import sale_order_line

--- a/warranty_extension/models/product_template.py
+++ b/warranty_extension/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    is_warranty_available = fields.Boolean(string="Warranty Available")

--- a/warranty_extension/models/sale_order_line.py
+++ b/warranty_extension/models/sale_order_line.py
@@ -1,0 +1,8 @@
+from odoo import fields, models, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    warranty_id = fields.Many2one("warranty.configuration",string="Warranty")
+    linked_order_line_id = fields.Many2one("sale.order.line", string="Linked Product Line", ondelete="cascade")

--- a/warranty_extension/models/warranty_configuration.py
+++ b/warranty_extension/models/warranty_configuration.py
@@ -1,0 +1,15 @@
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+class WarrantyConfiguration(models.Model):
+    _name = 'warranty.configuration'
+    _description = "Warranty Configuration"
+
+    name = fields.Char(string="Warranty Name", required=True)
+    product_template_id = fields.Many2one("product.template", string="Product", ondelete="cascade", required=True)
+    year = fields.Float(string="Year", default=1)
+    percentage = fields.Float(string="Percentage", required=True)
+
+    sql_constraints = [
+        ('name_uniq', 'unique(name)', 'A warranty with this name already exists!')
+    ]

--- a/warranty_extension/security/ir.model.access.csv
+++ b/warranty_extension/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+warranty_extension.access_warranty_configuration,access_warranty_configuration,warranty_extension.model_warranty_configuration,base.group_user,1,1,1,1
+warranty_extension.access_warranty_wizards,access_warranty_wizards,warranty_extension.model_warranty_wizards,base.group_user,1,1,1,1

--- a/warranty_extension/views/product_template_views.xml
+++ b/warranty_extension/views/product_template_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_template_warranty_extension_form" model="ir.ui.view">
+        <field name="name">product.template.view.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"></field>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='upsell']" position="after">
+                <group string="Warranty">
+                    <field name="is_warranty_available" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/warranty_extension/views/sale_order_views.xml
+++ b/warranty_extension/views/sale_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sale_order_form" model="ir.ui.view">
+        <field name="name">view.sale.order.form</field>
+        <field name="model">sale.order</field>
+       <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='so_button_below_order_lines']" position="inside">
+                <button string="Add Warranty" name="%(action_warranty_wizard)d" type="action" class="btn btn-primary"/>   
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/warranty_extension/views/warranty_configuration_views.xml
+++ b/warranty_extension/views/warranty_configuration_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+     <record id="action_warranty_configuration" model="ir.actions.act_window">
+        <field name="name">Warranty Configuration</field>
+        <field name="res_model">warranty.configuration</field>
+        <field name="view_mode">list</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Define new warranty
+            </p>
+        </field>
+    </record>
+
+    <record id="action_warranty_configuration_view_list" model="ir.ui.view">
+        <field name="name">warranty.configuration.view.list</field>
+        <field name="model">warranty.configuration</field>
+        <field name="arch" type="xml">
+            <list string="Warranty Config" editable="bottom">
+                <field name="name" />
+                <field name="product_template_id" />
+                <field name="year" />
+                <field name="percentage" />
+            </list>
+        </field>
+    </record>
+
+</odoo>

--- a/warranty_extension/views/warranty_menu.xml
+++ b/warranty_extension/views/warranty_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+     <menuitem id="menu_warranty_config" 
+     name="Warranty Configuration"
+     parent="sale.prod_config_main"
+     action="action_warranty_configuration"/>
+</odoo>

--- a/warranty_extension/wizards/__init__.py
+++ b/warranty_extension/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import warranty_wizards

--- a/warranty_extension/wizards/warranty_wizard_views.xml
+++ b/warranty_extension/wizards/warranty_wizard_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_warranty_wizard_list" model="ir.ui.view">
+        <field name="name">warranty.wizard.form</field>
+        <field name="model">warranty.wizards</field>
+        <field name="arch" type="xml">
+            <form string="Add Warranty to Product">
+                <group>
+                    <field name="order_id" />
+                    <field name="order_line_id" />
+                    <field name="product_id" />
+                    <field name="warranty_id" />
+                    <field name="end_date" />
+                </group>
+                <footer>
+                    <button name="apply_warranty" string="Confirm" type="object" class="oe_highlight"/>
+                    <button string="Cancel" class="oe_link" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+      <record id="action_warranty_wizard" model="ir.actions.act_window">
+        <field name="name">Add Warranty</field>
+        <field name="res_model">warranty.wizards</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_warranty_wizard_list"/>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/warranty_extension/wizards/warranty_wizards.py
+++ b/warranty_extension/wizards/warranty_wizards.py
@@ -1,0 +1,88 @@
+from odoo import api, fields, models
+from dateutil.relativedelta import relativedelta
+from datetime import datetime
+
+
+class WarrantyWizards(models.TransientModel):
+    _name = "warranty.wizards"
+    _description = "Wizard to Add Warranty to Products"
+
+    order_id = fields.Many2one(
+        "sale.order", 
+        string="Sale Order", 
+        readonly=True
+    )
+    order_line_id = fields.Many2one(
+        "sale.order.line",
+        string="Sale Order Line",
+        domain="[('order_id', '=', order_id), ('product_id.is_warranty_available', '=', True)]"
+    )
+    product_id = fields.Many2one(
+        "product.product", 
+        string="Product", 
+        related="order_line_id.product_id", 
+        readonly=True
+    )
+    warranty_id = fields.Many2one(
+        "warranty.configuration",
+        string="Product Warranty"
+    )
+    end_date = fields.Date(
+        string="End Date", 
+        readonly=True
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        defaults = super().default_get(fields_list)
+        sale_order = self.env["sale.order"].browse(self.env.context.get("active_id"))
+    
+        if sale_order:
+            sale_order_lines = sale_order.order_line.filtered(lambda l: l.product_id.is_warranty_available)
+    
+            if sale_order_lines:
+                defaults["order_line_id"] = sale_order_lines[0].id
+    
+            defaults["order_id"] = sale_order.id
+        return defaults
+    
+    @api.onchange("warranty_id")
+    def _onchange_end_date(self):
+        for record in self:
+            if record.warranty_id:
+                end_date = fields.Date.today() + relativedelta(
+                    years=int(self.warranty_id.year), 
+                    months=int((self.warranty_id.year % 1) * 12)
+                )
+                record.end_date = end_date
+
+    def apply_warranty(self):
+        if not all([self.order_id, self.warranty_id, self.order_line_id]):
+            return
+
+        end_date = fields.Date.today() + relativedelta(
+            years=int(self.warranty_id.year), 
+            months=int((self.warranty_id.year % 1) * 12)
+        )
+
+        warranty_vals = {
+            "product_id": self.warranty_id.product_template_id.product_variant_id.id,
+            "name": f"Warranty: {self.warranty_id.name} for {self.product_id.name} (Valid until: {end_date})",
+            "product_uom_qty": 1,
+            "price_unit": (self.warranty_id.percentage / 100) * self.product_id.list_price,
+        }
+
+        warranty = self.env["sale.order.line"].search([
+            ("order_id", "=", self.order_id.id),
+            ("linked_order_line_id", "=", self.order_line_id.id),
+        ], limit=1)
+
+        if warranty:
+            warranty.write(warranty_vals)
+        else:
+            warranty_vals["order_id"] = self.order_id.id
+            warranty_vals["linked_order_line_id"] = self.order_line_id.id
+            warranty = self.env["sale.order.line"].create(warranty_vals)
+
+        warranty.sequence = self.order_line_id.sequence + 1
+        return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
 - Added a new module for managing product warranties.
 - Implemented a selection wizard for choosing warranty options.
 - Displaying only relevant warranty products in the wizard.
 - Pre-populates warranty details from `sale.order.line` when opening the wizard.
 - Ensures warranties are linked to sale order lines instead of products.
 - Dynamically updates or creates warranty lines upon modifications.
 - Automatically removes warranties when linked products are deleted.