### PR TITLE
[ADD] zero_stock_blockage: approving sale orders with zero stock product

### DIFF
--- a/odoo_self_order_details/__manifest__.py
+++ b/odoo_self_order_details/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Self Order Product Details",
+    "version": "1.0",
+    "description": "Open custom dialog on product click",
+    "depends": ["pos_self_order", "pos_restaurant"],
+    "assets": {
+        "pos_self_order.assets": 
+            ["odoo_self_order_details/static/src/**/*"],
+    },
+    'license': 'LGPL-3'
+}

--- a/odoo_self_order_details/static/src/product_card.js
+++ b/odoo_self_order_details/static/src/product_card.js
@@ -1,0 +1,37 @@
+import { patch } from "@web/core/utils/patch";
+import { ProductCard } from "@pos_self_order/app/components/product_card/product_card";
+import { CustomProductInfoPopup } from "./product_info_popup";
+
+patch(ProductCard.prototype, {
+    async selectProduct(qty = 1) {
+        const product = this.props.product;
+
+        if (!product.self_order_available || !this.isAvailable) {
+            return;
+        }
+
+        if (product.isCombo()) {
+            this.router.navigate("combo_selection", { id: product.id });
+        } else if (product.needToConfigure()) {
+            this.router.navigate("product", { id: product.id });
+        } else {
+            this.dialog.add(CustomProductInfoPopup, {
+                product: product,
+                addToCart: (qty) => {
+                    this.flyToCart();
+                    this.scaleUpPrice();
+
+                    const isProductInCart = this.selfOrder.currentOrder.lines.find(
+                        (line) => line.product_id === product.id
+                    );
+
+                    if (isProductInCart) {
+                        isProductInCart.qty += qty;
+                    } else {
+                        this.selfOrder.addToCart(product, qty);
+                    }
+                }
+            });
+        }
+    }
+});

--- a/odoo_self_order_details/static/src/product_info_popup.js
+++ b/odoo_self_order_details/static/src/product_info_popup.js
@@ -1,0 +1,11 @@
+import { Component } from "@odoo/owl";
+
+export class CustomProductInfoPopup extends Component {
+    static template = "odoo_self_order_details.ProductInfoPopup";
+    static props = ["addToCart"];
+
+    orderProduct() {
+        this.props.addToCart(1);
+        this.props.close();
+    }
+}

--- a/odoo_self_order_details/static/src/product_info_popup.xml
+++ b/odoo_self_order_details/static/src/product_info_popup.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="odoo_self_order_details.ProductInfoPopup">
+        <div class="modal d-block">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button class="btn-close" t-on-click="props.close"/>
+                    </div>
+                    <div class="modal-body text-center">
+                        <img t-if="props.product.id"
+                            t-attf-src="/web/image/product.product/{{props.product.id}}/image_1024?unique={{props.product.write_date}}"
+                            alt="Product Image"
+                            class="img-fluid rounded w-75 mb-3"
+                            onerror="this.style.display='none'"/>
+                        <h5 class="modal-title fw-bold" t-esc="props.product.display_name"/>
+                        <h5 t-out="props.product.public_description"/>
+                    </div>
+                    <div class="modal-footer d-flex justify-content-between">
+                        <button class="btn btn-success flex-fill me-2" t-on-click="orderProduct">Order</button>
+                        <button class="btn btn-danger flex-fill ms-2" t-on-click="props.close">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'Zero Stock Approval',
+    'version': '1.0',
+    'category': 'Sales',
+    'summary': 'Adds a Zero Stock Approval field in Sale Order',
+    'description': 'This module adds a boolean field "Zero Stock Approval" to Sale Order, read-only for sales users but editable for administrators.',
+    'depends': ['sale_management','stock'],
+    'data': ['views/sale_order_view.xml'
+    ],
+    'license': 'LGPL-3'
+    }

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,23 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    zero_stock_approval = fields.Boolean(string="Zero Stock Approval")
+    approval = fields.Boolean(compute="_compute_approval")
+
+    def _action_confirm(self):
+        for order in self:
+            if not order.zero_stock_approval:
+                for line in order.order_line:
+                    if line.product_uom_qty > line.product_id.qty_available:
+                        raise UserError(
+                            "Ordered quantity exceeds available stock Approval From Administration Required Before Confirming Order"
+                        )
+        return super(SaleOrder, self)._action_confirm()
+
+    @api.depends_context("uid")
+    def _compute_approval(self):
+        self.approval = self.env.user.has_group("sales_team.group_sale_manager")

--- a/zero_stock_blockage/views/sale_order_view.xml
+++ b/zero_stock_blockage/views/sale_order_view.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval" readonly="not approval" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added a new field zero_stock_approval in Sale Order.
- Implemented approval for orders containing zero stock products.
- Sales users have readonly access, while administrators can edit the field.