### PR TITLE
18.0 zero stock blockage atpa

### DIFF
--- a/zero_stock_approval/__init__.py
+++ b/zero_stock_approval/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from . import models

--- a/zero_stock_approval/__manifest__.py
+++ b/zero_stock_approval/__manifest__.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 {
     'name': 'Zero Stock Approval',
     'version': '1.0',

--- a/zero_stock_approval/models/__init__.py
+++ b/zero_stock_approval/models/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from . import sale_order

--- a/zero_stock_approval/models/sale_order.py
+++ b/zero_stock_approval/models/sale_order.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -10,12 +10,11 @@ class SaleOrder(models.Model):
 
     zero_stock_approval = fields.Boolean(string='Approval', copy=False)
 
+    @api.model
     def fields_get(self, allfields=None, attributes=None):
-        res = super().fields_get()
+        res = super().fields_get(allfields, attributes)
         user = self.env.user
-        is_salesman = user.has_group("sales_team.group_sale_salesman")
-        is_manager = user.has_group("sales_team.group_sale_manager")
-        if is_salesman and not is_manager:
+        if not user.has_group("sales_team.group_sale_manager"):
             if "zero_stock_approval" in res:
                 res["zero_stock_approval"]["readonly"] = True
         return res

--- a/zero_stock_approval/views/sale_order_view.xml
+++ b/zero_stock_approval/views/sale_order_view.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <odoo>
-    <record id="sale_order_view_form" model="ir.ui.view">
-        <field name="name">sale.order.inherit.form</field>
+    <record id="view_order_form_inherit_zero_stock_approval" model="ir.ui.view">
+        <field name="name">view.order.form.inherit.zero.stock.approval</field>
         <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"></field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='payment_term_id']" position="after">
-                <field name="zero_stock_approval"></field>
+                <field name="zero_stock_approval"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The 'zero_stock_approval' module introduces a zero stock approval feature for sale order.
The Sales/User group has read-only access to the approval field.
A sale order cannot be confirmed without approval.
To proceed with confirmation, a user must obtain approval, which can only be granted by an administrator.
Task: 4612545