### PR TITLE
[ADD] product_kit_management: Implement kit functionality in Sale Orders

### DIFF
--- a/product_kit_management/__init__.py
+++ b/product_kit_management/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/product_kit_management/__manifest__.py
+++ b/product_kit_management/__manifest__.py
@@ -1,0 +1,25 @@
+{
+    'name': 'Product Kit Management',
+    'version': '1.0',
+    'category': 'Sales',
+    'author': 'Odoo S.A.',
+    'summary': 'Add a new product type "is_kit" and manage product kits in sales orders.',
+    'description': """
+        This module introduces a new product type called "Kit" that allows bundling multiple products 
+        into a single sale order line. It provides a wizard to manage kit components, updates sales 
+        and invoice reports accordingly, and ensures stock and pricing consistency.
+    """,
+    'depends': ['sale_management'],
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/product_kit_wizard_view.xml',
+        'report/sale_order_report.xml',
+        'report/invoice_report.xml',
+        'views/sale_product_template.xml',
+        'views/product_template_view.xml',
+        'views/sale_order_view.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/product_kit_management/models/__init__.py
+++ b/product_kit_management/models/__init__.py
@@ -1,0 +1,4 @@
+from . import product_kit_component
+from . import product_template
+from . import sale_order
+from . import sale_order_line

--- a/product_kit_management/models/product_kit_component.py
+++ b/product_kit_management/models/product_kit_component.py
@@ -1,0 +1,22 @@
+from odoo import fields, models
+
+
+class ProductKitComponent(models.Model):
+    _name = 'product.kit.component'
+    _description = "Product Kit Component"
+
+    parent_order_line_id = fields.Many2one(
+        comodel_name="sale.order.line",
+        help="Refrence to the sale order line this kit component belongs to."
+    )
+    kit_component_id = fields.Many2one(
+        comodel_name="product.product", string="Sub Product",
+        help="sub-product that is part of kit"
+    )
+    kit_qty = fields.Integer(
+        string="Quantity",
+        required=True,
+        default=1,
+        store=True
+    )
+    price = fields.Float(string="Price", required=True)

--- a/product_kit_management/models/product_template.py
+++ b/product_kit_management/models/product_template.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    is_kit = fields.Boolean(string="Is Kit")
+    sub_product_ids = fields.Many2many(comodel_name='product.product', string="Sub Products")

--- a/product_kit_management/models/sale_order.py
+++ b/product_kit_management/models/sale_order.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    is_print_report = fields.Boolean(string="Print in Report", default=True)

--- a/product_kit_management/models/sale_order_line.py
+++ b/product_kit_management/models/sale_order_line.py
@@ -1,0 +1,72 @@
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    is_kit = fields.Boolean(string="Is Kit", related='product_id.is_kit')
+    kit_component_ids = fields.One2many(
+        comodel_name='product.kit.component',
+        inverse_name='parent_order_line_id',
+        string="Kit Components",
+        compute="_compute_sub_products",
+        store=True,
+        help="List of sub products"
+    )
+    is_kit_component = fields.Boolean(string="Is Kit Component?")
+    kit_parent_line_id = fields.Many2one(
+        comodel_name='sale.order.line',
+        string="Parent Kit Line",
+        help="Refrence to the main kit product's sale order line"
+    )
+
+    def open_kit_wizard(self):
+        self.ensure_one()
+        return self.env['product.kit'].with_context(
+            default_sale_order_line_id=self.id,
+        )._get_records_action(name=_("Product Kit Wizard"), target='new')
+
+    @api.depends('product_id')
+    def _compute_sub_products(self):
+        """
+        Computes the sub-products (kit components) for a sale order line.
+        It retrieves the sub-products linked to the main product and updates
+        the `kit_component_ids` field accordingly.
+        """
+        for line in self:
+            for sub_product in line.product_id.product_tmpl_id.sub_product_ids:
+                if sub_product not in line.kit_component_ids.kit_component_id:
+                    line.kit_component_ids = [
+                        Command.create({
+                            'parent_order_line_id': line.id,
+                            'kit_component_id': sub_product.id,
+                            'price': sub_product.lst_price,
+                        })
+                    ]
+
+    @api.ondelete(at_uninstall=False)
+    def _delete_sub_products(self):
+        """
+        Ensures that when a kit product is deleted from a sale order,
+        all its linked kit component lines are also removed.
+        """
+        lines_with_kit = self.filtered(lambda l: l.is_kit)
+        if lines_with_kit:
+            self.env['sale.order.line'].search([
+                ('order_id', 'in', lines_with_kit.order_id.ids),
+                ('kit_parent_line_id', 'in', lines_with_kit.ids)
+            ]).unlink()
+
+    def write(self, vals):
+        """
+        Prevents manual modification of key fields (`product_id`, `product_uom_qty`, `price_unit`)
+        for sub-products (components of a kit) to maintain data integrity.
+        """
+        if (
+            any(line.is_kit_component for line in self)
+            and any(field in vals for field in {'product_id', 'product_uom_qty',
+            'price_unit'})
+        ):
+            raise ValidationError("Subproduct of a kit cannot be modified manually")
+        return super(SaleOrderLine, self).write(vals)

--- a/product_kit_management/report/invoice_report.xml
+++ b/product_kit_management/report/invoice_report.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <template id="product_is_print_report_subproduct" inherit_id="account.report_invoice_document">
+        <xpath expr="//tbody[hasclass('invoice_tbody')]//tr" position="attributes">
+            <attribute name="t-if">not line.sale_line_ids.kit_parent_line_id or (line.sale_line_ids.kit_parent_line_id and line.sale_line_ids.order_id.is_print_report)</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/product_kit_management/report/sale_order_report.xml
+++ b/product_kit_management/report/sale_order_report.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <template id="product_kit_print_subproduct" inherit_id="sale.report_saleorder_document">
+        <xpath expr="//tbody[hasclass('sale_tbody')]//tr" position="attributes">
+            <attribute name="t-if">not line.kit_parent_line_id or (line.kit_parent_line_id and doc.is_print_report)</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/product_kit_management/security/ir.model.access.csv
+++ b/product_kit_management/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+product_kit_management.access_product_kit,access_product_kit,product_kit_management.model_product_kit,base.group_user,1,1,1,1
+product_kit_management.access_product_kit_line,access_product_kit_line,product_kit_management.model_product_kit_line,base.group_user,1,1,1,1
+product_kit_management.access_product_kit_component,access_product_kit_component,product_kit_management.model_product_kit_component,base.group_user,1,1,1,0

--- a/product_kit_management/views/product_template_view.xml
+++ b/product_kit_management/views/product_template_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_view_form" model="ir.ui.view">
+        <field name="name">product.template.form.inherit.product.type</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page//field[@name='product_tooltip']" position="after">
+                <field name="is_kit"/>
+                <field name="sub_product_ids" widget="many2many_tags" invisible="not is_kit"/>
+            </xpath>            
+        </field>
+    </record>
+</odoo>

--- a/product_kit_management/views/sale_order_view.xml
+++ b/product_kit_management/views/sale_order_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">sale.order.line.form.inherit.product.type</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="is_print_report"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_template_id']" position="after">
+                <button name="open_kit_wizard"
+                        type="object"
+                        class="btn btn-primary" 
+                        string="Sub Products"
+                        invisible="not is_kit or state in ['sale', 'cancel']"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_kit_management/views/sale_product_template.xml
+++ b/product_kit_management/views/sale_product_template.xml
@@ -1,0 +1,9 @@
+<odoo>
+    <template id="sale_order_portal_content_inherited" inherit_id="sale.sale_order_portal_content">
+        <xpath expr="//tbody[hasclass('sale_tbody')]//tr" position="attributes">
+            <attribute name="t-if">
+                not line.kit_parent_line_id or (line.kit_parent_line_id and sale_order.is_print_report)
+            </attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/product_kit_management/wizard/__init__.py
+++ b/product_kit_management/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import product_kit_wizard

--- a/product_kit_management/wizard/product_kit_wizard.py
+++ b/product_kit_management/wizard/product_kit_wizard.py
@@ -1,0 +1,115 @@
+from odoo import Command, api, fields, models
+
+
+class ProductKit(models.TransientModel):
+    _name = 'product.kit'
+    _description = "Kit Wizard"
+
+    sale_order_line_id = fields.Many2one(
+        comodel_name='sale.order.line',
+        string="Sale Order Line",
+        required=True,
+        help="Reference to the sale order line",
+    )
+    kit_product_id = fields.Many2one(related='sale_order_line_id.product_id')
+    kit_subproducts_ids = fields.One2many(
+        comodel_name='product.kit.line',
+        inverse_name='product_kit_id',
+        string="Sub Products",
+        compute="_compute_kit_subproducts",
+        store=True,
+        readonly=False,
+    )
+
+    @api.depends('sale_order_line_id')
+    def _compute_kit_subproducts(self):
+        for product in self:
+            if product.sale_order_line_id:
+                product.kit_subproducts_ids = [
+                    Command.create({
+                        'product_id': component.kit_component_id.id,
+                        'kit_component_id': component.id,
+                        'quantity': component.kit_qty,
+                        'price': component.price,
+                    })
+                    for component in product.sale_order_line_id.kit_component_ids
+                ]
+
+    def action_confirm(self):
+        """
+        Confirms the changes made in the wizard and updates the sale order line accordingly.
+        - Updates existing kit components with the new quantities and prices.
+        - If a sub-product does not exist in the order, it creates a new sale order line for it.
+        - Adjusts the sequence of sub-products in the sale order.
+        - Updates the total price of the main kit product based on its components.
+        """
+        if self.sale_order_line_id.is_kit:
+            sale_order_line = self.sale_order_line_id
+            order = sale_order_line.order_id
+            main_product_sequence = sale_order_line.sequence
+            total_subproduct_price = 0.0
+
+            for index, line in enumerate(self.kit_subproducts_ids, start=1):
+                component = sale_order_line.kit_component_ids.filtered(
+                    lambda c: c.kit_component_id.id == line.product_id.id
+                )
+                if component:
+                    component.write({
+                        'kit_qty': line.quantity,
+                        'price': line.price
+                    })
+                existing_line = order.order_line.filtered(
+                    lambda ol: ol.product_id == line.product_id and
+                    ol.is_kit_component
+                )
+                if existing_line:
+                    existing_line.write({
+                        'product_uom_qty': line.quantity,
+                        'price_unit': 0.0,
+                        'sequence': main_product_sequence + index
+                    })
+                else:
+                    self.env['sale.order.line'].create({
+                        'order_id': order.id,
+                        'product_id': line.product_id.id,
+                        'product_uom_qty': line.quantity,
+                        'price_unit': 0.0,
+                        'is_kit_component': True,
+                        'kit_parent_line_id': sale_order_line.id,
+                        'sequence': main_product_sequence + index
+                    })
+                total_subproduct_price += line.total_price
+                sale_order_line.write({
+                    'price_unit': sale_order_line.price_unit + total_subproduct_price
+                })
+
+
+class ProductKitLine(models.TransientModel):
+    _name = 'product.kit.line'
+    _description = "Wizard Line for Sub Products"
+
+    product_kit_id = fields.Many2one(
+        'product.kit', string="Product Kit",
+        help="Reference to the product kit wizard"
+    )
+    product_id = fields.Many2one(
+        'product.product', string="Product",
+        help="Main product of the kit"
+    )
+    kit_component_id = fields.Many2one(
+        'product.kit.component', string="Kit Component",
+        help="Sub-product of the kit"
+    )
+    quantity = fields.Integer(string="Quantity", required=True, default=1)
+    price = fields.Float(string="Price", required=True, default=0.0)
+    total_price = fields.Float(string="Total Price", compute="_compute_total_price", store=True)
+
+    @api.depends('quantity', 'price')
+    def _compute_total_price(self):
+        """
+        Computes the total price of the kit component in the wizard.
+        - Formula: total_price = quantity * price
+        - Ensures total price is calculated only if both quantity and price are set.
+        """
+        for line in self:
+            line.total_price = line.quantity * line.price

--- a/product_kit_management/wizard/product_kit_wizard_view.xml
+++ b/product_kit_management/wizard/product_kit_wizard_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_kit_wizard_form_view" model="ir.ui.view">
+        <field name="name">product.kit.wizard.form.view</field>
+        <field name="model">product.kit</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <field name="sale_order_line_id" invisible="True"/>
+                    <h3>Product: <field name="kit_product_id" readonly="1" nolabel="1"/></h3>
+                </header>
+                <h4>Sub Products</h4>
+                <field name="kit_subproducts_ids">
+                    <list create="false" editable="bottom">
+                        <field name="product_id"/>
+                        <field name="quantity"/>
+                        <field name="price"/>
+                        <field name="total_price"/> 
+                    </list>
+                </field>
+                <footer>
+                    <button string="Confirm" name="action_confirm" class="btn btn-primary" type="object"/>
+                    <button string="Cancel" name="cancel" class="oe_link" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This update adds the ability to sell products as a kit in Sale Orders without using the Bill of Materials or Manufacturing module.

Key Features:
- Adds an "Is Kit" field in products to define kits.
- Introduces a button on the Sale Order Line to open a wizard for managing sub-products.
- The wizard allows users to adjust sub-product quantities and prices.
- Upon confirmation, sub-products are automatically added as sale order lines.
- Sub-products are non-editable and set to zero price since the cost is covered by the main kit product.
- If the main product is removed, all associated sub-products are also removed.
- Provides an option to print sub-products in reports.

task:[4617148](https://www.odoo.com/odoo/my-tasks/4617148)