### PR TITLE
[ADD] product_category_global_info: add required attribute in global …

### DIFF
--- a/product_category_global_info/__init__.py
+++ b/product_category_global_info/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_category_global_info/__manifest__.py
+++ b/product_category_global_info/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': "Product Category Global Info",
+    'version': '1.0',
+    'summary': 'Extends product category with global info fields and a new tab grouping attributes by category.',
+    'description': """
+                This module extends the product category form by:
+                - Adding a boolean field "Show on Global Info"
+                - Adding a many2many field to map required attributes
+                It also adds a new tab called "Global Info" that displays category and attribute information grouped by product category.
+                """,
+    'category': 'Productivity',
+    'depends': ['stock', 'sale_management'],
+    'data': [
+        'views/product_category_global_info.xml',
+        'views/sale_order_view_inherit.xml',
+    ],
+    'license': 'AGPL-3'
+}

--- a/product_category_global_info/models/__init__.py
+++ b/product_category_global_info/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_category
+from . import sale_order_line

--- a/product_category_global_info/models/product_category.py
+++ b/product_category_global_info/models/product_category.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    show_on_global_info = fields.Boolean(
+        string="Show on Global info",
+        help="If checked, this category will appear in the 'Global Info' tab of Sale Orders.",
+        default=False,
+        store=True
+    )
+
+    required_attribute_ids = fields.Many2many(
+        comodel_name="product.attribute",
+        string="Required Attribute",
+        help="Attributes that must be specified for products in this category."
+    )

--- a/product_category_global_info/models/sale_order_line.py
+++ b/product_category_global_info/models/sale_order_line.py
@@ -1,0 +1,44 @@
+from odoo import  api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    product_category_id = fields.Many2one(
+        comodel_name='product.category',
+        string="Product Category",
+        compute="_compute_product_category",
+        store=True
+    )
+
+    attribute_ids = fields.Many2many(
+        comodel_name='product.attribute',
+        string="Attributes"
+    )
+
+    attribute_value_ids = fields.Many2many(
+        comodel_name='product.attribute.value',
+        string="Attribute Value"
+    )
+
+    @api.depends('product_id')
+    def _compute_product_category(self):
+        for line in self:
+            if line.product_id and line.product_id.categ_id.show_on_global_info:
+                line.product_category_id = line.product_id.categ_id
+            else:
+                line.product_category_id = False
+
+    @api.onchange('product_category_id')
+    def _onchange_product_category(self):
+        if self.product_category_id:
+            required_attributes = self.product_category_id.required_attribute_ids
+            default_attribute_values = []
+            default_attributes = []
+
+            for attribute in required_attributes:
+                selected_value = self.product_template_attribute_value_ids.filtered(lambda v: v.attribute_id == attribute)
+                default_attributes.append(attribute.id)
+                default_attribute_values.append(selected_value.product_attribute_value_id.id)
+            self.attribute_ids = [(6, 0, default_attributes)]
+            self.attribute_value_ids = [(6, 0, default_attribute_values)]

--- a/product_category_global_info/views/product_category_global_info.xml
+++ b/product_category_global_info/views/product_category_global_info.xml
@@ -1,0 +1,13 @@
+<odoo>
+    <record id="view_product_category_form_inherit" model="ir.ui.view">
+        <field name="name">product.category.form.inherit</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="stock.product_category_form_view_inherit"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='removal_strategy_id']" position="after">
+                    <field name="show_on_global_info"/>
+                    <field name="required_attribute_ids" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_category_global_info/views/sale_order_view_inherit.xml
+++ b/product_category_global_info/views/sale_order_view_inherit.xml
@@ -1,0 +1,46 @@
+<odoo>
+
+    <record id="view_sale_order_line_list_global_info" model="ir.ui.view">
+        <field name="name">sale.order.line.list.global.info</field>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <list default_group_by="product_category_id" create="false" delete="false">
+                <field name="product_category_id" string="Product Category"/>
+                <field name="attribute_ids" widget="many2many_tags" string="Attributes"/>
+                <field name="attribute_value_ids" widget="many2many_tags" string="Attribute Values"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_sale_order_global_info" model="ir.ui.view">
+        <field name="name">sale.order.global.info.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Global Info">
+                    <field name="order_line" context="{'list_view_ref': 'product_category_global_info.view_sale_order_line_list_global_info'}"/>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_sale_order_global_info_search" model="ir.ui.view">
+        <field name="name">sale.order.global.info.search</field>
+        <field name="model">sale.order.line</field>
+        <field name="arch" type="xml">
+            <search>
+                <filter name="group_by_product_category" context="{'group_by': 'product_category_id'}"/>
+            </search>
+        </field>
+    </record>
+    <record id="sale_order_view_global_info" model="ir.actions.act_window">
+        <field name="name">Global Info</field>
+        <field name="res_model">sale.order.line</field>
+        <field name="view_id" ref="view_sale_order_line_list_global_info"/>
+        <field name="search_view_id" ref="view_sale_order_global_info_search"/>
+        <field name="view_mode">list</field>
+        <field name="context">{'search_default_group_by_product_category': 1}</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION

--  Added two new options in the product category: one to show it in global info and another for required attributes.
--  Updated the product category form to include these new options. 
-- Ensured that when a product is added to a sale order, it checks if the category should be shown in global info is true and retrieves the related details.
-- Created a new page in the sale order to display these details clearly.