### PR TITLE
[ADD] quantity_on_hand: ui changes of product view

### DIFF
--- a/quantity_on_hand/__init__.py
+++ b/quantity_on_hand/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/quantity_on_hand/__manifest__.py
+++ b/quantity_on_hand/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "On Hand Quantitiy",
+    "depends": ["stock"],
+    "data": [
+        "views/product_views.xml",
+    ],
+    
+    "installable": True,
+    "application": False,
+    "license": "LGPL-3",
+}

--- a/quantity_on_hand/models/__init__.py
+++ b/quantity_on_hand/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/quantity_on_hand/models/product.py
+++ b/quantity_on_hand/models/product.py
@@ -1,0 +1,69 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    # Add to product.product class
+    qty_available = fields.Float(
+        compute='_compute_quantities',
+        inverse='_inverse_qty_available',  # Add inverse
+        search='_search_qty_available',
+        digits='Product Unit of Measure',
+        compute_sudo=False
+    )
+    show_qty_update_button = fields.Boolean(compute='_compute_show_qty_update_button')
+
+    @api.depends('product_tmpl_id')
+    def _compute_show_qty_update_button(self):
+        for product in self:
+            product.show_qty_update_button = (self.env.user.has_group("stock.group_stock_multi_locations"))
+
+    def _inverse_qty_available(self):
+        """Handle direct quantity updates for single-location installations"""
+
+        if self.env.context.get('skip_qty_available_update', False):
+            return
+        for product in self:
+            if (product.type == "consu" and product.is_storable and product.qty_available > 0):
+                warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+                self.env['stock.quant'].with_context(inventory_mode=True).create({
+                    'product_id': product.id,
+                    'location_id': warehouse.lot_stock_id.id,
+                    'inventory_quantity': product.qty_available,
+                }).action_apply_inventory()
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    qty_available = fields.Float(
+        compute='_compute_quantities',
+        inverse='_inverse_qty_available',  # Add inverse
+        search='_search_qty_available',
+        digits='Product Unit of Measure',
+        compute_sudo=False
+    )
+
+    show_qty_update_button = fields.Boolean(compute='_compute_show_qty_update_button')
+
+    def _inverse_qty_available(self):
+        if self.env.context.get('skip_qty_available_update', False):
+            return
+        for template in self:
+            if template.qty_available and not template.product_variant_id:
+                raise UserError("Save the product form before updating the Quantity On Hand.")
+            else:
+                template.product_variant_id.qty_available = template.qty_available
+
+    @api.depends('product_variant_count', 'tracking')
+    def _compute_show_qty_update_button(self):
+
+        for product in self:
+            product.show_qty_update_button = (
+                self.env.user.has_group("stock.group_stock_multi_locations")
+                or product.product_variant_count > 1
+            )
+
+
+            

--- a/quantity_on_hand/static/src/scss/custom_stock_quantity.scss
+++ b/quantity_on_hand/static/src/scss/custom_stock_quantity.scss
@@ -1,0 +1,14 @@
+.hover-container .hover-button {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    position: absolute;
+    right: -25px;
+    top: 50%;
+    transform: translateY(-50%);
+}
+.hover-container:hover .hover-button {
+    opacity: 1;
+}
+.quantity_on_hand_group .o_stat_info {
+    min-width: 150px;
+}

--- a/quantity_on_hand/views/product_views.xml
+++ b/quantity_on_hand/views/product_views.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="product_product_view_inherit_stock_quantity_update">
+        <field name="name">product.product.inherit.stock.quantity.update</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <!-- Remove from header -->
+            <xpath expr="//header/button[@name='action_update_quantity_on_hand']" position="replace" />
+            <xpath expr="//header/button[@name='action_open_label_layout']" position="replace" />
+            <xpath expr="//header/button[@groups='stock.group_stock_user']" position="replace" />
+
+            <!-- Remove On Hand Stat Button -->
+            <xpath expr="//button[@icon='fa-cubes']" position="replace" />
+
+            <xpath expr="//button[@icon='fa-area-chart']/div" position="replace">
+                <div class="d-flex flex-row gap-1 ms-1">
+                    <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
+                        <span class="o_stat_value">
+                            <field name="qty_available" widget="statinfo" nolabel="1"/>
+                        </span>
+                        <field name="virtual_available" invisible="1"/>
+                        <span class="o_stat_value" >
+                            <field name="virtual_available" nolabel="1" decoration-info="virtual_available &gt; 0" decoration-danger="virtual_available &lt; 0"/>
+                        </span>
+                    </div>
+                    <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
+                        <span class="o_stat_value">
+                            <field name="uom_name" widget="statinfo" nolabel="1"/>
+                        </span>
+                        <span class="o_stat_value text-muted">
+                            Forecasted
+                        </span>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="product_template_view_inherit_stock_quantity_update">
+        <field name="name">product.template.inherit.stock.quantity.update</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
+        <field name="arch" type="xml">
+            <!-- Remove from header -->
+            <xpath expr="//header/button[@name='action_update_quantity_on_hand']" position="replace" />
+            <xpath expr="//header/button[@name='action_open_label_layout']" position="replace" />
+            <xpath expr="//header/button[@groups='stock.group_stock_user']" position="replace" />
+
+            <!-- Remove On Hand Stat Button -->
+            <xpath expr="//button[@icon='fa-cubes']" position="replace" />
+
+            <xpath expr="//button[@icon='fa-area-chart']/div" position="replace">
+                <div class="d-flex flex-row gap-1 ms-1">
+                    <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">
+                        <span class="o_stat_value">
+                            <field name="qty_available" widget="statinfo" nolabel="1"/>
+                        </span>
+                        <span class="o_stat_value" >
+                            <field name="virtual_available" nolabel="1" decoration-info="virtual_available &gt; 0" decoration-danger="virtual_available &lt; 0"/>
+                        </span>
+                    </div>
+                    <div class="o_field_widget o_stat_info flex-column align-items-start gap-1">
+                        <span class="o_stat_value">
+                            <field name="uom_name" widget="statinfo" nolabel="1"/>
+                        </span>
+                        <span class="o_stat_value text-muted">
+                            Forecasted
+                        </span>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_template_property_form" model="ir.ui.view">
+            <field name="name">product.template.stock.property.form.inherit</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='product_tooltip']" position="replace" />
+                <xpath expr="//field[@name='type']" position="after">
+                        <label for="qty_available" class="oe_inline" invisible="not is_storable" groups="stock.group_stock_user"/>
+                        <div class="d-flex gap-2 align-items-baseline hover-show" invisible="not is_storable" groups="stock.group_stock_user">
+                            <field name="qty_available" style="max-width:100px;" readonly="True" groups="!stock.group_stock_manager"/>
+                            <field name="qty_available" style="max-width:100px;" readonly="show_qty_update_button" groups="stock.group_stock_manager"/>
+                            <span name="uom_span" groups="uom.group_uom">
+                                <field name="uom_name" class="oe_inline me-5"/>
+                            </span>
+                            <button id="update_product_qty_button" string="Update" type="object"
+                                name="action_open_quants"
+                                groups="stock.group_stock_manager"
+                                invisible="not show_qty_update_button"
+                                class="btn btn-link py-0 btn-show"/>
+                        </div>
+                </xpath>
+            </field>
+    </record>
+
+    <record id="action_product_product_print_labels" model="ir.actions.server">
+        <field name="name">Print Labels</field>
+        <field name="model_id" ref="product.model_product_product" />
+        <field name="binding_model_id" ref="product.model_product_product" />
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.action_open_label_layout()
+        </field>
+    </record>
+    
+    <record id="action_product_template_print_labels" model="ir.actions.server">
+        <field name="name">Print Labels</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="binding_model_id" ref="product.model_product_template"/>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.action_open_label_layout()
+        </field>
+    </record>
+
+    <record id="action_product_replenishment" model="ir.actions.server">
+        <field name="name">Replenish</field>
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]" />
+        <field name="model_id" ref="product.model_product_product" />
+        <field name="binding_model_id" ref="product.model_product_product" />
+        <field name="binding_view_types">form</field>
+        <field name="state">code</field>
+        <field name="code">
+            for record in records:
+                if record.type == 'consu':
+                    action = {
+                        "name": "Low on stock? Let's replenish.",
+                        "type": "ir.actions.act_window",
+                        "res_model": "product.replenish",
+                        "context": {'default_product_id': records.id},
+                        "views": [[False, "form"]],
+                        "target": "new",
+                    }
+                else:
+                    raise UserError("Replenishment is only available for inventory-managed products.")
+        </field>
+    </record>
+
+    <record id="action_product_template_replenishment" model="ir.actions.server">
+            <field name="name">Replenish</field>
+            <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]"/>
+            <field name="model_id" ref="product.model_product_template"/>
+            <field name="binding_model_id" ref="product.model_product_template"/>
+            <field name="binding_view_types">form</field>
+            <field name="state">code</field>
+            <field name="code">
+                for record in records:
+                    if record.type == 'consu':
+                        action = {
+                            "name": "Low on stock? Let's replenish.",
+                            "type": "ir.actions.act_window",
+                            "res_model": "product.replenish",
+                            "context": {'default_product_tmpl_id': records.id},
+                            "views": [[False, "form"]],
+                            "target": "new",
+                        }
+                    else:
+                        raise UserError("Replenishment is only available for inventory-managed products.")
+            </field>
+        </record>
+</odoo>


### PR DESCRIPTION
- added quantity on hand field editable if not multi-locations in product general information with update button invisible if not multi-locations and visible on hover, link to On Hand report
- Remove stat button, replace by update besides qty on hand in the form
- Change the layout of forecast button, red if negative
- Remove descriptions for goods