### PR TITLE
18.0 add_pricelist_price pasm

### DIFF
--- a/bookprice_sale_account/__init__.py
+++ b/bookprice_sale_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/bookprice_sale_account/__manifest__.py
+++ b/bookprice_sale_account/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'Book Price for Sales and Invoice',
+    'version': '1.0',
+    'category': 'Sales',
+    'author': "Odoo S.A.",
+    'summary': 'Display the Original Pricelist price (Book Price) on sales orders and invoices',
+    'depends': ['sale_management'],
+    'data': [
+        'views/account_move_view.xml',
+        'views/sale_order_view.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3'
+}

--- a/bookprice_sale_account/models/__init__.py
+++ b/bookprice_sale_account/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move_line
+from . import sale_order

--- a/bookprice_sale_account/models/account_move_line.py
+++ b/bookprice_sale_account/models/account_move_line.py
@@ -1,0 +1,36 @@
+from odoo import api, fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    # computational field for book price    
+    book_price = fields.Float(
+        string="Book Price",
+        compute="_compute_book_price",
+        help="Price without any discount and taxes",
+    )
+
+    @api.depends('product_id', 'quantity', 'move_id.partner_id.property_product_pricelist')
+    def _compute_book_price(self):
+        for line in self:
+            if line.move_type != 'out_invoice':
+                line.book_price = 0.0
+                continue
+            # if invoice have single sale order line then use the book price using sale_line_ids
+            if len(line.sale_line_ids) == 1:
+                line.book_price = line.sale_line_ids.book_price
+                continue
+            pricelist = (
+                len(line.sale_line_ids.order_id) == 1
+                and line.sale_line_ids.order_id.pricelist_id
+                or line.partner_id.specific_property_product_pricelist
+            )
+            if pricelist:
+                line.book_price = line.sale_line_ids.order_id.pricelist_id._get_product_price(
+                    line.product_id,
+                    line.quantity,
+                    line.product_uom_id
+                )
+            else:
+                line.book_price = line.product_id.lst_price

--- a/bookprice_sale_account/models/sale_order.py
+++ b/bookprice_sale_account/models/sale_order.py
@@ -1,0 +1,25 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    # computational field for book price
+    book_price = fields.Float(
+        string="Book Price", 
+        compute="_compute_book_price", 
+        help="Price without any discount and taxes",
+    )
+
+    @api.depends('product_id', 'product_uom_qty', 'order_id.pricelist_id')
+    def _compute_book_price(self):
+        for line in self:
+            if line.product_id and line.order_id.pricelist_id:
+                book_price = line.order_id.pricelist_id._get_product_price(
+                    product=line.product_id, 
+                    quantity=line.product_uom_qty,
+                    uom=line.product_uom,
+                )
+                line.book_price = book_price
+            else:
+                line.book_price = line.product_id.lst_price

--- a/bookprice_sale_account/views/account_move_view.xml
+++ b/bookprice_sale_account/views/account_move_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_move_view_form" model="ir.ui.view">
+        <field name="name">account.move.view.form.book.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list//field[@name='product_id']" position="after">
+                <field name="book_price" invisible="move_type != 'out_invoice'"
+                column_invisible="context.get('default_move_type') != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/bookprice_sale_account/views/sale_order_view.xml
+++ b/bookprice_sale_account/views/sale_order_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">sale.order.line.form.inherit.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list/field[@name='product_template_id']" position="after">
+                <field name="book_price"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
**bookprice_sale_account:** Display Book Price for Sales and Invoices

This PR introduces a computed "Book Price" field on Sales Order Lines and Invoice Lines to display the original pricelist price of a product before any manual adjustments.

- Added the book_price field to store the original pricelist price.
- Displayed "Book Price" only on customer invoices to keep the UI clean.
- Implemented logic to fetch the correct pricelist price based on the selected pricelist, product, and quantity.
- Updated Sales Order and Invoice views to include the new book price field.

**task-[4606369](https://www.odoo.com/odoo/my-tasks/4606369)**
