### PR TITLE
[ADD] limit_tickets: added limit for maximum tickets per registration

### DIFF
--- a/limit_tickets/__init__.py
+++ b/limit_tickets/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/limit_tickets/__manifest__.py
+++ b/limit_tickets/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Limit Tickets",
+    "description": "Limit Number of tickets per registration",
+    "depends": ["event", "website_event"],
+    "data": [
+        "views/event_ticket_views.xml",
+        "views/event_templates_page_registration.xml",
+    ],
+    "license": "LGPL-3",
+    "installable": True,
+    "application": False,
+}

--- a/limit_tickets/models/__init__.py
+++ b/limit_tickets/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_event_ticket

--- a/limit_tickets/models/event_event_ticket.py
+++ b/limit_tickets/models/event_event_ticket.py
@@ -1,0 +1,19 @@
+from odoo import fields, models
+
+
+class EventEventTicket(models.Model):
+    _inherit = "event.event.ticket"
+
+    max_tickets_register = fields.Integer(
+        string="Max tickets per registration",
+        default=9,
+        help="Limits the maximum number of tickets per registration",
+    )
+
+    _sql_constraints = [
+        (
+            "check_max_tickets_register",
+            "CHECK(max_tickets_register > 0 AND max_tickets_register < 10)",
+            "The maximum tickets per registration must be between 1-9.",
+        )
+    ]

--- a/limit_tickets/views/event_templates_page_registration.xml
+++ b/limit_tickets/views/event_templates_page_registration.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template inherit_id="website_event.modal_ticket_registration" id="ticket_registration_limit">
+        <xpath expr="//t[@t-set='seats_max']" position="after">
+            <t t-set="seats_max" t-value="min(seats_max, ticket.max_tickets_register + 1)" />
+        </xpath>
+        <xpath expr="//div[hasclass('o_wevent_registration_single')]//t[@t-set='seats_max']" position="after">
+            <t t-set="seats_max" t-value="min(seats_max, tickets.max_tickets_register + 1)" />
+        </xpath>
+    </template>
+</odoo>

--- a/limit_tickets/views/event_ticket_views.xml
+++ b/limit_tickets/views/event_ticket_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="event_event_ticket_view_tree_from_event" model="ir.ui.view">
+        <field name="name">event.event.ticket.view.list.inherit.from.event</field>
+        <field name="model">event.event.ticket</field>
+        <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='seats_taken']" position="after">
+                <field name="max_tickets_register" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Restrict the number of tickets a user can register in a single transaction. The system should dynamically adjust the available ticket options, based on the remaining tickets to prevent overbooking.

taskID: 4626613