### PR TITLE
[ADD] sale_mrp_modular: add module to provide modular types

### DIFF
--- a/sale_mrp_modular/__init__.py
+++ b/sale_mrp_modular/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/sale_mrp_modular/__manifest__.py
+++ b/sale_mrp_modular/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': 'MRP - Modular Types',
+    'version': '1.0',
+    'summary': 'Modular Types in MRP for BOM',
+    'author': 'Harsh Shah',
+    'license': 'LGPL-3',
+    'installable': True,
+    'depends': [ 'sale_mrp', 'sale_management' ],
+    'data': [
+        'security/ir.model.access.csv',
+
+        'views/product_template_view.xml',
+        'views/mrp_bom_view.xml',
+        'views/sale_mrp_modular_wizard_view.xml',
+        'views/sale_order_view.xml',
+        'views/mrp_production_view.xml'
+    ],
+}
+

--- a/sale_mrp_modular/models/__init__.py
+++ b/sale_mrp_modular/models/__init__.py
@@ -1,0 +1,6 @@
+from . import mrp_bom_line
+from . import product_template
+from . import stock_move
+from . import sale_mrp_modular
+from . import sale_order
+from . import sale_order_line

--- a/sale_mrp_modular/models/mrp_bom_line.py
+++ b/sale_mrp_modular/models/mrp_bom_line.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class MrpBomLine(models.Model):
+    _inherit = 'mrp.bom.line'
+
+    modular_type_id = fields.Many2one(comodel_name='sale.mrp.modular', string='Module Type')

--- a/sale_mrp_modular/models/product_template.py
+++ b/sale_mrp_modular/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    modular_type_ids = fields.Many2many(comodel_name='sale.mrp.modular', string='Modular Types')

--- a/sale_mrp_modular/models/sale_mrp_modular.py
+++ b/sale_mrp_modular/models/sale_mrp_modular.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class SaleMrpModular(models.Model):
+    _name = 'sale.mrp.modular'
+    _description = 'List of Modular Types'
+
+    name = fields.Text(string='Modular Type Name')
+    color = fields.Integer(string='Color')

--- a/sale_mrp_modular/models/sale_order.py
+++ b/sale_mrp_modular/models/sale_order.py
@@ -1,0 +1,19 @@
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def action_confirm(self):
+        res = super().action_confirm()
+
+        for mrp_production_id in self.mrp_production_ids:
+            source_order_line = self.env['sale.order.line'].search([("order_id.name", "=", mrp_production_id.origin), ("product_id", "=", mrp_production_id.product_id.id)])
+
+            for component in mrp_production_id.move_raw_ids:
+                if component.modular_type_id:
+                    sale_order_modular_values = source_order_line.modular_value_ids.filtered(lambda l: l.modular_type_id.id == component.modular_type_id.id).value
+                    component.quantity *= sale_order_modular_values
+                    component.product_uom_qty *= sale_order_modular_values
+
+        return res

--- a/sale_mrp_modular/models/sale_order_line.py
+++ b/sale_mrp_modular/models/sale_order_line.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    modular_value_ids = fields.One2many('sale.mrp.modular.wizard.line', 'source_sale_order_line_id', string='Modular Values')

--- a/sale_mrp_modular/models/stock_move.py
+++ b/sale_mrp_modular/models/stock_move.py
@@ -1,0 +1,12 @@
+from odoo import api, fields, models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    modular_type_id = fields.Many2one(comodel_name='sale.mrp.modular', compute="_compute_modular_type_id", string='Modular Type')
+
+    @api.depends('production_id.bom_id.bom_line_ids')
+    def _compute_modular_type_id(self):
+        for line in self:
+            line.modular_type_id = line.raw_material_production_id.bom_id.bom_line_ids.filtered(lambda l: l.product_id == line.product_id).modular_type_id

--- a/sale_mrp_modular/security/ir.model.access.csv
+++ b/sale_mrp_modular/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+sale_mrp_modular.access_sale_mrp_modular,access_sale_mrp_modular,sale_mrp_modular.model_sale_mrp_modular,base.group_user,1,1,1,1
+sale_mrp_modular.access_sale_mrp_modular_wizard,access_sale_mrp_modular_wizard,sale_mrp_modular.model_sale_mrp_modular_wizard,base.group_user,1,1,1,1
+sale_mrp_modular.access_sale_mrp_modular_wizard_line,access_sale_mrp_modular_wizard_line,sale_mrp_modular.model_sale_mrp_modular_wizard_line,base.group_user,1,1,1,1

--- a/sale_mrp_modular/views/mrp_bom_view.xml
+++ b/sale_mrp_modular/views/mrp_bom_view.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="mrp_bom_inherit_view_form" model="ir.ui.view">
+        <field name="name">mrp.bom.inherit.view.form</field>
+        <field name="model">mrp.bom</field>
+        <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='bom_line_ids']/list/field[@name='product_qty']" position="before">
+                <field name="modular_type_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_mrp_modular/views/mrp_production_view.xml
+++ b/sale_mrp_modular/views/mrp_production_view.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="mrp_production_inherit_view_form" model="ir.ui.view">
+        <field name="name">mrp.production.inherit.view.form</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='components']/field/list/field[@name='location_id']" position="after">
+                <field name="modular_type_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_mrp_modular/views/product_template_view.xml
+++ b/sale_mrp_modular/views/product_template_view.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="product_template_modular_inherit_view_form" model="ir.ui.view">
+        <field name="name">product.template.inherit.view.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='general_information']/group/group[@name='group_general']" position="inside">
+                <field name="modular_type_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_mrp_modular/views/sale_mrp_modular_wizard_view.xml
+++ b/sale_mrp_modular/views/sale_mrp_modular_wizard_view.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="sale_mrp_modular_wizard_view_form" model="ir.ui.view">
+        <field name="name">sale.mrp.modular.wizard.view.form</field>
+        <field name="model">sale.mrp.modular.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Modular Type Values">
+                <sheet>
+                    <group>
+                        <field name="source_sale_order_line_id" readonly="1" force_save="True" />
+                    </group>
+
+                    <group>
+                        <field name="modular_wizard_line_ids">
+                            <list editable="bottom" create="0">
+                                <field name="modular_type_id" readonly="1" force_save="True" />
+                                <field name="value"/>
+                            </list>
+                        </field>
+                    </group>
+
+                    <footer>
+                        <button name="action_add_modular_values" type="object" string="Add" class="btn btn-primary"/>
+                        <button string="Cancel" class="btn btn-secondary" special="cancel" />
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="sale_mrp_modular_wizard_action" model="ir.actions.act_window">
+        <field name="name">Set Modular Type Values</field>
+        <field name="res_model">sale.mrp.modular.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="sale_mrp_modular_wizard_view_form" />
+    </record>
+
+</odoo>

--- a/sale_mrp_modular/views/sale_order_view.xml
+++ b/sale_mrp_modular/views/sale_order_view.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="sale_order_inherit_view_form" model="ir.ui.view">
+        <field name="name">sale.order.inherit.view.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_template_id']" position="after">
+                <button name="%(sale_mrp_modular_wizard_action)d"
+                    type="action"
+                    string=""
+                    context="{'active_id': id}"
+                    icon="fa-flask"
+                    invisible="state == 'sale'" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_mrp_modular/wizards/__init__.py
+++ b/sale_mrp_modular/wizards/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_mrp_modular_wizard
+from . import sale_mrp_modular_wizard_line

--- a/sale_mrp_modular/wizards/sale_mrp_modular_wizard.py
+++ b/sale_mrp_modular/wizards/sale_mrp_modular_wizard.py
@@ -1,0 +1,36 @@
+from odoo import api, fields, models
+
+
+class SaleMrpModularWizard(models.Model):
+    _name = 'sale.mrp.modular.wizard'
+    _description = 'Wizard for modular values'
+
+    modular_wizard_line_ids = fields.One2many(comodel_name='sale.mrp.modular.wizard.line', inverse_name='modular_wizard_id', string='Modular Wizard Lines')
+    source_sale_order_line_id = fields.Many2one(comodel_name='sale.order.line', string='Source Order Line')
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+
+        sale_order_line_id = self.env['sale.order.line'].browse(self.env.context['active_id'])
+        res['source_sale_order_line_id'] = sale_order_line_id
+
+        if len(sale_order_line_id.product_id.modular_type_ids):
+            if not sale_order_line_id.modular_value_ids:
+                modular_lines_data = [
+                    (
+                        0,0, {
+                            "modular_type_id": modular_type_id.id,
+                            "value": 1
+                        }
+                    ) for modular_type_id in sale_order_line_id.product_id.modular_type_ids
+                ]
+            else:
+                modular_lines_data = sale_order_line_id.modular_value_ids
+
+            res['modular_wizard_line_ids'] = modular_lines_data
+
+        return res
+
+    def action_add_modular_values(self):
+        self.source_sale_order_line_id.modular_value_ids = self.modular_wizard_line_ids

--- a/sale_mrp_modular/wizards/sale_mrp_modular_wizard_line.py
+++ b/sale_mrp_modular/wizards/sale_mrp_modular_wizard_line.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class SaleMrpModularWizardLine(models.Model):
+    _name = 'sale.mrp.modular.wizard.line'
+    _description = 'Wizard Line for modular values'
+
+    modular_type_id = fields.Many2one(comodel_name='sale.mrp.modular', string='Modular Type')
+    value = fields.Integer(string='Values')
+    source_sale_order_line_id = fields.Many2one('sale.order.line')
+
+    modular_wizard_id = fields.Many2one(comodel_name='sale.mrp.modular.wizard', string='Modular Wizard')


### PR DESCRIPTION
Introduced a modular type multiplier for BOM components in Manufacturing Orders.
- Added a Modular Type field in BOM components to categorize components.
- Implemented a mechanism to set modular type values in the Sales Order line.
- When an SO with MTO flow is confirmed, the generated MO adjusts component quantities based on the modular type multiplier set in the SO line.
- Ensured that all MO component lines with the same modular type are multiplied accordingly.

Task ID: 4619182