### PR TITLE
[IMP] simplified-product-routes: added automatic product route configuration

### DIFF
--- a/simplified_product_routes/__init__.py
+++ b/simplified_product_routes/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/simplified_product_routes/__manifest__.py
+++ b/simplified_product_routes/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    'name': 'Simplified Product Routes',
+    'version': '1.0',
+    'summary': 'Simplifies route configuration for products',
+    'description': """
+        This module simplifies route configuration for products by:
+        - Automatically applying appropriate routes based on product configuration
+        - Merging dropship routes
+        - Hiding operation section when no routes are available
+    """,
+    'website': 'https://www.odoo.com/app/inventory',
+    'category': 'Inventory/Inventory',
+    'author': 'Himilsinh Sindha (hisi)',
+    'depends': ['stock', 'purchase', 'purchase_stock', 'mrp', 'mrp_subcontracting', 'mrp_subcontracting_dropshipping'],
+    'data': [
+        'views/product_template_views.xml',
+        'data/default_route_data.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+    'license': 'LGPL-3',
+}

--- a/simplified_product_routes/data/default_route_data.xml
+++ b/simplified_product_routes/data/default_route_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Make Buy, manufacture and resupply subcontractor routes warehouse_selectable by default -->
+        <record id="purchase_stock.route_warehouse0_buy" model="stock.route">
+            <field name="warehouse_selectable" eval="True"/>
+        </record>
+        <record id="mrp.route_warehouse0_manufacture" model="stock.route">
+            <field name="warehouse_selectable" eval="True"/>
+        </record>
+        <record id="mrp_subcontracting.route_resupply_subcontractor_mto" model="stock.route">
+            <field name="warehouse_selectable" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/simplified_product_routes/models/__init__.py
+++ b/simplified_product_routes/models/__init__.py
@@ -1,0 +1,3 @@
+from . import mrp_bom
+from . import product_template
+from . import stock_rule

--- a/simplified_product_routes/models/mrp_bom.py
+++ b/simplified_product_routes/models/mrp_bom.py
@@ -1,0 +1,82 @@
+from odoo import api, fields, models
+
+
+class MrpBom(models.Model):
+    """Extends mrp.bom to automatically update routes on product templates
+    
+    This extension ensures that whenever BOMs are created, modified, or deleted,
+    the routes on associated products are automatically updated to maintain
+    consistency with the manufacturing configuration.
+    """
+    _inherit = 'mrp.bom'
+    
+    @api.model
+    def create(self, vals):
+        """Override create to update routes on associated products"""
+        bom = super(MrpBom, self).create(vals)
+        # Update routes for the product
+        if bom.product_tmpl_id:
+            bom.product_tmpl_id._update_routes_based_on_config()
+        
+        # Update routes for components in case of subcontract BoM
+        if bom.type == 'subcontract':
+            component_templates = bom.bom_line_ids.mapped('product_id.product_tmpl_id')
+            if component_templates:
+                component_templates._update_routes_based_on_config()
+        
+        return bom
+    
+    def write(self, vals):
+        """Override write to update routes on associated products"""
+        old_type = {bom.id: bom.type for bom in self}
+        old_lines = {}
+        if 'bom_line_ids' in vals or 'type' in vals:
+            for bom in self:
+                old_lines[bom.id] = bom.bom_line_ids.mapped('product_id.product_tmpl_id')
+        
+        result = super(MrpBom, self).write(vals)
+        
+        # Update routes if type changed or lines changed
+        if 'type' in vals or 'bom_line_ids' in vals:
+            product_templates = self.mapped('product_tmpl_id')
+            product_templates.read(['route_ids'])
+            for bom in self:
+                # Update product routes
+                if bom.product_tmpl_id:
+                    bom.product_tmpl_id._update_routes_based_on_config()
+                
+                # If this is or was a subcontract BoM, update component routes
+                if bom.type == 'subcontract' or old_type.get(bom.id) == 'subcontract':
+                    # Get all affected components (old and new)
+                    component_templates = set()
+                    if bom.id in old_lines:
+                        component_templates.update(old_lines[bom.id].ids)
+                    component_templates.update(bom.bom_line_ids.mapped('product_id.product_tmpl_id').ids)
+                    
+                    # Update routes for all affected components
+                    for template_id in component_templates:
+                        template = self.env['product.template'].browse(template_id)
+                        template._update_routes_based_on_config()
+        
+        return result
+    
+    def unlink(self):
+        """Override unlink to update routes on associated products"""
+        # Store products and component products before deletion
+        products_to_update = self.mapped('product_tmpl_id')
+        subcontract_components = self.env['product.template']
+        
+        for bom in self:
+            if bom.type == 'subcontract':
+                subcontract_components |= bom.bom_line_ids.mapped('product_id.product_tmpl_id')
+        
+        result = super(MrpBom, self).unlink()
+        
+        # Update routes for affected products
+        for product in products_to_update:
+            product._update_routes_based_on_config()
+        
+        for component in subcontract_components:
+            component._update_routes_based_on_config()
+        
+        return result

--- a/simplified_product_routes/models/product_template.py
+++ b/simplified_product_routes/models/product_template.py
@@ -1,0 +1,116 @@
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    has_bom = fields.Boolean(string="Has Bills of Materials", compute="_compute_has_bom", store=True)
+    
+    @api.model
+    def _get_buy_route(self):
+        buy_route = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)
+        if not buy_route:
+            buy_route = self.env['stock.route'].search([('name', '=', 'Buy')], limit=1)
+        return buy_route
+    
+    @api.model
+    def _get_manufacture_route(self):
+        manufacture_route = self.env.ref('mrp.route_warehouse0_manufacture', raise_if_not_found=False)
+        if not manufacture_route:
+            manufacture_route = self.env['stock.route'].search([('name', '=', 'Manufacture')], limit=1)
+        return manufacture_route
+    
+    @api.model
+    def _get_subcontract_route(self):
+        subcontract_route = self.env.ref('mrp_subcontracting.route_resupply_subcontractor_mto', raise_if_not_found=False)
+        if not subcontract_route:
+            subcontract_route = self.env['stock.route'].search(
+                [('name', '=', 'Resupply Subcontractor on Order')], limit=1
+            )
+        return subcontract_route
+    
+    @api.depends('bom_ids')
+    def _compute_has_bom(self):
+        for product in self:
+            product.has_bom = bool(product.bom_ids)
+    
+    @api.onchange('purchase_ok')
+    def _onchange_purchase_ok(self):
+        """Automatically handle buy route when purchase option changes"""
+        buy_route = self._get_buy_route()
+        if not buy_route:
+            return
+            
+        if self.purchase_ok:
+            # Only add if not already in the routes
+            if buy_route.id not in self.route_ids.ids:
+                self.route_ids = [(4, buy_route.id, 0)]
+        else:
+            # Remove from routes
+            if buy_route.id in self.route_ids.ids:
+                self.route_ids = [(3, buy_route.id, 0)]
+    
+    @api.model
+    def create(self, vals):
+        """Override create to automatically manage routes"""
+        product = super(ProductTemplate, self).create(vals)
+        product._update_routes_based_on_config()
+        return product
+    
+    def write(self, vals):
+        """Override write to automatically manage routes"""
+        result = super(ProductTemplate, self).write(vals)
+        if any(field in vals for field in ['purchase_ok', 'route_ids']):
+            self._update_routes_based_on_config()
+        return result
+
+    def _is_subcontract_component(self):
+        """check if product is used as a component in any subcontracting BOM"""
+        self.ensure_one()
+        boms = self.env['mrp.bom'].search([('type', '=', 'subcontract')])
+        for bom in boms:
+            if bom.bom_line_ids.filtered(lambda bom_line: bom_line.product_id.product_tmpl_id.id == self.id):
+                return True
+        return False
+
+    def _update_routes_based_on_config(self):
+        """Update routes based on product configuration
+    
+        This method ensures that routes are correctly assigned based on:
+        - Purchase configuration (Buy route)
+        - Manufacturing configuration (Manufacture route)
+        - Subcontracting usage (Subcontract route)
+        
+        It will add or remove routes as needed without user intervention.
+        """
+        buy_route = self._get_buy_route()
+        manufacture_route = self._get_manufacture_route()
+        subcontract_route = self._get_subcontract_route()
+
+        for product in self:
+            route_commands = []
+            
+            # Handle Buy route
+            if product.purchase_ok and buy_route and buy_route.id not in product.route_ids.ids:
+                route_commands.append((4, buy_route.id, 0))
+            elif not product.purchase_ok and buy_route and buy_route.id in product.route_ids.ids:
+                route_commands.append((3, buy_route.id, 0))
+            
+            # Handle Manufacture route
+            if product.has_bom and manufacture_route and manufacture_route.id not in product.route_ids.ids:
+                route_commands.append((4, manufacture_route.id, 0))
+            elif not product.has_bom and manufacture_route and manufacture_route.id in product.route_ids.ids:
+                route_commands.append((3, manufacture_route.id, 0))
+            
+            # Handle Subcontract route (components used in subcontracting BoMs)  
+            is_subcontract_component = False
+            if subcontract_route:
+                is_subcontract_component = self._is_subcontract_component()
+            
+            if is_subcontract_component and subcontract_route.id not in product.route_ids.ids:
+                route_commands.append((4, subcontract_route.id, 0))
+            elif not is_subcontract_component and subcontract_route.id in product.route_ids.ids:
+                route_commands.append((3, subcontract_route.id, 0))
+            
+            if route_commands:
+                product.write({'route_ids': route_commands})

--- a/simplified_product_routes/models/stock_rule.py
+++ b/simplified_product_routes/models/stock_rule.py
@@ -1,0 +1,29 @@
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+    
+    def _get_stock_move_values(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
+        """Override to skip rules for invalid configurations"""
+        skip_rule = False
+
+        if self.action == 'buy' and not product_id.seller_ids:
+            skip_rule = True
+            
+        if self.action == 'manufacture':
+            bom = self.env['mrp.bom']._bom_find(products=product_id, company_id=company_id)
+            if not bom:
+                skip_rule = True
+        
+        if skip_rule:
+            _logger.info(f"Skipping rule {self.name} for product {product_id.name} due to invalid configuration")
+            return False
+        
+        return super()._get_stock_move_values(
+            product_id, product_qty, product_uom, location_id, name, origin, company_id, values
+        )

--- a/simplified_product_routes/views/product_template_views.xml
+++ b/simplified_product_routes/views/product_template_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_template_form_inherit_simplified_routes" model="ir.ui.view">
+        <field name="name">product.template.form.inherit.simplified.routes</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="stock.view_template_property_form"/>
+        <field name="arch" type="xml">
+            <!-- Hide Operations section if no routes available -->
+            <xpath expr="//page[@name='inventory']//group[@name='operations']" position="attributes">
+                <attribute name="invisible">not route_ids</attribute>
+            </xpath>
+            
+            <!-- Add information about automatic route selection -->
+            <xpath expr="//page[@name='inventory']//field[@name='route_ids']" position="after">
+                <div class="text-muted mt-2" invisible="purchase_ok == False">
+                    <i class="fa fa-info-circle"/> Buy route is automatically added when purchase option is enabled.
+                </div>
+                <div class="text-muted" invisible="purchase_ok == True">
+                    <i class="fa fa-info-circle"/> Routes will be automatically managed based on product configuration.
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this PR:
1) Automatically adds/removes Buy, Manufacture, and Subcontract routes
   based on product configuration.
2) Hides the Operations section when no routes are available and
   adds informative messages for route selection.
3) Updates routes for finished products and components in subcontracting BOMs. 
4) Skips invalid configurations (e.g., buy rule without seller) and logs
   a message.
5) Makes Buy, Manufacture, and Resupply Subcontractor routes selectable by
   default for warehouses.
6) Integrates dropship handling with unified approach for both 
   standard dropshipping and subcontracting dropshipping scenarios.