### PR TITLE
[ADD] webshop_extension: add extended product description with multi-language

### DIFF
--- a/webshop_extension/__init__.py
+++ b/webshop_extension/__init__.py
@@ -1,0 +1,10 @@
+from . import models
+
+def post_init_hook(env):
+    languages_to_activate = ['da_DK', 'sv_SE']
+    
+    for lang_code in languages_to_activate:
+        # with_context(active_test=False) allows us to find records even if they are inactive by default odoo will ignore them
+        lang = env['res.lang'].with_context(active_test=False).search([('code', '=', lang_code)], limit=1)
+        if lang:
+            lang.write({'active': True})

--- a/webshop_extension/__manifest__.py
+++ b/webshop_extension/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "webshop_extension",
+    "description": "This module adds an extended description field in the website's product view.",
+    "author": "Mahavir Patel (pmah)",
+    "version": "1.0",
+    "category": "website",
+    "depends": ["product","website_sale"],
+    "data" : [
+        "views/product_views.xml",
+        "views/product_web_template.xml"
+    ],
+    'post_init_hook': 'post_init_hook',
+    "installable": True,
+    "license": "LGPL-3"
+}

--- a/webshop_extension/models/__init__.py
+++ b/webshop_extension/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/webshop_extension/models/product_template.py
+++ b/webshop_extension/models/product_template.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+from odoo.tools.translate import html_translate
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    extended_description = fields.Html(
+        string="Extended Product Description",
+        translate=html_translate,
+    )

--- a/webshop_extension/views/product_views.xml
+++ b/webshop_extension/views/product_views.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record id="product_template_form_view_inherit_webshop_extension" model="ir.ui.view">
+        <field name="name">product.template.form.view.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='sales']//group[@name='sale']" position="after">
+                <group name="extended_description" string="Extended Description of Product">
+                        <field name="extended_description"
+                            nolabel="1"
+                            placeholder="A detailed,formatted extended description to promote your product on this page. Use '/' to discover more features."
+                        />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/webshop_extension/views/product_web_template.xml
+++ b/webshop_extension/views/product_web_template.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <template id="template_with_extended_description" inherit_id="website_sale.product">
+        <xpath expr="//section[@id='product_detail']" position="inside">
+             <div id="product_extended_description" class="oe_website_sale container my-3 my-lg-4">
+                <t t-if="product.extended_description">
+                    <h2 class="mt-4">Extended Description</h2>
+                    <div class="oe_structure">
+                        <t t-esc="product.extended_description"/>
+                    </div>
+                </t>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
- Allow adding and editing detailed product descriptions in the backend.
- Display extended descriptions on the product page below product details.
- Support Danish and Swedish translations for the description.
- Enable import/export functionality for the new field.