### PR TITLE
[ADD] simplified_receipt: enable users to print simple receipt

### DIFF
--- a/simplified_receipt/__init__.py
+++ b/simplified_receipt/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/simplified_receipt/__manifest__.py
+++ b/simplified_receipt/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "POS Simplified Receipt",
+    "summary": "",
+    "description": """  """,
+    "depends": ["point_of_sale" , "pos_restaurant"],
+     "data": [
+        "views/res_config_settings_views.xml",
+    ],
+    "assets": {
+        "point_of_sale._assets_pos": [
+            "simplified_receipt/static/src/**/*",
+        ],
+    },
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/simplified_receipt/models/__init__.py
+++ b/simplified_receipt/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_config_settings
+from . import pos_config

--- a/simplified_receipt/models/pos_config.py
+++ b/simplified_receipt/models/pos_config.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class PosConfig(models.Model):
+    _inherit = "pos.config"
+
+    simplified_receipt = fields.Boolean(
+        string="Simplified receipts",
+        help="Print Receipt with no details about the items bought",
+    )

--- a/simplified_receipt/models/res_config_settings.py
+++ b/simplified_receipt/models/res_config_settings.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    
+    _inherit = 'res.config.settings'
+    
+    pos_simplified_receipt = fields.Boolean(related='pos_config_id.simplified_receipt', readonly=False)

--- a/simplified_receipt/static/src/order_receipt/order_receipt.js
+++ b/simplified_receipt/static/src/order_receipt/order_receipt.js
@@ -1,0 +1,33 @@
+import { patch } from "@web/core/utils/patch";
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+
+patch(OrderReceipt, {
+    props: {
+        ...OrderReceipt.props,
+        simplified_receipt: { type: Boolean, optional: true },
+    },
+
+    defaultProps: {
+        ...OrderReceipt.defaultProps,
+        simplified_receipt: true,
+    }
+});
+
+patch(OrderReceipt.prototype, {
+    setup() {
+        super.setup()
+        this.pos = usePos()
+        this.guestLines()
+    },
+
+    guestLines() {
+        let customerCount = this.pos.get_order().getCustomerCount();
+        let totalAmount = parseFloat(this.props.data.total_paid)
+        let items = []
+        for (let i = 0; i < customerCount; i++) {
+            items.push({ id: i, name: `Menuitem ${i + 1}`, price: (totalAmount / customerCount).toFixed(2)});
+        }
+        this.guests = items
+    }
+})

--- a/simplified_receipt/static/src/order_receipt/order_receipt.xml
+++ b/simplified_receipt/static/src/order_receipt/order_receipt.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="order_receipt_template" xml:space="preserve">
+    <t t-name="simplified_receipt.order_receipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
+        <xpath expr="//OrderWidget" position="replace">
+
+            <t t-if="props.simplified_receipt">
+                <t t-foreach="guests" t-as="guest" t-key="guest.id">
+                    <div style="margin-bottom: 8px;">
+                        <span style="font-weight: bold; font-size: 16px; display: block;">
+                            <t t-esc="guest.name"/>
+                        </span>
+                        <span style="margin-left: 20px; display: block; font-size: 14px; color: #555;">
+            1 X $ <t t-esc="guest.price"/> / Units
+                        </span>
+                    </div>
+                </t>
+
+            </t>
+            <t t-else="">
+                <OrderWidget t-if="props.data.orderlines?.length" lines="props.data.orderlines" t-slot-scope="scope" generalNote="props.data.generalNote or ''" screenName="props.data.screenName">
+                    <t t-set="line" t-value="scope.line"/>
+                    <Orderline basic_receipt="props.basic_receipt" line="omit(scope.line, 'customerNote')" class="{ 'px-0': true }" showTaxGroupLabels="showTaxGroupLabels">
+                        <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">
+                            <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
+                            <t t-esc="line.customerNote" />
+                        </li>
+                    </Orderline>
+                </OrderWidget>
+            </t>
+
+        </xpath>
+    </t>
+</templates>

--- a/simplified_receipt/static/src/pos_store.js
+++ b/simplified_receipt/static/src/pos_store.js
@@ -1,0 +1,34 @@
+import { patch } from "@web/core/utils/patch";
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+
+patch(PosStore.prototype, {
+    async setup() {
+        await super.setup(...arguments);  
+    },
+
+    async printReceipt({
+        basic = false,
+        simple = false,
+        order = this.get_order(),
+        printBillActionTriggered = false,
+    } = {}) {
+        const result = await this.printer.print(
+            OrderReceipt,
+            {
+                data: this.orderExportForPrinting(order),
+                formatCurrency: this.env.utils.formatCurrency,
+                basic_receipt: basic,
+                simplified_receipt: simple,
+            },
+            { webPrintFallback: true }
+        );
+        if (!printBillActionTriggered) {
+            order.nb_print += 1;
+            if (typeof order.id === "number" && result) {
+                await this.data.write("pos.order", [order.id], { nb_print: order.nb_print });
+            }
+        }
+        return true;
+    }
+})

--- a/simplified_receipt/static/src/receipt_screen/receipt_screen.xml
+++ b/simplified_receipt/static/src/receipt_screen/receipt_screen.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="receipt_screentemplate" xml:space="preserve">
+    <t t-name="simplified_receipt.receipt_screen" t-inherit="point_of_sale.ReceiptScreen" t-inherit-mode="extension">
+        <xpath expr="//div[@class='d-flex gap-1']" position="inside">
+            <button t-if="pos.config.simplified_receipt" class="button print btn btn-lg btn-secondary w-100 py-3" t-on-click="() => doSimplePrint.call()">
+                <i t-attf-class="fa {{doBasicPrint.status === 'loading' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />
+                    Print Simplified Receipt
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/simplified_receipt/static/src/receipt_screen/reciept_screen.js
+++ b/simplified_receipt/static/src/receipt_screen/reciept_screen.js
@@ -1,0 +1,10 @@
+import { patch } from "@web/core/utils/patch";
+import { useTrackedAsync } from "@point_of_sale/app/utils/hooks";
+import { ReceiptScreen } from "@point_of_sale/app/screens/receipt_screen/receipt_screen";
+
+patch(ReceiptScreen.prototype, {
+    setup() {
+        super.setup();
+        this.doSimplePrint = useTrackedAsync(() => this.pos.printReceipt({ simple: true }));
+    },
+});

--- a/simplified_receipt/views/res_config_settings_views.xml
+++ b/simplified_receipt/views/res_config_settings_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.point_of_sale</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="95"/>
+        <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+
+            <xpath expr="//block[@id='pos_bills_and_receipts_section']" position="inside">
+                <setting help="Print Receipt with no details about the items bought" documentation="/applications/sales/point_of_sale/receipts_invoices.html">
+                    <field name="pos_simplified_receipt"/>
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this commit:
 - Add a "Simplified receipts" menu in the POS configurations.
 - Its enables users to print the receipt after the payment with no details about the items bought.
 - The total paid amount will get divided with total number of guests.
 - Hence each line in receipt will be dedicated to each guests and their respected payable amounts.