### PR TITLE
[ADD] deposit_rental: created new module 'deposit_rental'

### DIFF
--- a/deposit_rental/__init__.py
+++ b/deposit_rental/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/deposit_rental/__manifest__.py
+++ b/deposit_rental/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Deposit Rental',
+    'version': '1.0',
+    'depends': ['sale_renting', 'website_sale'],
+    'description': """
+This module helps to implement the deposit option in the rental app.
+""",
+    'data': [
+        'views/product_template_view.xml',
+        'views/res_config_settings_view.xml',
+        'views/website_deposit_amount_template.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': {
+            'deposit_rental/static/src/website_deposit_amount.js',
+        }
+    },
+    'license': 'LGPL-3'
+}

--- a/deposit_rental/models/__init__.py
+++ b/deposit_rental/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_template
+from . import res_config_settings
+from . import sale_order
+from . import sale_order_line

--- a/deposit_rental/models/product_template.py
+++ b/deposit_rental/models/product_template.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    deposit_require = fields.Boolean(string='Require Deposit')
+    deposit_amount = fields.Float(string='Amount', compute='_compute_deposit_amount', store=True)
+
+    @api.model
+    def _update_deposit_amount(self):
+        products = self.search([('deposit_require', '=', True)])
+        products._compute_deposit_amount()
+
+    @api.depends('deposit_require')
+    def _compute_deposit_amount(self):
+        deposit_product_id = self.env['ir.config_parameter'].sudo().get_param('deposit_rental.deposit_product')
+        deposit_id = self.env['product.product'].sudo().search([('id', '=', int(deposit_product_id))]) if deposit_product_id else None
+
+        for record in self:
+            if record.deposit_require and deposit_id and deposit_id.exists():
+                record.deposit_amount = deposit_id.list_price
+            else:
+                record.deposit_amount = 0.0

--- a/deposit_rental/models/res_config_settings.py
+++ b/deposit_rental/models/res_config_settings.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    deposit_product = fields.Many2one('product.product', string='Deposit')
+
+    @api.model
+    def get_values(self):
+        res = super().get_values()
+        deposit_product_id = self.env['ir.config_parameter'].sudo().get_param('deposit_rental.deposit_product', default=0)
+        res.update(deposit_product=int(deposit_product_id) if deposit_product_id else False)
+        return res
+
+    def set_values(self):
+        super().set_values()
+        self.env['ir.config_parameter'].sudo().set_param('deposit_rental.deposit_product', self.deposit_product.id or False)
+        self.env['product.template'].sudo()._update_deposit_amount()

--- a/deposit_rental/models/sale_order.py
+++ b/deposit_rental/models/sale_order.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _add_deposit_product(self, order_line):
+        deposit_product_id = int(self.env['ir.config_parameter'].sudo().get_param('deposit_rental.deposit_product', default=0))
+        if not deposit_product_id:
+            raise UserError(_("This product requires a deposit, but no deposit item is configured. Please configure it in Rental Settings."))
+        deposit_id = self.env['product.product'].browse(deposit_product_id)
+        if not deposit_id.exists():
+            raise UserError(_("The configured deposit product does not exist."))
+        existing_deposit_line = self.order_line.filtered(lambda line: line.linked_line_id.id == order_line.id)
+        if existing_deposit_line:
+            existing_deposit_line.product_uom_qty = order_line.product_uom_qty
+        else:
+            self.env['sale.order.line'].create({
+                'order_id': self.id,
+                'product_id': deposit_product_id,
+                'product_uom_qty': order_line.product_uom_qty,
+                'product_uom': deposit_id.uom_id.id,
+                'price_unit': deposit_id.list_price,
+                'linked_line_id': order_line.id,
+            })

--- a/deposit_rental/models/sale_order_line.py
+++ b/deposit_rental/models/sale_order_line.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.model_create_multi
+    def create(self, vals):
+        lines = super().create(vals)
+        for line in lines:
+            deposit_product_id = int(self.env['ir.config_parameter'].sudo().get_param('deposit_rental.deposit_product', default=0))
+            if line.product_id.id != deposit_product_id and line.product_id.rent_ok and line.product_id.deposit_require:
+                line.order_id._add_deposit_product(line)
+        return line
+
+    def write(self, vals):
+        res = super().write(vals)
+        for line in self:
+            if 'product_uom_qty' in vals and line.product_id.deposit_require:
+                line.order_id._add_deposit_product(line)
+        return res

--- a/deposit_rental/static/src/website_deposit_amount.js
+++ b/deposit_rental/static/src/website_deposit_amount.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+publicWidget.registry.DepositRental = publicWidget.Widget.extend({
+    selector: "#product_detail",
+    events: {
+        'change input[name="add_qty"]': '_updateDepositAmount',
+    },
+    start: function() {
+        this._super.apply(this, arguments);
+        if ($("#deposit_amount").length && $("#deposit_amount").data("base-amount") > 0) {
+            this._updateDepositAmount();
+        } else {
+            this.$el.off('change input[name="add_qty"]');
+        }
+    },
+    _updateDepositAmount: function() {
+        var qty = parseFloat($("#o_wsale_cta_wrapper").find("input[name='add_qty']").val()) || 1;
+        var depositAmount = parseFloat($("#deposit_amount").data("base-amount")) || 0;
+        $("#deposit_amount").text(depositAmount * qty);
+    }
+})

--- a/deposit_rental/views/product_template_view.xml
+++ b/deposit_rental/views/product_template_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="product_template_form_view_deposit_rental" model="ir.ui.view">
+        <field name="name">product.template.form.view.deposit.rental</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="sale_renting.product_template_form_view_rental"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='extra_daily']" position="after">
+                <field name="deposit_require"/>
+                <field name="deposit_amount" widget="monetary" invisible="deposit_require == False"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/deposit_rental/views/res_config_settings_view.xml
+++ b/deposit_rental/views/res_config_settings_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.deposit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale_renting.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@name='rental_delay_costs']" position="inside">
+                <div class="row mt8">
+                    <label for="deposit_product" class="col-lg-3"/>
+                    <field class="o_field_widget" name="deposit_product" placeholder="Set a product to be used for deposit on sale order."/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/deposit_rental/views/website_deposit_amount_template.xml
+++ b/deposit_rental/views/website_deposit_amount_template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<odoo>
+    <template id="deposit_rental_website_view" inherit_id="website_sale.product">
+        <xpath expr="//div[@id='product_option_block']" position="after">
+        <div t-if="product.deposit_require">
+            Deposit Required: <t t-esc="product.currency_id.symbol"></t><span id="deposit_amount" t-att-data-base-amount="product.deposit_amount"/>
+        </div>
+        </xpath>
+    </template>
+    <template id="deposit_amount_cart_line" inherit_id="website_sale.cart_lines">
+        <xpath expr="//div[@name='o_wsale_cart_line_button_container']" position="after">
+            <t t-if="line.product_id.deposit_require">
+                <p>
+                    Deposit for <t t-esc="line.product_id.display_name"/>: 
+                    <t t-esc="line.currency_id.symbol"/><t t-esc="line.product_id.deposit_amount * line.product_uom_qty"/>
+                </p>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
The 'deposit_rental' module helps to implement the deposit option in the rental app. 
A field is added in Rental configuration to set the deposit product.
A 'deposit_require' checkbox is added in the rental product form, along with a 'deposit_amount' field.
The 'deposit_amount' field is displayed only when the checkbox is selected.
The deposit amount is automatically updated when the deposit product is changed in the settings.
When a rental product requiring a deposit is added to a Sale Order, a deposit product is automatically added.
Additionally, the deposit product's quantity is updated whenever the linked product's quantity in the Sale Order is modified.
Displayed deposit amount field in website, so that when the quantity is updated of product the deposit amount should also be updated.
Also the final amount is displayed in the website shop cart.