### PR TITLE
[ADD] distribution_cost: implement distribution_cost module

### DIFF
--- a/distribute_cost/__init__.py
+++ b/distribute_cost/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import wizard

--- a/distribute_cost/__manifest__.py
+++ b/distribute_cost/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name' : 'Distribute Cost',
+    'version' : '1.0',
+    'description' : """
+This module provides a real estate accounting services
+""",
+    'depends' : ['sale_management'],
+    'data' : [
+        'security/ir.model.access.csv',
+        'views/sale_order_line_views.xml',
+        'wizard/sale_order_line_wizard.xml',
+    ],
+    'installable' : True,
+    'application' : True,
+    'license' : 'LGPL-3',
+}

--- a/distribute_cost/models/__init__.py
+++ b/distribute_cost/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order_line

--- a/distribute_cost/models/sale_order_line.py
+++ b/distribute_cost/models/sale_order_line.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+    _description = "Sales Order Lines"
+
+    distributed_price = fields.Float(string="Distributed Price")
+    distributed_price_tags = fields.Many2many(
+        "sale.order.distribution.tag",
+        string="Division",
+        compute="_compute_distributed_price_tags",
+        store=True,
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super(SaleOrderLine, self).create(vals_list)
+        for record in records:
+            record._compute_distributed_price_tags()
+        return records
+
+    @api.depends("distributed_price")
+    def _compute_distributed_price_tags(self):
+        for line in self:
+            tags = []
+            rounded_price = round(line.distributed_price, 2)
+            latest_distribution = self.env["sale.order.line.distribution"].search(
+                [("target_sale_order_line_id", "=", line.id)],
+                order="id desc",
+                limit=1,
+            )
+
+            new_tag = self.env["sale.order.distribution.tag"].create(
+                {
+                    "name": str(rounded_price),
+                    "color": 2
+                    if line.distributed_price == 0
+                    else latest_distribution.source_sale_order_line_id % 10,
+                }
+            )
+            tags.append(new_tag.id)
+
+            line.distributed_price_tags = [(6, 0, tags)]
+    
+    def unlink(self):
+        for record in self:
+            self_distributions = record.env["sale.order.line.distribution"].search(
+                [("source_sale_order_line_id", "=", record.id)]
+            )
+
+            distributions = self.env['sale.order.line.distribution'].search([
+                ('target_sale_order_line_id', '=', record.id)
+            ])
+
+            for dist in self_distributions:
+                if dist.price > 0:
+                    destination_line = record.env["sale.order.line"].browse(dist.target_sale_order_line_id)
+                    if destination_line:
+                        destination_line.distributed_price -= dist.price
+                        destination_line.price_subtotal -= dist.price
+                    dist.unlink()
+
+            for dist in distributions:
+                source_sale_order_line = self.env['sale.order.line'].browse(dist.source_sale_order_line_id)
+                if source_sale_order_line.exists():
+                    source_sale_order_line.write({
+                        # 'distributed_price': source_sale_order_line.distributed_price + dist.price,
+                        'price_subtotal': source_sale_order_line.price_subtotal + dist.price
+                    })
+                dist.unlink()
+        return super().unlink()
+
+    def open_wizard(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Distributed Price',
+            'res_model': 'sale.order.line.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {
+                'default_order_id' : self.id,
+            }
+        }
+
+class SaleOrderLineDistribution(models.Model):
+    _name = "sale.order.line.distribution"
+    _description = "Tracks Distributed Prices Between Sale Order Lines"
+
+    source_sale_order_line_id = fields.Integer(string="Source Sale Order Line")
+    target_sale_order_line_id = fields.Integer(string="Target Sale Order Line")
+    price = fields.Float(string="Distributed Price", required=True)
+
+class SaleOrderDistributionTag(models.Model):
+    _name = "sale.order.distribution.tag"
+    _description = "Sale Order Distribution Tags"
+
+    name = fields.Char(string="Name", required=True)
+    color = fields.Integer(string="Color", default=3)

--- a/distribute_cost/security/ir.model.access.csv
+++ b/distribute_cost/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_order_line_wizard_user,access.sale.order.line.wizard,model_sale_order_line_wizard,base.group_user,1,1,1,1
+access_sale_order_line_wizard_line_user,access.sale.order.line.wizard.line,model_sale_order_line_wizard_line,base.group_user,1,1,1,1
+access_sale_order_line_distribution_user,access.sale.order.line.distribution,model_sale_order_line_distribution,base.group_user,1,1,1,1
+access_sale_order_distribution_tag_user,access.sale.order.distribution.tag,model_sale_order_distribution_tag,base.group_user,1,1,1,1

--- a/distribute_cost/views/sale_order_line_views.xml
+++ b/distribute_cost/views/sale_order_line_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="sale_order_view_list" model="ir.ui.view">
+        <field name="name">sale.order.view.list.inherit.order_lines</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']/list/field[@name='product_uom_qty']"
+                position="before">
+                <button name="open_wizard" type="object" icon="fa-share-alt" title="Button"/>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/list/field[@name='price_subtotal']"
+                position="before">
+                <field name="distributed_price_tags" widget="many2many_tags"
+                    options="{'color_field': 'color'}" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/distribute_cost/wizard/__init__.py
+++ b/distribute_cost/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line_wizard

--- a/distribute_cost/wizard/sale_order_line_wizard.py
+++ b/distribute_cost/wizard/sale_order_line_wizard.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError, ValidationError
+
+
+class SaleOrderLineWizard(models.TransientModel):
+    _name = "sale.order.line.wizard"
+    _description = "Distribute Price Wizard"
+
+    line_ids = fields.One2many("sale.order.line.wizard.line", "wizard_id", string="Sale Order Lines")
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        active_line_id = self._context.get("active_id")
+        active_line = self.env["sale.order.line"].browse(active_line_id)
+        order = active_line.order_id
+        lines_to_divide = order.order_line.filtered(
+            lambda line: line.id != active_line.id
+        )
+        lines = []
+        for line in lines_to_divide:
+            line = self.env["sale.order.line.wizard.line"].create(
+                {
+                    "wizard_id": self.id,
+                    "product_id": line.product_id.id,
+                    "sale_order_line_id": line.id,
+                    "divided_price": active_line.price_subtotal / len(lines_to_divide) if lines_to_divide else 0,
+                }
+            )
+            lines.append(line.id)
+            res["line_ids"] = [(6, 0, lines)]
+        return res
+
+    def action_divide(self):
+        active_line_id = self._context.get("active_id")
+        source_sale_order_line_id = self.env["sale.order.line"].browse(active_line_id)
+        current_total_price = source_sale_order_line_id.price_subtotal
+        sum_price = 0
+        for line in self.line_ids:
+            sum_price += line.divided_price
+        if sum_price > current_total_price:
+            raise UserError(_('Sum of divided prices cannot be more than the total price of the source sale order line.'))
+        else:
+            if sum_price < (source_sale_order_line_id.price_subtotal - source_sale_order_line_id.distributed_price):
+                source_sale_order_line_id.price_subtotal -= sum_price
+            else:
+                source_sale_order_line_id.price_subtotal -= sum_price
+                source_sale_order_line_id.distributed_price = source_sale_order_line_id.price_subtotal
+        for line in self.line_ids:
+            if line.divided_price < 0:
+                raise UserError(_('Divided price cannot be negative.'))
+
+            target_sale_order_line = line.sale_order_line_id
+
+            self.env['sale.order.line.distribution'].create({
+                'source_sale_order_line_id': source_sale_order_line_id.id,
+                'target_sale_order_line_id': target_sale_order_line.id,
+                'price': line.divided_price,
+            })
+
+            target_sale_order_line.write({
+                'distributed_price': target_sale_order_line.distributed_price + line.divided_price,
+                'price_subtotal': target_sale_order_line.price_subtotal + line.divided_price
+            })  
+
+class SaleOrderLineWizardLine(models.TransientModel):
+    _transient_max_count = 0
+    _name = "sale.order.line.wizard.line"
+    _description = "Distribute Price Wizard Lines"
+
+    wizard_id = fields.Many2one("sale.order.line.wizard", string="Wizard")
+    sale_order_line_id = fields.Many2one("sale.order.line", string="Sale Order Line")
+    product_id = fields.Many2one("product.product", string="Product")
+    divided_price = fields.Float(string="Divided Price")
+    include_for_division = fields.Boolean(string="Include for Division", default=True)
+
+    @api.onchange('include_for_division')
+    def _onchange_divided_price(self):
+        active_line_id = self._context.get("active_id")
+        active_line = self.env["sale.order.line"].browse(active_line_id)
+        current_total_price = active_line.price_subtotal
+
+        selected_lines = self.wizard_id.line_ids.filtered(lambda line: line.include_for_division)
+
+        for line in self.wizard_id.line_ids:
+            if line.include_for_division:
+                line.divided_price = current_total_price / len(selected_lines)
+            else:
+                line.divided_price = 0

--- a/distribute_cost/wizard/sale_order_line_wizard.xml
+++ b/distribute_cost/wizard/sale_order_line_wizard.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_line_wizard_form" model="ir.ui.view">
+        <field name="name">sale.order.line.wizard.form</field>
+        <field name="model">sale.order.line.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Distribute Price">
+                <sheet>
+                    <group>
+                        <field name="line_ids" nolabel="1">
+                            <list editable="bottom" create="false" delete="false">
+                                <field name='wizard_id' column_invisible="1"/>
+                                <field name="product_id" readonly="1" force_save="1"/>
+                                <field name="sale_order_line_id" column_invisible="1"/>
+                                <field name="include_for_division" />
+                                <field name="divided_price" force_save="1"/>
+                            </list>
+                        </field>
+                    </group>    
+                    <footer>
+                        <button name="action_divide" type="object" string="Divide" class="btn-primary" />
+                        <button string="Cancel" class="btn-secondary" special="cancel" />
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="sale_order_line_wizard_action" model="ir.actions.act_window">
+        <field name="name">Distribute Price</field>
+        <field name="res_model">sale.order.line.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="sale_order_line_wizard_form" />
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this commit:
- Added a new `sale.order.line.wizard` to allow splitting the price among multiple order lines.
- Updated `sale.order.line` model:
  - Introduced a `distributed_price` field to track assigned amounts.
  - Added `distributed_price_tags` (Many2many) to show the breakdown with color-coded labels.
  - Included an `include_for_division` checkbox to let users choose which lines should be considered for cost distribution.
- Implemented smart price allocation:
  - Automatically spreads the cost evenly across selected lines, while allowing manual edits.
  - Ensures any leftover amount (if the total doesn’t match the original) remains on the initial line.
  - Rebalances allocations when lines are added or removed.
- Improved rounding logic to avoid fractional inconsistencies (e.g., `10/3 → 3.33`).
- Kept the `Distribute` button always available so users can make multiple adjustments.