### PR TITLE
[ADD] pos_customer_display: show customer name, order details, and refunds

### DIFF
--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "POS Customer Display",
+    "version": "1.0",
+    "category": "Point of Sale",
+    "description": """
+        Enhances the POS Customer Display by showing customer names, order details, 
+        payment and refund information in a structured format.
+    """,
+    "depends": ["point_of_sale"],
+    "installable": True,
+    "assets": {
+        'point_of_sale.assets_prod': [
+            'pos_customer_display/static/src/pos_order.js',
+        ],
+        'point_of_sale.customer_display_assets': [
+            'pos_customer_display/static/src/customer_display/*',
+        ],
+    },
+    "license": "LGPL-3",
+}
+

--- a/pos_customer_display/static/src/customer_display/customer_display.xml
+++ b/pos_customer_display/static/src/customer_display/customer_display.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_customer.CustomerDisplay" t-inherit="point_of_sale.CustomerDisplay" t-inherit-mode="extension">
+        <xpath expr="//div[@t-if='order.amount and !order.finalized']" position="inside">
+         <div class="d-flex flex-column justify-content-center gap-1 w-100 w-sm-50 ms-auto">
+            <div class="row fw-bolder">
+                <div class="col text-end">Customer</div>
+                <div class="col text-end" t-out="order.partnerName or 'Guest'"/>
+            </div>
+            <div class="row fw-bolder">
+                <t t-if="order.amount_per_guest">
+                    <div class="col text-end">Amount</div>
+                    <div class="col text-end" t-out="format_float(order.amount_per_guest, 2)"/>/ Guest
+                </t>
+            </div>
+         </div>
+        </xpath>
+        <xpath expr="//div[hasclass('o_customer_display_main')]/OrderWidget" position="replace">
+            <OrderWidget t-if="!order.finalized" lines="order.lines"/>
+            <t t-if="order.refundLines">
+                <div class="mt-3 p-2 fw-bold">Refund</div>
+                <OrderWidget t-if="!order.finalized" lines="order.refundLines"/>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/pos_customer_display/static/src/pos_order.js
+++ b/pos_customer_display/static/src/pos_order.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+
+patch(PosOrder.prototype, {
+    getCustomerDisplayData() {
+        const lines = this.getSortedOrderlines();
+        const refundLines = lines.filter((l) => l.refunded_orderline_id);
+        const nonRefundLines = lines.filter((l) => !l.refunded_orderline_id);
+
+        return {
+            ...super.getCustomerDisplayData(),
+
+            partnerName: this.get_partner_name() ? this.get_partner_name() : "Guest",
+            amount_per_guest: this.amountPerGuest,
+            refundLines: refundLines.map((l) => l.getDisplayData()),
+            lines: nonRefundLines.map((l) => l.getDisplayData()),
+        };
+    },
+});


### PR DESCRIPTION
This module improves the POS Customer Display by providing structured information about the order:

- Displays customer name if available, otherwise shows Guest.
- Shows order amount and amount per guest for better transparency.
- Separates refund items from regular order lines.