### PR TITLE
[ADD] update_discount_value: removed discount product line on removal…

### DIFF
--- a/update_discount_value/__init__.py
+++ b/update_discount_value/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/update_discount_value/__manifest__.py
+++ b/update_discount_value/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    "name": "Discount update",
+    "description": """
+    Update discount in sale order line
+    """,
+    "depends": ["sale_management"],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/update_discount_value/models/__init__.py
+++ b/update_discount_value/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/update_discount_value/models/sale_order_line.py
+++ b/update_discount_value/models/sale_order_line.py
@@ -1,0 +1,29 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    is_discount_line = fields.Boolean(default=False)
+
+    @api.model_create_multi
+    def create(self, vals):
+        line = super().create(vals)
+        discount_product = self.env.company.sale_discount_product_id
+        if discount_product and line.product_id == discount_product:
+            line.is_discount_line = True
+
+
+    def unlink(self):
+        orders = self.mapped("order_id")
+        res = super().unlink()
+
+        for order in orders:
+            product_lines = order.order_line.filtered(lambda l: not l.is_discount_line)
+
+            if not product_lines:
+                discount_line = order.order_line.filtered(lambda l: l.is_discount_line)
+                if discount_line:
+                    discount_line.unlink()
+
+        return res


### PR DESCRIPTION
… of product

This commit adds logic to automatically remove the discount product line from a sale order when all regular product lines are removed. The discount line is identified using a newly added is_discount_line field on sale.order.line.

When a discount is applied through the discount wizard, the discount product line is created with is_discount_line set to True. During line removal, if no regular product lines remain in the sale order, any discount product line is also automatically removed.

This ensures correct discount behavior, prevents orphaned discount lines, and improves order data consistency.

task-4626806