### PR TITLE
18.0 related product on ecommerce add kupa

### DIFF
--- a/related_products_ecommerce/__init__.py
+++ b/related_products_ecommerce/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/related_products_ecommerce/__manifest__.py
+++ b/related_products_ecommerce/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': "Related Products On E-commerce",
+    'summary': "Automatically add related products to cart in odoo ecommerce",
+    'description': "Automatically add related products to cart in odoo ecommerce",
+    'category': 'Sales',
+    'depends': [
+        'website_sale'
+    ],
+    'data': [
+        'views/product_template_views.xml',
+        'views/template.xml'
+    ],
+    'license': 'AGPL-3'
+}

--- a/related_products_ecommerce/models/__init__.py
+++ b/related_products_ecommerce/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import sale_order
+from . import sale_order_line

--- a/related_products_ecommerce/models/product_template.py
+++ b/related_products_ecommerce/models/product_template.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    related_product_ids = fields.Many2many(
+        comodel_name='product.template',
+        relation='related_product_relation',
+        column1='product_id',
+        column2='related_id',
+        string="Related Products"
+    )

--- a/related_products_ecommerce/models/sale_order.py
+++ b/related_products_ecommerce/models/sale_order.py
@@ -1,0 +1,35 @@
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _cart_update(self, product_id, line_id=None, add_qty=1, set_qty=0, **kwargs):
+        res = super()._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)
+        product = self.env["product.product"].browse(product_id)
+
+        actual_product_line = self.order_line.filtered(lambda l: l.product_id.id == product_id)
+        actual_qty = sum(actual_product_line.mapped("product_uom_qty"))
+
+        related_lines = self.order_line.filtered(
+            lambda l: l.is_related_product and 
+                l.product_id.product_tmpl_id in product.product_tmpl_id.related_product_ids
+        )
+
+        if actual_qty == 0:
+            related_lines.unlink()
+            return res
+
+        if related_lines:
+            related_lines.product_uom_qty = actual_qty
+
+        pending_products = product.product_tmpl_id.related_product_ids - related_lines.product_id.product_tmpl_id
+        for related_product in pending_products:
+            order_line = self.env["sale.order.line"].create({
+                "order_id": self.id,
+                "product_id": related_product.product_variant_id.id,
+                "product_uom_qty": actual_qty,
+                "is_related_product": True,
+            })
+
+        return res

--- a/related_products_ecommerce/models/sale_order_line.py
+++ b/related_products_ecommerce/models/sale_order_line.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    is_related_product = fields.Boolean(
+        string="Is Related Product",
+        default=False,
+        help="Indicates if this product was automatically added as a related product."
+    )

--- a/related_products_ecommerce/tests/__init__.py
+++ b/related_products_ecommerce/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_cart

--- a/related_products_ecommerce/tests/test_cart.py
+++ b/related_products_ecommerce/tests/test_cart.py
@@ -1,0 +1,62 @@
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+from odoo import Command
+
+
+@tagged("post_install", "-at_install")
+class TestCartRelatedProducts(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_a_template = cls.env['product.template'].create({
+            'name': 'product A'
+        })
+        cls.product_b_template = cls.env['product.template'].create({
+            'name': 'product B'
+        })
+        cls.product_c_template = cls.env['product.template'].create({
+            'name': 'product C'
+        })
+        cls.product_d_template = cls.env['product.template'].create({
+            'name': 'product D'
+        })
+        
+        cls.product_a = cls.product_a_template.product_variant_id
+        cls.product_b = cls.product_b_template.product_variant_id
+        cls.product_c = cls.product_c_template.product_variant_id
+        cls.product_d = cls.product_d_template.product_variant_id
+
+        cls.product_a_template.write({
+            'related_product_ids': [Command.set([cls.product_b_template.id, cls.product_c_template.id])]
+        })
+        cls.product_b_template.write({
+            'related_product_ids': [Command.set([cls.product_d_template.id])]
+        })
+        cls.product_d_template.write({
+            'related_product_ids': [Command.set([cls.product_a_template.id])]
+        })
+
+        cls.sale_order = cls.env['sale.order'].create({
+            'partner_id': cls.env.ref('base.res_partner_1').id
+        })
+
+    def test_add_related_products_of_actual_product(self):
+        self.sale_order._cart_update(product_id=self.producta.id, add_qty=1)
+        product_ids = self.sale_order.order_line.mapped('product_id')
+
+        self.assertIn(self.producta, product_ids, "Product a should be in the cart")
+        self.assertIn(self.productb, product_ids, "Product b should be automatically added")
+        self.assertIn(self.productc, product_ids, "Product c should be automatically added")
+        self.assertNotIn(self.productd, product_ids, "Product d should not be added")
+
+    def test_remove_actual_product_and_its_related_product(self):
+        self.sale_order._cart_update(product_id=self.producta.id, add_qty=1)
+        self.sale_order._cart_update(product_id=self.producta.id, add_qty=-1)
+        
+        product_ids = self.sale_order.order_line.mapped('product_id')
+
+        self.assertNotIn(self.producta, product_ids, "Product a should be removed from the cart")
+        self.assertNotIn(self.productb, product_ids, "Product b should be removed from the cart")
+        self.assertNotIn(self.productc, product_ids, "Product c should be removed from the cart")

--- a/related_products_ecommerce/views/product_template_views.xml
+++ b/related_products_ecommerce/views/product_template_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_product_template_from_related" model="ir.ui.view">
+        <field name="name">product.template.form.related.products</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales']/group[@name='sale']" position="after">
+                <group string="Related Products">
+                    <field name="related_product_ids" string="Related Products" widget="many2many_tags"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/related_products_ecommerce/views/template.xml
+++ b/related_products_ecommerce/views/template.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="product_quantity_inherit_related" inherit_id="website_sale.cart_lines" name="Hide Quantity Update for Related Products">
+        
+        <xpath expr="//a[i[hasclass('fa-minus')]]" position="attributes">
+            <attribute name="t-if">
+                not line.is_related_product
+            </attribute>
+        </xpath>
+
+        <xpath expr="//input[hasclass('js_quantity', 'quantity', 'form-control')]" position="attributes">
+            <attribute name="readonly">
+                not line.is_related_product
+            </attribute>
+        </xpath>
+
+        <xpath expr="//a[i[hasclass('fa-plus')]]" position="attributes">
+            <attribute name="t-if">
+                not line.is_related_product
+            </attribute>
+        </xpath>
+
+        <xpath expr="//a[hasclass('js_delete_product')]" position="attributes">
+            <attribute name="t-if">
+                not line.is_related_product
+            </attribute>
+        </xpath>
+
+    </template>
+</odoo>


### PR DESCRIPTION
Task-4606662

This task ensures that when a user adds a product to the cart, its related products are automatically added with the same quantity. If the user updates or removes the main product, the related products update or get removed accordingly. Additionally, users cannot manually change or remove related products in the cart, ensuring consistency. The solution modifies the Odoo _cart_update method in sale.order to enforce these rules. 

