### PR TITLE
[ADD] sale_product_kit: added support for configurable kit sub-products in sales

### DIFF
--- a/sale_product_kit/__init__.py
+++ b/sale_product_kit/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_product_kit/__manifest__.py
+++ b/sale_product_kit/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Sales kit",
+    "description": """
+    sales kit integration
+    """,
+    "depends": ["sale_management"],
+    "data": [
+        "security/ir.model.access.csv",
+        "report/sale_order_report.xml",
+        "report/invoice_report.xml",
+        "report/sale_portal_customer_view.xml",
+        "views/product_template_views.xml",
+        "views/sale_order_line.xml",
+        "wizard/sub_product_wizard_view.xml",
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/sale_product_kit/models/__init__.py
+++ b/sale_product_kit/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import sale_order_line
+from . import sale_order

--- a/sale_product_kit/models/product_template.py
+++ b/sale_product_kit/models/product_template.py
@@ -1,0 +1,17 @@
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProducTemplate(models.Model):
+    _inherit = "product.template"
+
+    is_kit = fields.Boolean(string="Is kit")
+    sub_product_ids = fields.Many2many(
+        "product.product", string="Sub Product", required=True
+    )
+
+    @api.constrains("sub_product_ids")
+    def _check_no_self_reference(self):
+        for record in self:
+            if record.product_variant_id in record.sub_product_ids:
+                raise ValidationError("A product cannot be part of its own sub-products list")

--- a/sale_product_kit/models/sale_order.py
+++ b/sale_product_kit/models/sale_order.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    print_in_report = fields.Boolean(string="Print in report")

--- a/sale_product_kit/models/sale_order_line.py
+++ b/sale_product_kit/models/sale_order_line.py
@@ -1,0 +1,28 @@
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    is_kit = fields.Boolean(related="product_template_id.is_kit")
+    kit_parent_id = fields.Many2one("sale.order.line")
+    is_kit_component = fields.Boolean()
+    extra_price = fields.Float(default=0.0)
+
+    def open_kit_wizard(self):
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Kit Configuration",
+            "res_model": "sub.product.kit.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"active_id": self.id},
+        }
+
+    def unlink(self):
+        child_lines = self.env["sale.order.line"].search([("kit_parent_id", "in", self.ids)])
+        for line in self:
+            if not line.kit_parent_id:
+                child_lines.filtered(lambda l: l not in self).unlink()
+
+        return super().unlink()

--- a/sale_product_kit/report/invoice_report.xml
+++ b/sale_product_kit/report/invoice_report.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="report_invoice_document_inherited_view" inherit_id="account.report_invoice_document">
+        <xpath expr="//table[@name='invoice_line_table']/tbody/t/tr" position="attributes">
+            <attribute name="t-if">
+                not any(line.sale_line_ids.mapped('kit_parent_id')) or any(line.sale_line_ids.mapped('kit_parent_id') and line.sale_line_ids.mapped('order_id.print_in_report'))
+            </attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_product_kit/report/sale_order_report.xml
+++ b/sale_product_kit/report/sale_order_report.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="report_saleorder_document_inherited_view" inherit_id="sale.report_saleorder_document">
+        <xpath expr="//tbody/t/tr" position="attributes">
+            <attribute name="t-if">
+                (not line.kit_parent_id) or (doc.print_in_report and line.kit_parent_id)
+            </attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_product_kit/report/sale_portal_customer_view.xml
+++ b/sale_product_kit/report/sale_portal_customer_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="sale_order_portal_content_inherited_view" inherit_id="sale.sale_order_portal_content">
+        <xpath expr="//tbody/t/tr" position="attributes">
+            <attribute name="t-if">
+                (not line.kit_parent_id) or (sale_order.print_in_report and line.kit_parent_id)
+            </attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_product_kit/security/ir.model.access.csv
+++ b/sale_product_kit/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+sale_product_kit.access_subproducts_wizard,Access Subproducts Wizard,sale_product_kit.model_sub_product_kit_wizard,base.group_user,1,1,1,0
+sale_product_kit.access_subproducts_wizard_line,Access Subproducts Wizard Line,sale_product_kit.model_sub_product_kit_wizard_line,base.group_user,1,1,1,0

--- a/sale_product_kit/views/product_template_views.xml
+++ b/sale_product_kit/views/product_template_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_tooltip']" position="after">
+                <field name="is_kit" invisible="type != 'consu'"/>
+                <field name="sub_product_ids" widget= "many2many_tags" invisible="not is_kit"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_product_kit/views/sale_order_line.xml
+++ b/sale_product_kit/views/sale_order_line.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="inherit_sale_order_line_form_view" model="ir.ui.view">
+        <field name="name">sale.order.form.view.kit.button</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_template_id']" position="after">
+                <button name="open_kit_wizard" type="object" string="Kit" class="btn btn-primary" invisible="not is_kit or state!='draft'" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list" position="attributes">
+                <attribute name="editable">bottom</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_id']" position="attributes">
+                <attribute name="readonly">is_kit_component</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_template_id']" position="attributes">
+                <attribute name="readonly">is_kit_component</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="attributes">
+                <attribute name="readonly">is_kit_component</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']" position="attributes">
+                <attribute name="readonly">is_kit_component</attribute>
+            </xpath>
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="print_in_report" string="Print in report"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_product_kit/wizard/__init__.py
+++ b/sale_product_kit/wizard/__init__.py
@@ -1,0 +1,2 @@
+from . import sub_product_kit_wizard
+from . import sub_product_kit_wizard_line

--- a/sale_product_kit/wizard/sub_product_kit_wizard.py
+++ b/sale_product_kit/wizard/sub_product_kit_wizard.py
@@ -1,0 +1,97 @@
+from odoo import api, fields, models
+from odoo.fields import Command
+
+
+class SubProductKitWizard(models.TransientModel):
+    _name = "sub.product.kit.wizard"
+    _description = "Sub products Kit selection Wizard"
+
+    sale_order_line_id = fields.Many2one("sale.order.line", string="Sale order line")
+    product_id = fields.Many2one("product.product", string="Product", required=True)
+    kit_component_ids = fields.One2many(
+        "sub.product.kit.wizard.line", "wizard_id", string="Sub Products"
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        sale_order_line_id = self.env.context.get("active_id")
+        sale_order_line = self.env["sale.order.line"].browse(sale_order_line_id)
+
+        if sale_order_line.product_id:
+            product = sale_order_line.product_id
+            sale_order = sale_order_line.order_id
+
+            existing_lines = sale_order.order_line.filtered(
+                lambda line: line.product_id in product.sub_product_ids
+                and line.kit_parent_id == sale_order_line
+            )
+
+            kit_component_commands = []
+
+            for sub_product in product.sub_product_ids:
+                existing_line = existing_lines.filtered(
+                    lambda line: line.product_id == sub_product
+                )
+
+                if existing_line:
+                    existing_line = existing_line[0]
+
+                kit_component_commands.append(
+                    Command.create(
+                        {
+                            "product_id": sub_product.id,
+                            "quantity": existing_line.product_uom_qty if existing_line else 1.0,
+                            "price": existing_line.extra_price if existing_line else sub_product.lst_price,
+                            "existing_line_id": existing_line.id if existing_line else False,
+                        }
+                    )
+                )
+
+            res.update(
+                {
+                    "product_id": product.id,
+                    "sale_order_line_id": sale_order_line.id,
+                    "kit_component_ids": kit_component_commands,
+                }
+            )
+
+        return res
+
+    def confirm_kit(self):
+        order = self.sale_order_line_id.order_id
+        main_product_line = self.sale_order_line_id
+        main_product = main_product_line.product_id
+        parent_sequence = main_product_line.sequence
+        total_price = main_product.list_price
+
+        for component in self.kit_component_ids:
+            existing_line = order.order_line.filtered(
+                lambda line: line.product_id == component.product_id
+                and line.kit_parent_id == main_product_line
+                and line.order_id == order
+            )
+            values = {
+                "product_uom_qty": component.quantity,
+                "price_unit": 0.0,
+                "extra_price": component.price,
+                "sequence": parent_sequence,
+            }
+
+            if existing_line:
+                existing_line.write(values)
+            else:
+                self.env["sale.order.line"].create(
+                    {
+                        **values,
+                        "name": component.product_id.name,
+                        "order_id": order.id,
+                        "product_id": component.product_id.id,
+                        "is_kit_component": True,
+                        "kit_parent_id": main_product_line.id,
+                    }
+                )
+
+            total_price += component.price * component.quantity
+
+        main_product_line.write({"price_unit": total_price})

--- a/sale_product_kit/wizard/sub_product_kit_wizard_line.py
+++ b/sale_product_kit/wizard/sub_product_kit_wizard_line.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class SubProductKitWizardLine(models.TransientModel):
+    _name = "sub.product.kit.wizard.line"
+    _description = "Wizard Sub Products"
+
+    wizard_id = fields.Many2one("sub.product.kit.wizard", string="wizard")
+    product_id = fields.Many2one("product.product", string="Product")
+    quantity = fields.Float(string="Quantity", default=1.0)
+    price = fields.Float(string="Price")
+    existing_line_id = fields.Many2one("sale.order.line")

--- a/sale_product_kit/wizard/sub_product_wizard_view.xml
+++ b/sale_product_kit/wizard/sub_product_wizard_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_product_kit_wizard" model="ir.ui.view">
+        <field name="name">sub.product.kit.wizard.form</field>
+        <field name="model">sub.product.kit.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Select Kit Components">
+                <group>
+                    <field name="product_id" readonly="1"/>
+                </group>
+                <group>
+                    <field name="kit_component_ids" nolabel="1">
+                        <list editable="bottom" create="false">
+                            <field name="product_id" readonly="1" force_save="1"/>
+                            <field name="quantity"/>
+                            <field name="price"/>
+                        </list>
+                    </field>
+                </group>
+                <footer>
+                    <button name="confirm_kit" string="Confirm" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## New Product Type in Odoo

    - Added support for product kits in sale orders with sub-product management.
    - Introduced kit_parent_id to link parent and sub-product lines.
    - Added a wizard to configure sub-products and their prices/quantities directly from the sale order line.
    - Enhanced sale order report to conditionally display sub-products based on print_in_report.
    - Customized customer portal order view to follow the same logic for sub-product visibility.
    - Updated invoice PDF and preview to show sub-products only when required.


Task Id: 4603443
