### PR TITLE
[ADD] zero_stock_blockage:  introduce zero stock approval field

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'Zero Stock Blockage',
+    'version': '1.0',
+    'summary': 'Restricts sales order confirmation without Zero Stock Approval',
+    'depends': ['sale_management','sales_team'],
+    'license': "LGPL-3",
+    'data': [
+        'views/sale_order_view.xml',
+    ],
+    'installable': True,
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,21 @@
+from odoo import api, fields, models, exceptions
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(string='Approval')
+    zero_stock_approval_readonly = fields.Boolean(compute='_compute_readonly', store=False)
+
+    @api.depends('zero_stock_approval')
+    def _compute_readonly(self):
+        """Make `zero_stock_approval` readonly for Sales Users"""
+        for order in self:
+            order.zero_stock_approval_readonly = not order.env.user.has_group('sales_team.group_sale_manager')
+
+    def action_confirm(self):
+        """Prevent confirmation if `zero_stock_approval` is False"""
+        for order in self:
+            if not order.zero_stock_approval:
+                raise exceptions.ValidationError("You cannot confirm this sales order because Zero Stock Approval is not enabled.")
+        return super().action_confirm()

--- a/zero_stock_blockage/views/sale_order_view.xml
+++ b/zero_stock_blockage/views/sale_order_view.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="sale_order_form_view_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval" readonly="zero_stock_approval_readonly"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added a new boolean field `Zero Stock Approval` in `sale.order`.
- Allows sales users to confirm sale orders when enabled.
- Set field as read-only for `Sales/User` group.
- Only `Sales/Administrator` can modify this field.