### PR TITLE
[IMP] redesign_catalog_view: redesign product catalog view

### DIFF
--- a/redesign_catalog_view/__manifest__.py
+++ b/redesign_catalog_view/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Redesign Catalog View',
+    'version': '1.0',
+    'depends': ['product'],
+    'data': [
+        'views/product_kanban_views.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'redesign_catalog_view/static/src/scss/product_kanban.scss',
+            'redesign_catalog_view/static/src/js/image_preview_widget.js',
+            'redesign_catalog_view/static/src/js/image_preview_widget.xml',
+        ],
+    },
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/redesign_catalog_view/static/src/js/image_preview_widget.js
+++ b/redesign_catalog_view/static/src/js/image_preview_widget.js
@@ -1,0 +1,29 @@
+import { ImageField } from "@web/views/fields/image/image_field";
+import { registry } from "@web/core/registry";
+import { useFileViewer } from "@web/core/file_viewer/file_viewer_hook";
+
+export class ImagePreviewField extends ImageField {
+    static template = "product_kanban_catalog_inherit.ShowImage";
+    setup() {
+        super.setup();
+        this.fileViewer = useFileViewer();
+    }
+
+    openImageFullScreen(event) {
+        event.stopPropagation();
+        event.preventDefault();
+        if (this.env.isSmall) {
+            const imageUrl = this.getUrl(this.props.name);  // Get the image URL
+            if (imageUrl) {
+                this.fileViewer.open({
+                    isImage: true,
+                    isViewable: true,
+                    defaultSource: imageUrl,
+                    downloadUrl: imageUrl,
+                });
+            }
+        }
+    }
+}
+
+registry.category("fields").add("image_custom", { component: ImagePreviewField, });

--- a/redesign_catalog_view/static/src/js/image_preview_widget.xml
+++ b/redesign_catalog_view/static/src/js/image_preview_widget.xml
@@ -1,0 +1,9 @@
+<templates>
+    <t t-name="product_kanban_catalog_inherit.ShowImage"
+        t-inherit="web.ImageField"
+        t-inherit-mode="primary">
+        <xpath expr="//img[@loading='lazy']" position="attributes">
+            <attribute name="t-on-click">openImageFullScreen</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/redesign_catalog_view/static/src/scss/product_kanban.scss
+++ b/redesign_catalog_view/static/src/scss/product_kanban.scss
@@ -1,0 +1,12 @@
+@media (max-width: 768px) {
+    .o_product_image_custom {
+        div {
+            img {
+                max-width: 150px !important;
+                max-height: 150px !important;
+                width: 150px !important;
+                height: 150px !important;
+            }
+        }
+    }
+}

--- a/redesign_catalog_view/views/product_kanban_views.xml
+++ b/redesign_catalog_view/views/product_kanban_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_kanban_custom" model="ir.ui.view">
+        <field name="name">product.custom.catalog</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='image_128']" position="attributes">
+                <attribute name="class">ms-auto o_product_image_custom</attribute>
+                <attribute name="widget">image_custom</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit aims to implement @media to make catalog view's product image large into mobile view also when user click on image then open a image popup with zoom-in, zoom-out, rotate, close button functionality.

Task - 4625699