### PR TITLE
[ADD] deposit_rental: deposit for rental products

### DIFF
--- a/deposit_rental/__init__.py
+++ b/deposit_rental/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/deposit_rental/__manifest__.py
+++ b/deposit_rental/__manifest__.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Deposit for rental products",
+    'description': "Adds deposit management to rental products",
+    'version': '1.0',
+    'author': "nmak",
+    'depends': ["sale_renting", "website_sale"],
+    'data': [
+        'views/product_template_views.xml',
+        'views/website_sale_views.xml',
+        'views/res_config_settings_views.xml',
+    ],
+    'installable': True,
+    'license': "LGPL-3",
+}

--- a/deposit_rental/models/__init__.py
+++ b/deposit_rental/models/__init__.py
@@ -1,0 +1,6 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_template
+from . import res_config_settings
+from . import sale_order_line
+from . import sale_order

--- a/deposit_rental/models/product_template.py
+++ b/deposit_rental/models/product_template.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    deposit_product = fields.Boolean(
+        string="Deposit Product", help="Make it a deposit product."
+    )
+    require_deposit = fields.Boolean(
+        string="Require Deposit", help="Enable if this product requires deposit.", default=False
+    )
+    deposit_amount = fields.Float(
+        string="Amount", help="This specifies deposit for 1 unit of this product."
+    )
+
+    @api.onchange("deposit_product")
+    def _onchange_deposit_product(self):
+        self.require_deposit = self.deposit_product

--- a/deposit_rental/models/res_config_settings.py
+++ b/deposit_rental/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    deposit_product_id = fields.Many2one(
+        'product.product', string="Deposit Product",
+        help="This product will be used to add deposits in the Rental Order.",
+        domain="[('product_tmpl_id.rent_ok', '=', True)]",
+        config_parameter="sale_renting.deposit_product_id"
+    )

--- a/deposit_rental/models/sale_order.py
+++ b/deposit_rental/models/sale_order.py
@@ -1,0 +1,35 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, _, fields
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+            
+    @api.onchange('order_line')
+    def _onchange_order_line(self):
+        """Add or update deposit lines when rental products are added/changed"""
+        deposit_product_id = int(self.env['ir.config_parameter'].sudo().get_param(
+            'sale_renting.deposit_product_id', False))
+        
+        if not deposit_product_id:
+            return
+            
+        for line in self.order_line.filtered(lambda l: not l.is_deposit_line):
+            if line.product_id.require_deposit:
+                existing_deposit = self.order_line.filtered(
+                    lambda l: l.is_deposit_line and 
+                             l.linked_product_id.id == line.product_id.id)
+                
+                deposit_amount = line.product_id.deposit_amount * line.product_uom_qty
+                
+                if not existing_deposit:
+                    self.order_line = [(0, 0, {
+                        'product_id': deposit_product_id,
+                        'name': f'Deposit for {line.product_id.name}',
+                        'product_uom_qty': 1,
+                        'price_unit': deposit_amount,
+                        'is_deposit_line': True,
+                        'linked_product_id': line.product_id.id,
+                    })]
+                else:
+                    existing_deposit.price_unit = deposit_amount

--- a/deposit_rental/models/sale_order_line.py
+++ b/deposit_rental/models/sale_order_line.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields, api
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    is_deposit_line = fields.Boolean("Is Deposit Line", default=False)
+    linked_product_id = fields.Many2one('product.product', "Linked Rental Product")

--- a/deposit_rental/views/product_template_views.xml
+++ b/deposit_rental/views/product_template_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_form_view_rental" model="ir.ui.view">
+        <field name="name">product.template.form.inherit.rental</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='options']" position='inside'>
+                    <field name="deposit_product" />
+                    <label for="deposit_product" />
+            </xpath>
+
+            <xpath expr="//page[@name='pricing']/group/group[@name='extra_rental']" position="inside">
+                <group string="Deposit" name="rental_deposit" invisible="not rent_ok">
+                    <field name="require_deposit" invisible="not deposit_product" />
+                    <field name="deposit_amount" widget="monetary" invisible="not require_deposit" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/deposit_rental/views/res_config_settings_views.xml
+++ b/deposit_rental/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <record id="view_res_config_settings_rental" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.rental</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale_renting.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="inside">
+                <div class="app_settings_block" data-string="Rental Deposit">
+                    <block title="Rental Deposit">
+                        <setting name="rental_deposit_product_setting" help="Select Products for mandatory deposits">
+                            <field name="deposit_product_id" options="{'no_create': true}" />
+                        </setting>
+                    </block>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/deposit_rental/views/website_sale_views.xml
+++ b/deposit_rental/views/website_sale_views.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="product_template_inherit" inherit_id="website_sale.product">
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
+            <t t-if="product.product_variant_id.require_deposit">
+                <div class="border rounded p-3 bg-light mt-3">
+                    <div class="d-flex align-items-center">
+                        <i class="fa fa-lock text-danger me-2" />
+                        <strong class="text-dark">Security Deposit Required:</strong>
+                    </div>
+                    <div class="fs-5 fw-semibold text-primary mt-1">
+                        <t t-out="product.currency_id.symbol"/>
+                        <t t-out="product.deposit_amount"/>
+                    </div>
+                    <small class="text-muted fst-italic">Refundable upon return</small>
+                </div>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="cart_lines" inherit_id="website_sale.cart_lines">
+    <xpath expr="//div[@id='cart_products']" position="after"> 
+        <t t-set="deposit_total" t-value="0"/>
+        <t t-foreach="website.sale_get_order().order_line" t-as="line">
+            <t t-if="line.product_id.require_deposit">
+                <t t-set="deposit_total" t-value="deposit_total + (line.product_id.deposit_amount * line.product_uom_qty)"/>
+            </t>
+        </t>
+        <t t-if="deposit_total > 0">
+            <div class="mt-3 d-flex justify-content-between"> 
+                <strong>Security Deposit:</strong> 
+                <t t-out="website.sale_get_order().currency_id.symbol"/> 
+                <t t-out="'{:,.2f}'.format(deposit_total)"/>
+            </div>
+        </t>
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
New configuration option to define a deposit product in rental settings. 
'Require Deposit' checkbox on rental products with an amount field. 
Deposit line appears in sales orders when a rental product  with deposit amount is added to the order line.
Deposit amount field added on webshop product page and order overview.

Task ID: 4605707