### PR TITLE
[ADD] l10n_in_zero_qty:  Implement zero quantity handling

### DIFF
--- a/l10n_in_edi_zero_qty/__init__.py
+++ b/l10n_in_edi_zero_qty/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_in_edi_zero_qty/__manifest__.py
+++ b/l10n_in_edi_zero_qty/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Add Zero Quantity",
+    'description': """
+        Adding the zero quantity on account move line.
+        If it is checked the quantity would be passed as 0 in einvoicing
+    """,
+    'author': "Odoo S.A.",
+    'category': 'Tutorials/AddZeroQuantity',
+    'installable': True,
+    'depends': ['l10n_in_edi'],
+    'data': [
+        'views/view_move_line_form.xml',
+    ],
+    'license': 'AGPL-3'
+}

--- a/l10n_in_edi_zero_qty/models/__init__.py
+++ b/l10n_in_edi_zero_qty/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_edi_format
+from . import account_move_line

--- a/l10n_in_edi_zero_qty/models/account_edi_format.py
+++ b/l10n_in_edi_zero_qty/models/account_edi_format.py
@@ -1,0 +1,19 @@
+from odoo import fields, models
+
+
+class AccountEdiFormat(models.Model):
+    _inherit = "account.edi.format"
+
+    def _get_l10n_in_edi_line_details(self, index, line, line_tax_details):
+        """
+        Extend the method to set the quantity to zero if the l10n_in_is_zero_quantity field is True.
+
+        :param index: Line index in the EDI data.
+        :param line: The account.move.line record.
+        :param line_tax_details: Tax details associated with the line.
+        :return: Updated line details for EDI.
+        """
+        data = super()._get_l10n_in_edi_line_details(index, line, line_tax_details)
+        if line.l10n_in_is_zero_quantity:
+            data['Qty'] = 0
+        return data

--- a/l10n_in_edi_zero_qty/models/account_move_line.py
+++ b/l10n_in_edi_zero_qty/models/account_move_line.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    """
+    Extension of the 'account.move.line' model to add a custom field.
+    """
+    _inherit = 'account.move.line'
+
+    l10n_in_is_zero_quantity = fields.Boolean(
+        string="Is Zero Quantity",
+        help="When checked, the product quantity for this line will be set to zero."
+    )

--- a/l10n_in_edi_zero_qty/tests/__init__.py
+++ b/l10n_in_edi_zero_qty/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_zero_quantity

--- a/l10n_in_edi_zero_qty/tests/test_zero_quantity.py
+++ b/l10n_in_edi_zero_qty/tests/test_zero_quantity.py
@@ -1,0 +1,52 @@
+from odoo import Command, fields
+from odoo.addons.l10n_in.tests.common import L10nInTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestZeroQuantityField(L10nInTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.invoice = cls.init_invoice('out_invoice', cls.partner_a)
+
+        cls.invoice_line = cls.env['account.move.line'].create({
+            'move_id': cls.invoice.id,
+            'product_id': cls.product_a.id,
+            'quantity': 10,
+            'price_unit': 100,
+            'l10n_in_is_zero_quantity': False
+        })
+
+    def test_l10n_in_zero_quantity_field(self):
+        """
+        Test that the 'l10n_in_is_zero_quantity' field sets the quantity to zero
+        in EDI line details.
+        """
+        # Ensure quantity is not zero by default
+        edi_format = self.env['account.edi.format'].search([('name', 'ilike', 'Invoice')])
+
+        line_details = edi_format._get_l10n_in_edi_line_details(0, self.invoice_line, {})
+        self.assertNotEqual(line_details['Qty'], 0)
+
+        # Set the zero quantity field and check again
+        self.invoice_line.l10n_in_is_zero_quantity = True
+        line_details = edi_format._get_l10n_in_edi_line_details(0, self.invoice_line, {})
+        self.assertEqual(line_details['Qty'], 0)
+
+    def test_invoice_workflow_with_zero_quantity(self):
+        """
+        Full workflow test: Create, validate invoice and ensure the zero quantity
+        behavior is consistent throughout.
+        """
+        self.invoice_line.l10n_in_is_zero_quantity = True
+
+        # Validate invoice
+        self.invoice.action_post()
+        self.assertEqual(self.invoice.state, 'posted')
+
+        # Ensure quantity remains zero in EDI line details
+        edi_format = self.env['account.edi.format'].search([('name', 'ilike', 'Invoice')])
+        line_details = edi_format._get_l10n_in_edi_line_details(0, self.invoice_line, {})
+        self.assertEqual(line_details['Qty'], 0)

--- a/l10n_in_edi_zero_qty/views/view_move_line_form.xml
+++ b/l10n_in_edi_zero_qty/views/view_move_line_form.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_move_line_form_inherit" model="ir.ui.view">
+        <field name="name">account.move.line.form.inherit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@id='invoice_tab']//field[@name='product_id'][@optional='show']" position="after">
+                <field name="l10n_in_is_zero_quantity" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit introduces zero quantity handling for the -Indian E-invoicing `l10n_in_edi`.

Key changes:

- Added boolean field to the `account.move.line` model to pass the quantity as 0 or not.
- Set the product quantity according to field while passing the data for einvoicing.

Task-4622902