### PR TITLE
[FIX] discount: fix discount lines persisting after product line dele…

### DIFF
--- a/discount/__init__.py
+++ b/discount/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/discount/__manifest__.py
+++ b/discount/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    'name': 'Discount',
+    'version': '1.0',
+    'depends': ['sale_management'],
+    'description': 'Improvement in the discount functionality in sale order',
+    'author': 'Odoo - Rushil Patel',
+    'license': 'LGPL-3',
+}

--- a/discount/models/__init__.py
+++ b/discount/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_line
+from . import sale_order_discount

--- a/discount/models/sale_order_discount.py
+++ b/discount/models/sale_order_discount.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class SaleOrderDiscount(models.TransientModel):
+    _inherit = "sale.order.discount"
+
+    def _prepare_discount_line_values(self, product, amount, taxes, description=None):
+        self.ensure_one()
+        vals = super()._prepare_discount_line_values(product, amount, taxes, description)
+        vals['is_discount_line'] = True
+        return vals

--- a/discount/models/sale_order_line.py
+++ b/discount/models/sale_order_line.py
@@ -1,0 +1,21 @@
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    is_discount_line = fields.Boolean(
+        string="Is Discount Line",
+        default=False,
+        help="Indicates if this line is a discount line created by the discount wizard."
+    )
+
+    def unlink(self):
+        orders = self.mapped('order_id')
+        res = super().unlink()
+        for order in orders:
+            product_lines = order.order_line.filtered(lambda line: not line.is_discount_line)
+            discount_lines = order.order_line.filtered(lambda line: line.is_discount_line)
+            if not product_lines and discount_lines:
+                discount_lines.unlink()
+        return res


### PR DESCRIPTION
In this commit:
- Added 'is_discount_line' boolean field to 'sale_order_line' to identify discount line.
- Modified 'sale_order_discount' to set 'is_discount_line' to True when creating discount lines.
- Overrode 'unlink' method in 'sale_order_line' to automatically remove discount lines when no product lines remain after deletion.