### PR TITLE
[ADD] pos_customer:  Show customer name, separate refunds & display a…

### DIFF
--- a/pos_customer/__manifest__.py
+++ b/pos_customer/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'POS Customer Display',
+    'version': '1.0',
+    'depends': ['point_of_sale'],
+    'author': 'matd',
+    'category': 'Category',
+    'description': """
+It provides POS customer display module
+""",
+    'installable': True,
+    'application': True,
+    'assets': {
+        'point_of_sale.assets_prod': [
+            'pos_customer/static/src/pos_order.js',
+        ],
+        'point_of_sale.customer_display_assets': [
+            'pos_customer/static/src/customer_display/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/pos_customer/static/src/customer_display/customer_display.xml
+++ b/pos_customer/static/src/customer_display/customer_display.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_customer.CustomerDisplay" t-inherit="point_of_sale.CustomerDisplay" t-inherit-mode="extension">
+        <xpath expr="//div[@t-if='order.amount and !order.finalized']" position="inside">
+            <div class="row fw-bolder">
+                <div class="col text-end">Customer</div>
+                <div class="col text-end" t-esc="order.partnerName"/>
+            </div>
+            <div class="row fw-bolder">
+                <div class="col text-end">Amount</div>
+                <div class="col text-end" t-esc="this.order.amount_per_guest?.toFixed(2)"/>/ Guest
+            </div>
+        </xpath>
+        <xpath expr="//div[hasclass('o_customer_display_main')]/OrderWidget" position="replace">
+            <OrderWidget t-if="!order.finalized" lines="order.lines"/>
+            <div>Refund</div>
+            <OrderWidget t-if="!order.finalized" lines="order.refundLines"/>
+        </xpath>
+    </t>
+</templates>

--- a/pos_customer/static/src/pos_order.js
+++ b/pos_customer/static/src/pos_order.js
@@ -1,0 +1,22 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+
+patch(PosOrder.prototype, {
+    getCustomerDisplayData() {
+        const temp = this.getSortedOrderlines().map((l) => ({
+            ...l.getDisplayData(),
+            isRefund: l.refunded_orderline_id ? true : false,
+        }));
+
+        return {
+            ...super.getCustomerDisplayData(),
+            
+            partnerName: this.get_partner_name() ? this.get_partner_name() : "Guest",
+            amount_per_guest: this.amountPerGuest(),
+            refundLines: temp.filter((x) => x.isRefund),
+            lines: temp.filter((x) => !x.isRefund),
+        };
+    },
+});


### PR DESCRIPTION
…mount/guest

- Added customer name on Customer Display by fetching data from Product screen
- Separate refund orders from regular orders in Customer Display
- Display Amount per Guest on the Customer Display when on the Ticket Screen