### PR TITLE
[ADD] zero_stock_blockage: Implement Zero Stock validation

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Sale Order Zero Stock Approval',
+    'version': '1.0',
+    'category': 'Sales',
+    'summary': 'Adds a Zero Stock Approval boolean field to Sale Orders.',
+    'description': 'Adds a new boolean field Zero Stock Approval in Sale Orders with access restrictions.',
+    'author': 'Shiv Bhadaniya',
+    'depends': ['sale_management'],
+    'data': [
+        'views/sale_order_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,41 @@
+from odoo import fields, models
+from odoo.exceptions import ValidationError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    zero_stock_approval = fields.Boolean(string="Approval", help="Administrator approval is required for zero stock products.")
+
+
+
+    def fields_get(self, allfields=None, attributes=None):
+        """
+        Dynamically modify field attributes based on user groups.
+        """
+
+        # Get the all fields of model
+        fields_metadata = super().fields_get(allfields, attributes)
+
+        if "zero_stock_approval" in fields_metadata:
+
+            # If the user is a Administrator, then the field is editable otherwise, for any other user it is read-only.
+            if self.env.user.has_group("sales_team.group_sale_manager"):
+                fields_metadata["zero_stock_approval"]["readonly"] = False
+            else:
+                fields_metadata["zero_stock_approval"]["readonly"] = True
+
+        return fields_metadata
+
+
+    def action_confirm(self):
+        """
+        Override the Sale Order confirmation action to enforce Zero Stock Approval validation.
+        """
+
+        for line in self.order_line:
+            # Less than or equal to zero product quantity for approval is required
+            if line.product_uom_qty <= 0 and self.zero_stock_approval == False:
+                raise ValidationError("You cannot confirm this Sale Order without Zero Stock Approval.")
+
+        return super().action_confirm()

--- a/zero_stock_blockage/views/sale_order_views.xml
+++ b/zero_stock_blockage/views/sale_order_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_sale_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.zero.stock.approval</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval" string="Approval" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Added validation to restrict order confirmation if any product has zero stock. 
Introduced a Zero Stock Approval field in sale.order. 
Only administrators can approve others, the field is read-only.