### PR TITLE
[ADD] product_warranty: implement warranty management for products

### DIFF
--- a/product_warranty/__init__.py
+++ b/product_warranty/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/product_warranty/__manifest__.py
+++ b/product_warranty/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': 'Product Warranty',
+    'description': 'Product Warranty Module',
+    'sequence': 1,
+    'version': '1.0',
+    'depends': ['sale_management'],
+    'author': 'Shiv Bhadaniya',
+    "installable": True,
+    "application": True,
+    'license': 'LGPL-3',
+    'data': [
+        'security/ir.model.access.csv',
+
+        'wizard/warranty_wizard_views.xml',
+        'views/product_template_views.xml',
+        'views/product_warranty_views.xml',
+        'views/product_warranty_menus.xml',
+        'views/sale_order_views.xml',
+    ],
+}

--- a/product_warranty/models/__init__.py
+++ b/product_warranty/models/__init__.py
@@ -1,0 +1,4 @@
+from . import product_template
+from . import product_warranty
+from . import sale_order
+from . import sale_order_line

--- a/product_warranty/models/product_template.py
+++ b/product_warranty/models/product_template.py
@@ -1,0 +1,8 @@
+from odoo import api, fields, models
+
+class ProductTemplate(models.Model):
+    _name = 'product.template'
+    _inherit = 'product.template'
+
+    has_warranty = fields.Boolean(default=False)
+    warranty_id = fields.Many2one('product.warranty', string="Warranty")

--- a/product_warranty/models/product_warranty.py
+++ b/product_warranty/models/product_warranty.py
@@ -1,0 +1,11 @@
+from odoo import api, models, fields
+from odoo.exceptions import ValidationError
+
+class ProductWarranty(models.Model):
+    _name = 'product.warranty'
+    _description = 'Product Warranty'
+
+    name = fields.Char(string="Warranty Name", required=True)
+    product_id = fields.Many2one('product.template', string="Product", required=True)
+    percentage = fields.Float(string="Warranty Percentage", required=True)
+    year = fields.Integer(string="Warranty Year")

--- a/product_warranty/models/sale_order.py
+++ b/product_warranty/models/sale_order.py
@@ -1,0 +1,4 @@
+from odoo import api, fields, models
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'

--- a/product_warranty/models/sale_order_line.py
+++ b/product_warranty/models/sale_order_line.py
@@ -1,0 +1,26 @@
+from odoo import models, fields, api
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    def unlink(self):
+        """Ensure that when a product is deleted, its warranty is also removed."""
+        warranty_lines_to_delete = self.env['sale.order.line']
+
+        for line in self:
+            if not line.product_template_id:
+                continue
+
+            warranty_product = line.product_id.product_tmpl_id.warranty_id.product_id
+
+            if warranty_product:
+                warranty_line = self.env['sale.order.line'].search([
+                    ('order_id', '=', line.order_id.id),
+                    ('product_template_id', '=', warranty_product.id),
+                ], limit=1)
+
+                warranty_lines_to_delete |= warranty_line
+
+            warranty_lines_to_delete |= line
+
+        return super(SaleOrderLine, warranty_lines_to_delete).unlink()

--- a/product_warranty/security/ir.model.access.csv
+++ b/product_warranty/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_warranty_user,product.warranty.user,model_product_warranty,base.group_user,1,1,1,1
+access_product_warranty_wizard_user,product.warranty.wizard.user,model_product_warranty_wizard,base.group_user,1,1,1,1

--- a/product_warranty/views/product_template_views.xml
+++ b/product_warranty/views/product_template_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_template_inherit_warranty" model="ir.ui.view">
+        <field name="name">product.template.inherit.warranty</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='extra_info']" position="inside">
+                <field name="has_warranty" string="Is Warranty Available?" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_warranty/views/product_warranty_menus.xml
+++ b/product_warranty/views/product_warranty_menus.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <!-- Menu Item for Product Warranties under Sales > Configuration -->
+    <menuitem id="product_warranty_menu_action" name="Warranty Configuration" action="action_product_warranty" parent="sale.menu_sale_config" groups="base.group_system" sequence="20" />
+</odoo>

--- a/product_warranty/views/product_warranty_views.xml
+++ b/product_warranty/views/product_warranty_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="action_product_warranty" model="ir.actions.act_window">
+        <field name="name">Product Warranties</field>
+        <field name="res_model">product.warranty</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <record id="view_product_warranty_list" model="ir.ui.view">
+        <field name="name">product.warranty.list</field>
+        <field name="model">product.warranty</field>
+        <field name="arch" type="xml">
+            <list >
+                <field name="name"/>
+                <field name="product_id"/>
+                <field name="percentage"/>
+                <field name="year"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_product_warranty_form" model="ir.ui.view">
+        <field name="name">product.warranty.form</field>
+        <field name="model">product.warranty</field>
+        <field name="arch" type="xml">
+            <form string="Product Warranty">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="product_id"/>
+                        <field name="percentage"/>
+                        <field name="year"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/product_warranty/views/sale_order_views.xml
+++ b/product_warranty/views/sale_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_warranty_add_button" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.warranty</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='so_button_below_order_lines']" position="inside">
+                <button name="%(product_warranty_wizard_action)d" string="Add Warranty" type="action" class="btn btn-primary"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_warranty/wizard/__init__.py
+++ b/product_warranty/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import warranty_wizard

--- a/product_warranty/wizard/warranty_wizard.py
+++ b/product_warranty/wizard/warranty_wizard.py
@@ -1,0 +1,67 @@
+from odoo import models, fields, api
+from datetime import date
+from odoo.exceptions import ValidationError
+from datetime import timedelta
+
+class ProductWarrantyWizard(models.TransientModel):
+    _name = 'product.warranty.wizard'
+    _description = 'Warranty Wizard for adding warranties to products in sale orders'
+
+    end_date = fields.Date(string="Warranty End Date", readonly=True, store=True, compute="_calculate_end_date")
+    product_ids = fields.Many2one(
+        "product.template",
+        string="Products",
+        domain="[('has_warranty', '=', True)]",
+        required=True
+    )
+
+    warranty_ids = fields.Many2one("product.warranty", string="Select Warranty", required=True)
+
+
+    # ------------------------------------------------------------
+    # METHODS
+    # ------------------------------------------------------------
+
+    @api.depends('warranty_ids')
+    def _calculate_end_date(self):
+        """Calculate the warranty end date based on the selected warranty."""
+        if self.warranty_ids.year:
+            self.end_date = date.today() + timedelta(days=self.warranty_ids.year * 365)
+        else:
+            self.end_date = False
+
+    def calculate_warranty_price(self, warranty_percentage, product_price):
+        if not warranty_percentage or not product_price:
+            return 0.0
+
+        warranty_price = (product_price * warranty_percentage) / 100
+
+        return warranty_price
+
+
+    # ------------------------------------------------------------
+    # ACTIONS
+    # ------------------------------------------------------------
+
+    def add_warranty(self):
+        """ Adds a warranty with product as a new sale order line. """
+        active_order_id = self.env.context.get('active_id')
+        sale_order = self.env['sale.order'].browse(active_order_id)
+
+        if not sale_order:
+            raise ValidationError("No active Sale Order found.")
+
+        if not self.product_ids:
+            raise ValidationError("Please select a warranty product.")
+
+        product_price_including_warranty = self.calculate_warranty_price(self.warranty_ids.percentage, self.product_ids.list_price)
+
+        self.product_ids.write({'warranty_id': self.warranty_ids.id})
+
+        self.env['sale.order.line'].create({
+            'order_id': sale_order.id,
+            'product_id': self.warranty_ids.product_id.product_variant_ids.id,
+            'name': f"Warranty End Date {self.end_date}",
+            'price_unit': product_price_including_warranty,
+            'product_uom_qty': 1,
+        })

--- a/product_warranty/wizard/warranty_wizard_views.xml
+++ b/product_warranty/wizard/warranty_wizard_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_warranty_wizard_form" model="ir.ui.view">
+        <field name="name">warranty.wizard.form</field>
+        <field name="model">product.warranty.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Add Warranty">
+                <sheet>
+                    <group>
+                        <field name="product_ids" />
+                        <field name="warranty_ids" />
+                        <field name="end_date" />
+                    </group>
+                    <footer>
+                        <button name="add_warranty" type="object" string="Add" class="oe_highlight"/>
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="product_warranty_wizard_action" model="ir.actions.act_window">
+        <field name="name">Add Warranty</field>
+        <field name="res_model">product.warranty.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add an option to mark a product as warrantied.
- Add warranty config to set duration and percentage.
- Implement a wizard for selecting applicable warranties.
- Display only relevant warranty products in the wizard.
- Auto-remove warranties when the product is removed from a sale order line.