### PR TITLE
[ADD] product_kit_sale:  add new product type 'Kit'

### DIFF
--- a/product_kit_sale/__init__.py
+++ b/product_kit_sale/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import wizard

--- a/product_kit_sale/__manifest__.py
+++ b/product_kit_sale/__manifest__.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Product Kit Sale",
+    "version": "1.0",
+    "author": "Ayush",
+    "summary": "Allows selling products as kits.",
+    "category": "Tutorials/Product Kit Sale",
+    "depends": ["sale_management", "product"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/sale_order_views.xml",
+        "views/product_template_views.xml",
+        "wizard/sale_order_kit.xml"
+    ],
+    "installable": True,
+    "license": "LGPL-3"
+}

--- a/product_kit_sale/models/__init__.py
+++ b/product_kit_sale/models/__init__.py
@@ -1,0 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_template
+from . import sale_order
+from . import sale_order_line

--- a/product_kit_sale/models/product_template.py
+++ b/product_kit_sale/models/product_template.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    is_kit = fields.Boolean(string="Is Kit?", default=False)
+    sub_product_ids = fields.Many2many(comodel_name="product.product")

--- a/product_kit_sale/models/sale_order.py
+++ b/product_kit_sale/models/sale_order.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    print_sub_products_in_report = fields.Boolean(
+        string="Print in report?", help="Print sub product in report as well as in customer preview"
+    )
+
+    def _get_order_lines_to_report(self):
+        order_lines_to_report = super()._get_order_lines_to_report()
+        return order_lines_to_report.filtered(lambda line: not line.parent_kit_line_id or self.print_sub_products_in_report)

--- a/product_kit_sale/models/sale_order_line.py
+++ b/product_kit_sale/models/sale_order_line.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    show_kit_button = fields.Boolean(compute="_compute_kit_button")
+    parent_kit_line_id = fields.Many2one(comodel_name="sale.order.line", ondelete="cascade")
+    sub_product_line_ids = fields.One2many(comodel_name="sale.order.line", inverse_name="parent_kit_line_id")
+    sub_product_effective_price = fields.Float(help="Product price shown in wizard")
+
+    @api.depends("product_id", "order_id.state")
+    def _compute_kit_button(self):
+        for line in self:
+            line.show_kit_button = line.product_id.is_kit and line.order_id.state == 'draft'
+
+    def action_open_kit_wizard(self):
+        self.ensure_one()
+        return {
+            'name': f"Product: {self.product_id.name}",
+            'type': 'ir.actions.act_window',
+            'res_model': 'sale.order.kit',
+            'view_mode': 'form',
+            'target': 'new',
+        }

--- a/product_kit_sale/security/ir.model.access.csv
+++ b/product_kit_sale/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_order_kit,sale.order.kit,model_sale_order_kit,base.group_user,1,1,1,1
+access_sale_order_kit_line,sale.order.kit.line,model_sale_order_kit_line,base.group_user,1,1,1,1

--- a/product_kit_sale/views/product_template_views.xml
+++ b/product_kit_sale/views/product_template_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_kit_form_view" model="ir.ui.view">
+        <field name="name">product.template.kit.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_general']" position="inside">
+                <field name="is_kit" />
+                <field name="sub_product_ids" invisible="not is_kit" widget="many2many_tags" domain="[('is_kit', '=', False)]" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_kit_sale/views/sale_order_views.xml
+++ b/product_kit_sale/views/sale_order_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_kit_form" model="ir.ui.view">
+        <field name="name">sale.order.kit.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="print_sub_products_in_report" />
+            </xpath>
+            <xpath expr="//field[@name='product_template_id']" position="after">
+                <button invisible="not show_kit_button" name="action_open_kit_wizard" type="object" class="btn btn-secondary" icon="fa-wrench"></button>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list" position="attributes">
+                <attribute name="decoration-warning" add="parent_kit_line_id" separator="or"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_template_id']" position="attributes">
+                <attribute name="readonly" add="parent_kit_line_id" separator="or"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_id']" position="attributes">
+                <attribute name="readonly" add="parent_kit_line_id" separator="or"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="attributes">
+                <attribute name="readonly" add="parent_kit_line_id" separator="or"></attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']" position="attributes">
+                <attribute name="readonly" add="parent_kit_line_id" separator="or"></attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_kit_sale/wizard/__init__.py
+++ b/product_kit_sale/wizard/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order_kit
+from . import sale_order_kit_line

--- a/product_kit_sale/wizard/sale_order_kit.py
+++ b/product_kit_sale/wizard/sale_order_kit.py
@@ -1,0 +1,70 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command, _, api, fields, models
+
+
+class SaleOrderKit(models.TransientModel):
+    _name = "sale.order.kit"
+    _description = "Kit Wizard"
+
+    order_line_id = fields.Many2one(comodel_name="sale.order.line", required=True, ondelete="cascade")
+    wizard_line_ids = fields.One2many(comodel_name="sale.order.kit.line", inverse_name="wizard_id")
+    should_update = fields.Boolean(help="Whether to update sales order lines or create new ones")
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        order_line_id = self.env.context.get("active_id")
+        order_line = self.env["sale.order.line"].browse(order_line_id)
+        wizard_lines = []
+        should_update = False
+        if order_line.sub_product_line_ids:
+            should_update = True
+            for line in order_line.sub_product_line_ids:
+                wizard_lines.append({
+                    "product_id": line.product_id.id,
+                    "price_unit": line.sub_product_effective_price,
+                    "quantity": line.product_uom_qty
+                })
+        else:
+            sub_products = order_line.product_id.sub_product_ids
+            for sub_product in sub_products:
+                wizard_lines.append({"product_id": sub_product.id})
+        res["wizard_line_ids"] = [Command.clear()] + [Command.create(vals) for vals in wizard_lines]
+        res["order_line_id"] = order_line_id
+        res["should_update"] = should_update
+        return res
+
+    def _update_order(self):
+        wizard_lines_map = {line.product_id.id: line for line in self.wizard_line_ids}
+        total_price = 0
+        for order_line in self.order_line_id.sub_product_line_ids:
+            wizard_line = wizard_lines_map.get(order_line.product_id.id)
+            total_price += wizard_line.price_unit * wizard_line.quantity
+            order_line.update({
+                'sub_product_effective_price': wizard_line.price_unit,
+                'product_uom_qty': wizard_line.quantity,
+                'price_unit': 0
+            })
+        self.order_line_id.update({'price_unit': total_price})
+
+    def action_add_kit_products(self):
+        if self.should_update:
+            self._update_order()
+            return
+        vals_list = []
+        total_price = 0
+        for wizard_line in self.wizard_line_ids:
+            total_price += wizard_line.price_unit * wizard_line.quantity
+            vals_list.append({
+                'order_id': self.order_line_id.order_id.id,
+                'product_id': wizard_line.product_id.id,
+                'sub_product_effective_price': wizard_line.price_unit,
+                'product_uom_qty': wizard_line.quantity,
+                'parent_kit_line_id': self.order_line_id.id,
+                'price_unit': 0,
+                "linked_line_id": self.order_line_id.id
+            })
+        if len(vals_list) > 0:
+            self.env['sale.order.line'].create(vals_list)
+        self.order_line_id.update({'total_price': total_price})

--- a/product_kit_sale/wizard/sale_order_kit.xml
+++ b/product_kit_sale/wizard/sale_order_kit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="sale_order_kit_wizard_form" model="ir.ui.view">
+        <field name="name">sale.order.line.kit.wizard.form</field>
+        <field name="model">sale.order.kit</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <field name="order_line_id" invisible="True" />
+                    <field name="wizard_line_ids">
+                        <list editable="top" create="false" delete="False">
+                            <field name="product_id" readonly="True" force_save="True" />
+                            <field name="quantity" />
+                            <field name="price_unit" />
+                        </list>
+                    </field>
+                </sheet>
+                <footer>
+                    <button type="object" string="Add" name="action_add_kit_products" class="btn btn-primary" data-hotkey="q" />
+                    <button special="cancel" string="Discard" class="btn btn-secondary" data-hotkey="x" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/product_kit_sale/wizard/sale_order_kit_line.py
+++ b/product_kit_sale/wizard/sale_order_kit_line.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SaleOrderKitLine(models.TransientModel):
+    _name = "sale.order.kit.line"
+    _description = "Sale Order Kit product"
+
+    wizard_id = fields.Many2one(comodel_name="sale.order.kit", required=True, ondelete="cascade")
+    product_id = fields.Many2one(comodel_name="product.product", required=True, ondelete="cascade")
+    quantity = fields.Float(string="Quantity")
+    price_unit = fields.Float(string="Price")


### PR DESCRIPTION
- Added a field in the product form to designate a product as a 'Kit' and associate sub-products with it.
- When a kit product is added to a sales order, a button appears next to it.
- Clicking the button opens a popup (wizard) displaying the sub-products.
- Users can specify quantity and unit price for each sub-product in the wizard.
- Sub-products are added to the sales order with a price of 0, while the total price is included in the main kit product.
- When the wizard is reopened, previously set quantities and prices are retained.
- Introduced a 'Print in Report' checkbox in the sales order:
  - If checked, sub-products appear in the quotation and order report.
  - If unchecked, only the main kit product is shown to the customer. 
 
Task: 4609031