### PR TITLE
[ADD] pos_second_uom: Implemented Second UoM selection and conversion…

### DIFF
--- a/pos_second_uom/__init__.py
+++ b/pos_second_uom/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/pos_second_uom/__manifest__.py
+++ b/pos_second_uom/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name':'Pos second UOM',
+    'version':'1.0',
+    'author':'JODH',
+    'depends': ['point_of_sale', 'uom'],
+    'description':"""
+This Module provides second uom for pos
+""",
+    'data':[
+        'views/product_template_views.xml',
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_second_uom/static/src/**/*',
+        ],
+    },
+    'installable': True,
+    'auto_install': True,
+    'license':'LGPL-3',
+}

--- a/pos_second_uom/models/__init__.py
+++ b/pos_second_uom/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product
+from . import product_template

--- a/pos_second_uom/models/product.py
+++ b/pos_second_uom/models/product.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class Product(models.Model):
+    _inherit = 'product.product'
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        fields = super()._load_pos_data_fields(config_id)
+        fields.extend(['pos_second_uom_id'])
+        return fields   

--- a/pos_second_uom/models/product_template.py
+++ b/pos_second_uom/models/product_template.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    uom_categ_id = fields.Many2one(comodel_name="uom.uom", string="UOM category", related="uom_id.category_id", store=True)
+    pos_second_uom_id = fields.Many2one(comodel_name="uom.uom", string="Second UOM", domain="[('category_id', '=', uom_categ_id),  ('id', '!=', uom_id)]")

--- a/pos_second_uom/static/src/overrides/control_buttons/control_buttons.js
+++ b/pos_second_uom/static/src/overrides/control_buttons/control_buttons.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { patch } from "@web/core/utils/patch";
+import { SecondUomDialog } from "./second_uom_dialog/second_uom_dialog";
+
+patch(ControlButtons.prototype,{
+    get secondUomName(){        
+        return this.currentOrder.get_selected_orderline().product_id.pos_second_uom_id?.name;
+    },
+    setSecondUom(){
+        const orderLine = this.currentOrder?.get_selected_orderline();
+        if (!orderLine || !this.secondUomName) {
+            this.notification.add("No Second UoM available for this product.", { type: "warning" });
+            return;
+        }
+        const product = this.currentOrder.get_selected_orderline().get_product();         
+        this.dialog.add(SecondUomDialog,{
+            product,
+            secondUomName: this.secondUomName
+        })
+    }
+})

--- a/pos_second_uom/static/src/overrides/control_buttons/control_buttons.xml
+++ b/pos_second_uom/static/src/overrides/control_buttons/control_buttons.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_second_uom.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//SelectPartnerButton" position="after">
+            <button t-if="!props.showRemainingButtons" class="btn btn-light btn-lg lh-lg text-truncate w-auto" t-on-click="setSecondUom">
+                <div t-if="secondUomName" t-esc="secondUomName" class="text-truncate text-action"/>
+                <t t-else="">Second UOM</t>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/pos_second_uom/static/src/overrides/control_buttons/second_uom_dialog/second_uom_dialog.js
+++ b/pos_second_uom/static/src/overrides/control_buttons/second_uom_dialog/second_uom_dialog.js
@@ -1,0 +1,35 @@
+/** @odoo-module **/
+
+import { Component, useRef } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+
+export class SecondUomDialog extends Component {
+    static template = "pos_second_uom.SecondUomDialog";
+    static props = {
+        close: { type: Function },
+        product: { type: Object },
+        secondUomName: {type: String, optional: true},
+    };
+    static components = { Dialog }; 
+    setup() {
+       this.pos= usePos();
+       this.inp_qty = useRef("inp")
+       this.ratio = this.computeRatio(this.props.product)
+    }
+    computeRatio(product) {
+        if (product.uom_id && product.pos_second_uom_id) {
+            return product.uom_id.factor / product.pos_second_uom_id.factor;
+        }
+        return 1;
+    }
+    confirm() {
+        const qty = parseFloat(this.inp_qty.el.value)
+        const orderLine = this.pos.get_order().get_selected_orderline();
+        
+        if (orderLine) {
+            orderLine.set_quantity(qty * this.ratio);
+        }
+        this.props.close(); 
+    }
+}

--- a/pos_second_uom/static/src/overrides/control_buttons/second_uom_dialog/second_uom_dialog.xml
+++ b/pos_second_uom/static/src/overrides/control_buttons/second_uom_dialog/second_uom_dialog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_second_uom.SecondUomDialog">
+        <Dialog size="sm" header="false">
+            <div class="d-flex flex-column">
+                <label for="secondUomQty" class="fw-bold">Quantity in Second UoM:</label>
+                <input type="number" min="0" id="secondUomQty" t-ref="inp" class="form-control"/>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="confirm">Confirm</button>
+                <button class="btn btn-secondary" t-on-click="props.close">Cancel</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/pos_second_uom/views/product_template_views.xml
+++ b/pos_second_uom/views/product_template_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="product_template_view_form_inherit_pos_second_uom" model="ir.ui.view">
+        <field name="name">product.template.view.form.inherit.pos.second.uom</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"></field>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='pos']" position="inside">
+                <field name="pos_second_uom_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
… in POS

- Added a field to store the Second UoM for products.
- Loaded the Second UoM field in `pos_data` for use in the POS interface.
- Added a button in the POS store to trigger Second UoM dialogbox.
- Implemented a dialog box where users can input quantity in the Second UoM.
- Converted the entered quantity from Second UoM to the main UoM and updated the order line accordingly.