### PR TITLE
[ADD] salesperson_in_pos:  add salesperson selection to POS order

### DIFF
--- a/salesperson_pos/__init__.py
+++ b/salesperson_pos/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/salesperson_pos/__manifest__.py
+++ b/salesperson_pos/__manifest__.py
@@ -1,0 +1,24 @@
+{
+    'name': "Salesperson in Pos",
+    'summary': "Add Salesperson to POS orders",
+    'description': """
+        This module will add a button in the POS dashboard to assign a salesperson to respective orders.
+    """,
+    'author': "Devmitra Sharma",
+    'depends': ['point_of_sale','hr'],
+    'data': [
+        "views/pos_form_view.xml",
+        "views/hr_employee_form.xml",
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'salesperson_pos/static/src/**/*'
+        ],
+        'web.assets_backend': [
+            'salesperson_pos/static/src/**/*.scss',
+        ],
+    },
+    'application': False,
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/salesperson_pos/models/__init__.py
+++ b/salesperson_pos/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_order
+from . import pos_session
+from . import hr_employee

--- a/salesperson_pos/models/hr_employee.py
+++ b/salesperson_pos/models/hr_employee.py
@@ -1,0 +1,4 @@
+from odoo import models, fields, api
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"

--- a/salesperson_pos/models/pos_order.py
+++ b/salesperson_pos/models/pos_order.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields, api
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    salesperson_id = fields.Many2one('hr.employee', string='Salesperson' ,help='Salesperson who created the order')

--- a/salesperson_pos/models/pos_session.py
+++ b/salesperson_pos/models/pos_session.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        data = super()._load_pos_data_models(config_id)
+        data.append("hr.employee")
+        return data

--- a/salesperson_pos/static/src/action_pad/action_pad.js
+++ b/salesperson_pos/static/src/action_pad/action_pad.js
@@ -1,0 +1,11 @@
+import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
+import { SelectSalespersonButton } from "../control_buttons/select_salesperson_button/select_salesperson_button";
+import { patch } from "@web/core/utils/patch";
+
+
+patch(ActionpadWidget,{
+    components: {
+        ...ActionpadWidget.components,
+        SelectSalespersonButton,
+    },
+})

--- a/salesperson_pos/static/src/action_pad/action_pad.xml
+++ b/salesperson_pos/static/src/action_pad/action_pad.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="salesperson_pos.CustomActionpadWidget" t-inherit="point_of_sale.ActionpadWidget" t-inherit-mode="extension">
+        <xpath expr="//SelectPartnerButton" position="after">
+            <SelectSalespersonButton />
+        </xpath>
+    </t>
+</templates>

--- a/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonLine/SalespersonLine.js
+++ b/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonLine/SalespersonLine.js
@@ -1,0 +1,21 @@
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+
+export class SalespersonLine extends Component {
+    static template = "salesperson_pos.SalespersonLine";
+    static components = { Dropdown, DropdownItem };
+    static props = [
+        "close",
+        "salesperson",
+        "isSelected",
+        "onClickEdit",
+        "onClickUnselect",
+        "onClickSalesperson",
+    ];
+
+    setup() {
+        this.ui = useService("ui");
+    }
+}

--- a/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonLine/SalespersonLine.scss
+++ b/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonLine/SalespersonLine.scss
@@ -1,0 +1,15 @@
+.salesperson-line {
+    &.selected {
+        background-color: $o-component-active-bg;
+        border: $border-width solid $o-component-active-border;
+    }
+
+    &.selected .btn.btn-link:hover .fa-check {
+        display: none;
+    }
+
+    &.selected .btn.btn-link:hover::after {
+        content: "\e852";
+        font-family: 'odoo_ui_icons';
+    }
+}

--- a/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonLine/SalespersonLine.xml
+++ b/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonLine/SalespersonLine.xml
@@ -1,0 +1,63 @@
+<templates id="template" xml:space="preserve">
+
+    <t t-name="salesperson_pos.SalespersonLine">
+        <t t-if="ui.isSmall">
+            <div class="salesperson-info d-flex flex-column p-1 border-bottom"
+                 t-att-class="{'bg-primary-subtle': props.isSelected}"
+                 t-att-data-id="props.salesperson.id"
+                 t-on-click="() => this.props.onClickSalesperson(props.salesperson)">
+                <div class="d-flex justify-content-between align-items-center p-1">
+                    <div>
+                        <b t-esc="props.salesperson.name or ''" />
+                        <div class="job-title text-muted" t-esc="props.salesperson._role or '-'" />
+                    </div>
+                    <Dropdown>
+                        <button class="btn btn-light fa fa-bars" />
+                        <t t-set-slot="content">
+                            <DropdownItem onSelected="() => props.onClickEdit(props.salesperson)">
+                                Edit Details
+                            </DropdownItem>
+                        </t>
+                    </Dropdown>
+                </div>
+                <div class="salesperson-contact p-1">
+                    <div t-if="props.salesperson.work_contact_id.email">
+                        <i class="fa fa-fw fa-envelope me-2" />
+                        <t t-esc="props.salesperson.work_contact_id.email" />
+                    </div>
+                </div>
+            </div>
+        </t>
+        <t t-else="">
+            <tr class="salesperson-line salesperson-info"
+                t-att-class="{'selected': props.isSelected}"
+                t-att-data-id="props.salesperson.id"
+                t-on-click="() => props.onClickSalesperson(props.salesperson)">
+                <td>
+                    <b t-esc="props.salesperson.name or ''" />
+                </td>
+                <td>
+                    <div class="job-title text-muted" t-esc="props.salesperson._role or '-'" />
+                </td>
+                <td class="salesperson-email">
+                    <div t-if="props.salesperson.work_contact_id.email">
+                        <i class="fa fa-fw fa-envelope me-2" />
+                        <t t-esc="props.salesperson.work_contact_id.email" />
+                    </div>
+                </td>
+                <td class="edit-salesperson-button-cell align-middle">
+                    <Dropdown>
+                        <button class="btn btn-light btn-lg lh-lg border float-end">
+                            <i class="fa fa-fw fa-bars"/>
+                        </button>
+                        <t t-set-slot="content">
+                            <DropdownItem onSelected="() => props.onClickEdit(props.salesperson)">
+                                Edit Details
+                            </DropdownItem>
+                        </t>
+                    </Dropdown>
+                </td>
+            </tr>
+        </t>
+    </t>
+</templates>

--- a/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonList.js
+++ b/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonList.js
@@ -1,0 +1,80 @@
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { fuzzyLookup } from "@web/core/utils/search";
+import { Dialog } from "@web/core/dialog/dialog";
+import { SalespersonLine } from "./SalespersonLine/SalespersonLine";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
+import { Component, useState } from "@odoo/owl";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { unaccent } from "@web/core/utils/strings";
+import { makeActionAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+
+export class SalespersonList extends Component {
+    static components = { SalespersonLine, Dialog, Input };
+    static template = "salesperson_pos.SalespersonList";
+    static props = {
+        salesperson: { type: [{ value: null }, Object], optional: true },
+        getPayload: { type: Function },
+        close: { type: Function },
+    };
+
+    setup() {
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+        this.notification = useService("notification");
+        this.dialog = useService("dialog");
+        this.action = useService("action");
+
+        this.state = useState({
+            query: "",
+            previousQuery: "",
+            currentOffset: 0,
+            salespeople: [],
+        });
+
+        useHotkey("enter", () => this.onEnter());
+
+        this.loadSalespeople();
+    }
+
+    async loadSalespeople() {
+        this.state.salespeople = await this.getNewSalespeople();
+    }
+
+    async editSalesperson(salesperson = false) {
+        try {
+            const actionProps = salesperson && salesperson.id ? { resId: salesperson.id } : {};
+            await makeActionAwaitable(this.action, "salesperson_pos.action_open_simplified_employee_form", { props: actionProps });
+            this.loadSalespeople();
+            this.props.close();
+        } catch (error) {
+            console.error("Error opening salesperson form:", error);
+        }
+    }
+
+    getFilteredSalespeople() {
+        const searchWord = unaccent((this.state.query || "").trim(), false);
+        if (!searchWord) return this.state.salespeople;
+
+        return fuzzyLookup(searchWord, this.state.salespeople, (sp) => unaccent(sp.name || "", false));
+    }
+
+    clickSalesperson(salesperson) {
+        this.props.getPayload(salesperson);
+        this.props.close();
+    }
+
+    async getNewSalespeople() {
+        const employees = this.pos.models["hr.employee"]?.getAll() || [];
+
+        if (this.state.query) {
+            const searchWord = unaccent(this.state.query.trim().toLowerCase(), false);
+            return employees.filter((employee) =>
+                employee.name?.toLowerCase().includes(searchWord)
+            );
+        }
+
+        return employees;
+    }
+}

--- a/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonList.scss
+++ b/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonList.scss
@@ -1,0 +1,27 @@
+.salesperson-list table {
+    border-collapse: separate;
+    border-spacing: 0 8px;
+    margin-top: -8px;
+
+    td {
+        border: $border-width solid $border-color;
+        border-style: solid none;
+        padding: map-get($spacers, 3);
+    }
+
+    tr.selected td {
+        border-color: $o-component-active-border;
+    }
+
+    td:first-child {
+        border-left-style: solid;
+        border-top-left-radius: $border-radius-lg;
+        border-bottom-left-radius: $border-radius-lg;
+    }
+
+    td:last-child {
+        border-right-style: solid;
+        border-bottom-right-radius: $border-radius-lg;
+        border-top-right-radius: $border-radius-lg;
+    }
+}

--- a/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonList.xml
+++ b/salesperson_pos/static/src/app/screen/SalespersonList/SalespersonList.xml
@@ -1,0 +1,54 @@
+<templates id="template" xml:space="preserve">
+
+    <t t-name="salesperson_pos.SalespersonList">
+        <Dialog bodyClass="'salesperson-list overflow-y-auto'" contentClass="'h-100'">
+            <t t-set-slot="header">
+                <button t-if="!ui.isSmall" class="btn btn-primary btn-lg lh-lg" role="img" aria-label="Add a salesperson"
+                        t-on-click="() => this.editSalesperson()"
+                        title="Add a salesperson">
+                Create
+                </button>
+                <Input tModel="[state, 'query']"
+                    class="'ms-auto'"
+                    isSmall="ui.isSmall"
+                    placeholder.translate="Search Salespersons..."
+                    icon="{type: 'fa', value: 'fa-search'}"
+                    autofocus="true"
+                    debounceMillis="100" />
+            </t>
+            <table class="table table-hover">
+                <thead t-if="!ui.isSmall">
+                    <tr>
+                        <th class="py-2">Name</th>
+                        <th class="py-2">Job Title</th>
+                        <th class="py-2">Email</th>
+                        <th class="py-2"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="getFilteredSalespeople()" t-as="salesperson" t-key="salesperson.id">
+                        <SalespersonLine
+                                close="props.close"
+                                salesperson="salesperson"
+                                isSelected="props.salesperson?.id === salesperson.id"
+                                onClickEdit.bind="(s) => this.editSalesperson(s)"
+                                onClickUnselect.bind="() => this.clickSalesperson()"
+                                onClickSalesperson.bind="clickSalesperson"/>
+                    </t>
+                </tbody>
+            </table>
+            <t t-set-slot="footer">
+                <div class="d-flex justify-content-start flex-wrap gap-2 w-100">
+                    <button t-if="ui.isSmall" class="btn btn-primary btn-lg lh-lg" role="img" aria-label="Add a salesperson"
+                        t-on-click="() => this.editSalesperson()"
+                        title="Add a salesperson">
+                    New
+                    </button>
+                    <button class="btn btn-secondary btn-lg lh-lg o-default-button" t-on-click="props.close">
+                        Discard
+                    </button>
+                </div>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/salesperson_pos/static/src/control_buttons/control_buttons.js
+++ b/salesperson_pos/static/src/control_buttons/control_buttons.js
@@ -1,0 +1,10 @@
+import { SelectSalespersonButton } from "./select_salesperson_button/select_salesperson_button";
+import { patch } from "@web/core/utils/patch";
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+
+patch(ControlButtons, {
+    components: {
+        ...ControlButtons.components,
+        SelectSalespersonButton,
+    },
+});

--- a/salesperson_pos/static/src/control_buttons/control_buttons.xml
+++ b/salesperson_pos/static/src/control_buttons/control_buttons.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="salesperson_pos.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//OrderlineNoteButton" position="before">
+            <SelectSalespersonButton />
+        </xpath>
+    </t>
+</templates>

--- a/salesperson_pos/static/src/control_buttons/select_salesperson_button/select_salesperson_button.js
+++ b/salesperson_pos/static/src/control_buttons/select_salesperson_button/select_salesperson_button.js
@@ -1,0 +1,42 @@
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useService } from "@web/core/utils/hooks";
+import { SalespersonList } from "../../app/screen/SalespersonList/SalespersonList";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+
+export class SelectSalespersonButton extends Component {
+    static template = "salesperson_pos.SelectSalespersonButton";
+
+    setup() {
+        this.pos = usePos();
+        this.dialog = useService("dialog");
+        this.salesperson = useState({ type: Object, defaultValue: null });
+    }
+
+    async selectSalesperson() {
+        const currentOrder = this.pos.get_order();
+        if (!currentOrder) {
+            console.warn("No active order found.");
+            return;
+        }
+        const currentSalesperson = currentOrder.get_salesperson();
+        const payload = await makeAwaitable(this.dialog, SalespersonList, {
+            salesperson: currentSalesperson,
+            getPayload: (newSalesperson) => {
+                currentOrder.setSalesPerson(newSalesperson);
+            },
+        });
+
+        if (payload) {
+            if (payload.id === this.salesperson.id) {
+                this.salesperson.id = null;
+                this.salesperson.name = "Salesperson";
+                currentOrder.setSalesPerson(null);
+            } else {
+                this.salesperson.id = payload.id;
+                this.salesperson.name = payload.name;
+                currentOrder.setSalesPerson(payload);
+            }
+        }
+    }
+}

--- a/salesperson_pos/static/src/control_buttons/select_salesperson_button/select_salesperson_button.xml
+++ b/salesperson_pos/static/src/control_buttons/select_salesperson_button/select_salesperson_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="salesperson_pos.SelectSalespersonButton">
+        <button class="set-salesperson btn btn-light btn-lg lh-lg text-truncate w-auto" t-on-click="selectSalesperson">
+            <div t-if="salesperson.id" t-esc="salesperson.name" class="text-truncate text-action"/>
+            <t t-else="">Salesperson</t>
+        </button>
+    </t>
+</templates>

--- a/salesperson_pos/static/src/models/pos_order.js
+++ b/salesperson_pos/static/src/models/pos_order.js
@@ -1,0 +1,12 @@
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrder.prototype, {
+    setSalesPerson(salesperson) {
+        console.log("at pos order js level",salesperson);
+        this.update({ salesperson_id: salesperson })
+    },
+    get_salesperson() {
+        return this.salesperson_id;
+    },
+})

--- a/salesperson_pos/views/hr_employee_form.xml
+++ b/salesperson_pos/views/hr_employee_form.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_employee_form_simplified" model="ir.ui.view">
+        <field name="name">hr.employee.simplified.form</field>
+        <field name="model">hr.employee</field>
+        <field name="arch" type="xml">
+            <form string="Employee Details">
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Employee's Name" required="True"/>
+                        </h1>
+                        <h2 class="text-muted">
+                            <field name="job_title" placeholder="Job Title"/>
+                        </h2>
+                    </div>
+
+                    <group>
+                        <group string="Work Information">
+                            <field name="department_id"/>
+                            <field name="work_email" placeholder="Work Email"/>
+                        </group>
+                        <group string="Contact Details">
+                            <field name="work_phone" placeholder="Work Phone"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_open_simplified_employee_form" model="ir.actions.act_window">
+        <field name="name">Edit Employee</field>
+        <field name="res_model">hr.employee</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_employee_form_simplified"/>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/salesperson_pos/views/pos_form_view.xml
+++ b/salesperson_pos/views/pos_form_view.xml
@@ -1,0 +1,23 @@
+<odoo>
+  <record id="view_pos_pos_form_inherit" model="ir.ui.view">
+    <field name="name">pos.order.form.inherit</field>
+    <field name="model">pos.order</field>
+    <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//group[@name='order_fields']/field[@name='fiscal_position_id']" position="after">
+        <field name="salesperson_id" string="Salesperson"/>
+      </xpath>
+    </field>
+  </record>
+
+  <record id="view_pos_order_tree_inherit" model="ir.ui.view">
+    <field name="name">pos.order.tree.inherit</field>
+    <field name="model">pos.order</field>
+    <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
+    <field name="arch" type="xml">
+      <field name="partner_id" position="after">
+        <field name="salesperson_id"/>
+      </field>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
- Enabled Salesperson selection in the POS Order Dashboard.  
- Added searching and filtering for Salesperson records.  
- Enabled creation and editing of Salesperson records directly from the dashboard.  
- Salesperson field is now integrated into the POS Order form.  
- Improved small-screen visibility of Salesperson selection button.  

task-4617163