### PR TITLE
[IMP] cashfree_esign : added the sign verification using cashfree portal

### DIFF
--- a/cashfree_esign/__init__.py
+++ b/cashfree_esign/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers
+from . import models

--- a/cashfree_esign/__manifest__.py
+++ b/cashfree_esign/__manifest__.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+  'name': 'CashFree ESign',
+  'version': '1.0',
+  'depends': ['sign'],
+  'category': 'Sales/Sign',
+  'author': 'BHPR',
+  'description': "Integrates Cashfree eSign API for Aadhaar-based document signing workflow.",
+  'data': [
+      'report/sign_log_report.xml',
+      'views/res_config_settings.xml'
+   ],
+   'assets': {
+      'web.assets_backend': [
+          'cashfree_esign/static/src/**/*',
+      ],
+      'sign.assets_public_sign': [
+          'cashfree_esign/static/src/**/*',
+      ]
+   },
+   'license': 'OEEL-1',
+}

--- a/cashfree_esign/controllers/__init__.py
+++ b/cashfree_esign/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sign

--- a/cashfree_esign/controllers/sign.py
+++ b/cashfree_esign/controllers/sign.py
@@ -1,0 +1,196 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+import datetime
+import io
+import json
+
+import requests
+from requests.exceptions import RequestException
+from werkzeug.urls import url_join
+
+from odoo import http
+from odoo.addons.sign.controllers.main import Sign
+from odoo.exceptions import AccessError, MissingError
+from odoo.http import request
+from odoo.tools.pdf import PdfFileReader, PdfReadError
+
+CASHFREE_API_BASE_URL = 'https://sandbox.cashfree.com/verification/esignature'
+
+
+class SignController(Sign):
+
+    def _validate_auth_method(self, request_item_sudo, sms_token=None):
+        if request_item_sudo.role_id.auth_method == 'aadhar_esign':
+            return {'success': True}
+        super()._validate_auth_method(request_item_sudo, sms_token)
+
+    @http.route('/sign/upload_document', type='http', auth='public', methods=['POST'], csrf=False, cors='*')
+    def upload_document(self):
+        file = request.httprequest.files.getlist('document')
+        Config = request.env['ir.config_parameter'].sudo()
+
+        client_id = Config.get_param('cashfree_client_id')
+        client_secret = Config.get_param('cashfree_client_secret')
+
+        if not file:
+            return json.dumps({'error': 'No document uploaded'})
+        file_data = file[0].read()
+        url = url_join(CASHFREE_API_BASE_URL + '/', 'document')
+        headers = {
+            'x-client-id': str(client_id),
+            'x-client-secret': str(client_secret),
+        }
+        files = {
+            'document': (file[0].filename, file_data)
+        }
+        response = requests.post(url, headers=headers, files=files)
+        return json.dumps(response.json())
+
+    @http.route('/sign/verify_esignature', type='http', auth='public', csrf=False, cors='*')
+    def verify_esignature(self):
+        verification_id = request.params.get('verification_id')
+        Config = request.env['ir.config_parameter'].sudo()
+
+        client_id = Config.get_param('cashfree_client_id')
+        client_secret = Config.get_param('cashfree_client_secret')
+
+        headers = {
+            "x-client-id": str(client_id),
+            "x-client-secret": str(client_secret)
+        }
+        params = {
+            "verification_id": verification_id
+        }
+        try:
+            response = requests.get(CASHFREE_API_BASE_URL, headers=headers, params=params)
+            return json.dumps(response.json())
+        except RequestException as e:
+            return {"status": "ERROR", "message": str(e)}
+
+    @http.route('/e_sign/create_request', type='http', auth='public', methods=['POST'], csrf=False)
+    def send_signer_details(self):
+        signers_list = []
+        Config = request.env['ir.config_parameter'].sudo()
+        client_id = Config.get_param('cashfree_client_id')
+        client_secret = Config.get_param('cashfree_client_secret')
+        user_data = request.httprequest.get_data()
+        parsed_data = json.loads(user_data.decode("utf-8"))
+        document_id = parsed_data.get("document_id")
+        verification_id = parsed_data.get("verification_id")
+        expiry_days = parsed_data.get("expiry_days")
+        signers = parsed_data.get("signers")
+        redirect_url = parsed_data.get("redirect_url")
+        if expiry_days > 15:
+            expiry_days = 15
+        for index, signer in enumerate(signers, start=1):
+            signer_data = {
+                "name": str(signer['name']),
+                "email": str(signer['email']),
+                "sequence": index,
+                "sign_positions": [
+                    {
+                        "page": int(pos['page']),
+                        "top_left_x_coordinate": int(pos['top_left_x_coordinate']),
+                        "bottom_right_x_coordinate": int(pos['bottom_right_x_coordinate']),
+                        "top_left_y_coordinate": int(pos['top_left_y_coordinate']),
+                        "bottom_right_y_coordinate": int(pos['bottom_right_y_coordinate'])
+                    }
+                    for pos in signer['sign_positions']
+                ],
+                "phone": signer.get('phone'),
+                "aadhaar_last_four_digit": str(signer.get('aadhaar_last_four_digit')),
+            }
+            signers_list.append(signer_data)
+            payload = {
+                "verification_id": str(verification_id),
+                "document_id": document_id,
+                "notification_modes": ["email"],
+                "auth_type": "AADHAAR",
+                "expiry_in_days": str(expiry_days),
+                "signers": signers_list,
+                "redirect_url": redirect_url
+            }
+            headers = {
+                "x-client-id": str(client_id),
+                "x-client-secret": str(client_secret),
+                "Content-Type": "application/json"
+            }
+            try:
+                response = requests.post(
+                    CASHFREE_API_BASE_URL,
+                    json=payload,
+                    headers=headers,
+                    timeout=10
+                )
+                res_data = json.dumps(response.json())
+                return res_data
+            except requests.exceptions.RequestException as e:
+                return {"status": "ERROR", "message": str(e)}
+
+    @http.route(['/sign/data/<int:request_id>/<token>'], auth='public')
+    def get_data(self, request_id, token):
+        try:
+            sign_request = http.request.env['sign.request'].sudo().browse(request_id).exists()
+            if not sign_request or sign_request.access_token != token:
+                return http.request.not_found()
+            validity_date = sign_request.validity
+            today = datetime.date.today()
+            expiry_in_days = (validity_date - today).days if validity_date else 0
+            signers_data = []
+            old_pdf = PdfFileReader(io.BytesIO(base64.b64decode(sign_request.template_id.attachment_id.datas)), strict=False, overwriteWarnings=False)
+            itemsByPage = sign_request.template_id._get_sign_items_by_page()
+            for signer in sign_request.request_item_ids:
+                signer_info = {
+                    'name': signer.partner_id.name,
+                    'email': signer.partner_id.email,
+                    'phone': signer.partner_id.phone,
+                    'sign_positions': []
+                }
+                for p in range(0, old_pdf.getNumPages()):
+                    page = old_pdf.getPage(p)
+                    width = float(abs(page.mediaBox.getWidth()))
+                    height = float(abs(page.mediaBox.getHeight()))
+                    items = itemsByPage.get(p + 1, [])
+                    for item in items:
+                        if item.responsible_id.name == signer.role_id.name:
+                            signer_info['sign_positions'].append({
+                                'page': item.page,
+                                'top_left_X': int(width * item.posX),
+                                'top_left_Y': int(height * (1 - item.posY)),
+                                'bottom_right_X': int(width * item.posX) + (width * item.width),
+                                'bottom_right_Y': int(height * (1 - item.height - item.posY)),
+                            })
+                signers_data.append(signer_info)
+            result = {
+                'filename': f"{sign_request.reference}",
+                'mimetype': 'application/pdf',
+                'expiry_in_days': expiry_in_days,
+                'signers': signers_data,
+            }
+            res_data = json.dumps(result)
+            return res_data
+        except PdfReadError as e:
+            return http.Response(json.dumps({"error": "PDF error: " + str(e)}), content_type='application/json', status=500)
+        except (AttributeError, TypeError, KeyError) as e:
+            return http.Response(json.dumps({"error": "Data error: " + str(e)}), content_type='application/json', status=500)
+
+    @http.route(['/sign/file/<int:request_id>/<token>'], auth='public')
+    def get_file(self, request_id, token):
+        try:
+            sign_request = http.request.env['sign.request'].sudo().browse(request_id).exists()
+            if not sign_request or sign_request.access_token != token:
+                return http.request.not_found()
+            document = None
+            if sign_request.completed_document:
+                document = sign_request.completed_document
+            elif sign_request.template_id.attachment_id:
+                document = sign_request.template_id.attachment_id.datas
+            if not document:
+                return {'error': 'Document not found'}
+            document = base64.b64decode(document)
+            return http.Response(document, headers=[
+                ('Content-Type', 'application/pdf'),
+            ])
+        except (AccessError, MissingError) as e:
+            return http.Response(json.dumps({"error": str(e)}), content_type='application/json', status=500)

--- a/cashfree_esign/models/__init__.py
+++ b/cashfree_esign/models/__init__.py
@@ -1,0 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import res_config_settings
+from . import sign_request
+from . import sign_item_party

--- a/cashfree_esign/models/res_config_settings.py
+++ b/cashfree_esign/models/res_config_settings.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    module_cashfree_esign = fields.Boolean(
+        string="Sign With Aadhaar eSign",
+        default=False,
+        config_parameter='ESigner.esign_enabled',
+    )
+
+    cashfree_client_id = fields.Char('Cashfree Client ID', config_parameter='cashfree_client_id')
+    cashfree_client_secret = fields.Char('Cashfree Client Secret', config_parameter='cashfree_client_secret')

--- a/cashfree_esign/models/sign_item_party.py
+++ b/cashfree_esign/models/sign_item_party.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SignItemParty(models.Model):
+    _inherit = 'sign.item.role'
+
+    auth_method = fields.Selection(
+        selection_add=[('aadhar_esign', 'Aadhaar e-Sign')],
+        ondelete={'aadhar_esign': 'set default'}
+    )

--- a/cashfree_esign/models/sign_request.py
+++ b/cashfree_esign/models/sign_request.py
@@ -1,0 +1,155 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+import io
+import time
+
+from reportlab.pdfgen import canvas
+from reportlab.lib.utils import ImageReader
+from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError
+
+from odoo import models, Command, _
+from odoo.exceptions import ValidationError
+from odoo.tools import format_date
+from odoo.tools.misc import file_path
+from odoo.tools.pdf import PdfFileReader, PdfFileWriter, PdfReadError
+
+
+def _fix_image_transparency(image):
+    pixels = image.load()
+    for x in range(image.size[0]):
+        for y in range(image.size[1]):
+            if pixels[x, y] == (0, 0, 0, 0):
+                pixels[x, y] = (255, 255, 255, 0)
+
+
+class SignRequest(models.Model):
+    _name = 'sign.request'
+    _inherit = 'sign.request'
+
+    def _generate_completed_document(self):
+        self.ensure_one()
+        super()._generate_completed_document()
+        try:
+            old_pdf = PdfFileReader(io.BytesIO(base64.b64decode(self.completed_document)), strict=False, overwriteWarnings=False)
+            old_pdf.getNumPages()
+        except (PdfReadError, Exception):
+            raise ValidationError(_("ERROR: Invalid PDF file!"))
+
+        packet = io.BytesIO()
+        can = canvas.Canvas(packet, pagesize=self.get_page_size(old_pdf))
+        itemsByPage = self.template_id._get_sign_items_by_page()
+        items_ids = [id for items in itemsByPage.values() for id in items.ids]
+        values_dict = self.env['sign.request.item.value']._read_group(
+            [('sign_item_id', 'in', items_ids), ('sign_request_id', '=', self.id)],
+            groupby=['sign_item_id'],
+            aggregates=['value:array_agg', 'frame_value:array_agg', 'frame_has_hash:array_agg']
+        )
+        values = {
+                sign_item.id: {
+                    'value': values[0],
+                    'frame': frame_values[0],
+                    'frame_has_hash': frame_has_hashes[0],
+                }
+                for sign_item, values, frame_values, frame_has_hashes in values_dict
+        }
+
+        for p in range(0, old_pdf.getNumPages()):
+            page = old_pdf.getPage(p)
+            width = float(abs(page.mediaBox.getWidth()))
+            height = float(abs(page.mediaBox.getHeight()))
+            items = itemsByPage.get(p + 1, [])
+            for item in items:
+                value_dict = values.get(item.id)
+                if not value_dict:
+                    continue
+                value = value_dict['value']
+                if item.type_id.item_type == "signature":
+                    try:
+                        if item.responsible_id.auth_method == 'aadhar_esign':
+                            email = ""
+                            for x in self.request_item_ids:
+                                if x.role_id.id == item.responsible_id.id:
+                                    email = x.partner_id.email
+                                    break
+                            modified_sign = self.modify_signature(value[value.find(',') + 1:], email)
+                            image_reader = ImageReader(io.BytesIO(base64.b64decode(modified_sign)))
+                        else:
+                            image_reader = ImageReader(io.BytesIO(base64.b64decode(value[value.find(',') + 1:])))
+                    except UnidentifiedImageError:
+                        raise ValidationError(_("There was an issue downloading your document. Please contact an administrator."))
+                    _fix_image_transparency(image_reader._image)
+                    can.drawImage(image_reader, width * item.posX, height * (1 - item.posY - item.height), width * item.width, height * item.height, 'auto', True)
+            can.showPage()
+        can.save()
+        item_pdf = PdfFileReader(packet, overwriteWarnings=False)
+        new_pdf = PdfFileWriter()
+
+        for p in range(0, old_pdf.getNumPages()):
+            page = old_pdf.getPage(p)
+            page.mergePage(item_pdf.getPage(p))
+            new_pdf.addPage(page)
+        try:
+            output = io.BytesIO()
+            new_pdf.write(output)
+        except PdfReadError:
+            raise ValidationError(_("There was an issue downloading your document. Please contact an administrator."))
+
+        self.completed_document = base64.b64encode(output.getvalue())
+        output.close()
+        attachment = self.env['ir.attachment'].create({
+            'name': "%s.pdf" % self.reference if self.reference.split('.')[-1] != 'pdf' else self.reference,
+            'datas': self.completed_document,
+            'type': 'binary',
+            'res_model': self._name,
+            'res_id': self.id,
+        })
+        public_user = self.env.ref('base.public_user', raise_if_not_found=False)
+        if not public_user:
+            public_user = self.env.user
+        pdf_content, __ = self.env["ir.actions.report"].with_user(public_user).sudo()._render_qweb_pdf(
+            'sign.action_sign_request_print_logs',
+            self.ids,
+            data={'format_date': format_date, 'company_id': self.communication_company_id}
+        )
+        attachment_log = self.env['ir.attachment'].create({
+            'name': "Certificate of completion - %s.pdf" % time.strftime('%Y-%m-%d - %H:%M:%S'),
+            'raw': pdf_content,
+            'type': 'binary',
+            'res_model': self._name,
+            'res_id': self.id,
+        })
+        self.completed_document_attachment_ids = [Command.set([attachment.id, attachment_log.id])]
+
+    def modify_signature(self, signature_data, email):
+        image_file = base64.b64decode(signature_data)
+        image = Image.open(io.BytesIO(image_file))
+
+        width, height = image.size
+        draw = ImageDraw.Draw(image)
+        font_size = int(height * 0.15)
+        try:
+            font_type = 'Reg'
+            lato_path = f'web/static/fonts/lato/Lato-{font_type}-webfont.ttf'
+            font = ImageFont.truetype(file_path(lato_path), font_size)
+        except OSError:
+            font = ImageFont.load_default()
+
+        text = "Aadhar Esign by " + email
+        text_color = (0, 0, 255)
+
+        bbox = draw.textbbox((0, 0), text, font=font)
+        text_width, text_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+        while text_width > width - 20 and font_size > 10:
+            font_size -= 2
+            font_type = 'Reg'
+            lato_path = f'web/static/fonts/lato/Lato-{font_type}-webfont.ttf'
+            font = ImageFont.truetype(file_path(lato_path), font_size)
+            bbox = draw.textbbox((0, 0), text, font=font)
+            text_width, text_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        x, y = (width - text_width) // 2, height - text_height - 10
+        draw.text((x, y), text, font=font, fill=text_color)
+        buffered = io.BytesIO()
+        image.save(buffered, format="PNG")
+        return base64.b64encode(buffered.getvalue()).decode()

--- a/cashfree_esign/report/sign_log_report.xml
+++ b/cashfree_esign/report/sign_log_report.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <template id="sign_request_logs_user_inherit" inherit_id="sign.sign_request_logs_user">
+        <xpath expr="//thead/tr/th[@id='participants_email_verification']" position="after">
+            <t t-if="o.sudo().request_item_ids.filtered(lambda sri: sri.role_id.auth_method == 'aadhar_esign')">
+                 <th id="participants_authentication" class="text-start">Authentication Type</th>
+            </t>
+        </xpath>
+        <xpath expr="//tbody/t/tr/td[hasclass('text-center')]" position="after">
+            <td>
+                <t t-if="sri.role_id.auth_method == 'aadhar_esign'">
+                  <span t-field="sri.partner_id.name">John Smith</span>
+                  <span> on </span>
+                  <span t-field="sri.signing_date">31-03-2025</span>
+                  <span>(Aadhar) eSign</span>
+                </t>
+            </td>
+        </xpath>
+    </template>
+</odoo>

--- a/cashfree_esign/static/src/components/dialogs/mobile_aadhaar_dialog.js
+++ b/cashfree_esign/static/src/components/dialogs/mobile_aadhaar_dialog.js
@@ -1,0 +1,36 @@
+/** @odoo-module **/
+
+import { Dialog } from "@web/core/dialog/dialog";
+import { useService } from "@web/core/utils/hooks";
+import { Component, useState } from "@odoo/owl";
+
+export class MobileAadharDialog extends Component {
+    static template = "cashfree_esign.MobileAadharDialog";
+    static components = { Dialog };
+
+    setup() {
+        this.dialog = useService("dialog");
+        this.state = useState({ 
+            mobile: "", 
+            aadhaar: "" 
+        });
+    }
+
+    submitForm() {
+        if (this.state.mobile.length !== 10) {
+            alert("Mobile number must be 10 digits.");
+            return;
+        }
+        if (this.state.aadhaar.length !== 4) {
+            alert("Aadhaar number must be last 4 digits.");
+            return;
+        }
+        if (this.props.onSubmit) {
+            this.props.onSubmit({
+                mobile: this.state.mobile,
+                aadhaar: this.state.aadhaar
+            });
+        }
+        this.props.close(); 
+    }  
+}

--- a/cashfree_esign/static/src/components/dialogs/mobile_aadhaar_dialog.xml
+++ b/cashfree_esign/static/src/components/dialogs/mobile_aadhaar_dialog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="cashfree_esign.MobileAadharDialog">
+        <Dialog>
+            <t t-set-slot="header">
+                <h4 class="modal-title">Please submit the details to proceed to the <strong>Cashfree Aadhaar eSign</strong> portal for signing process</h4>
+            </t>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label class="form-label">Mobile Number</label>
+                    <input type="text" class="form-control" t-model="state.mobile" placeholder="Enter Mobile Number"/>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Aadhaar last 4 Number</label>
+                    <input type="text" class="form-control" t-model="state.aadhaar" placeholder="Enter Aadhaar Number"/>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-secondary" t-on-click="props.close">Cancel</button>
+                <button class="btn btn-primary" t-on-click="submitForm">Submit</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/cashfree_esign/static/src/components/sign_request/signable_PDF_iframe.js
+++ b/cashfree_esign/static/src/components/sign_request/signable_PDF_iframe.js
@@ -1,0 +1,158 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { MobileAadharDialog } from "../dialogs/mobile_aadhaar_dialog";
+import { SignablePDFIframe } from "@sign/components/sign_request/signable_PDF_iframe";
+
+patch(SignablePDFIframe.prototype, {
+
+    setup() {
+        this.signInfo = useService("signInfo");
+        this.dialog = useService("dialog");
+        this.ui = useService("ui")
+    },
+
+    async getAuthDialog() {
+        if (this.props.authMethod === 'aadhar_esign') {
+            return {
+                component: MobileAadharDialog,
+                props: {
+                    onSubmit: async (userData) => {
+                        this.signInfo.set("mobileNumber", userData.mobile);
+                        this.signInfo.set("aadhaarNumber", userData.aadhaar);
+                        this.ui.block();
+                        await this.fetchSignedDocument(userData.mobile, userData.aadhaar);
+                        this.ui.unblock();
+                    }
+                }
+            }
+        }
+        return super.getAuthDialog();
+    },
+
+    generateVerificationId(length = 10) {
+        const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        let verificationId = "";
+        for (let i = 0; i < length; i++) {
+            verificationId += characters.charAt(Math.floor(Math.random() * characters.length));
+        }
+        return verificationId;
+    },
+
+    async fetchSignedDocument(mobile, aadhaar) {
+
+        const req_id = this.signInfo.get("documentId");
+        const token = this.signInfo.get("signRequestToken");
+        const url1 = `/sign/data/${req_id}/${token}`;
+        const url2 = `/sign/file/${req_id}/${token}`;
+
+        try {
+            const data1 = await fetch(url1, {
+                method: "GET",
+            });
+            const data2 = await fetch(url2, {
+                method: "GET",
+            });
+            const response = await data1.json();
+            const pdfBlob = await data2.blob();
+            const formData = new FormData();
+            formData.append("document", pdfBlob, response.filename); 
+            const uploadResponse = await fetch("/sign/upload_document", {
+                method: "POST",
+                body: formData,
+            });
+            const result = await uploadResponse.json();
+            const verification_id = this.generateVerificationId()
+            const expiry_days = response.expiry_in_days
+            const redirect_url = "";
+            const signers = response.signers.map((signer, index) => ({
+                name: signer.name,
+                email: signer.email,
+                sequence: index + 1, 
+                sign_positions: signer.sign_positions.map(pos => ({
+                    page: pos.page,
+                    top_left_x_coordinate: pos.top_left_X,
+                    bottom_right_x_coordinate: pos.bottom_right_X,
+                    top_left_y_coordinate: pos.top_left_Y,
+                    bottom_right_y_coordinate: pos.bottom_right_Y
+                })),
+                phone: mobile, 
+                aadhaar_last_four_digit: aadhaar
+            }));
+            if (result.document_id) {
+                this.sendSignerDetails(verification_id, result.document_id, expiry_days, signers, redirect_url);
+            }   
+        } catch (error) {
+            console.log(error)
+        } 
+    },  
+
+    async sendSignerDetails(verification_id, document_id, expiry_in_days, signers, redirect_url) {
+        try {
+            const response = await fetch("/e_sign/create_request", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    verification_id: verification_id,
+                    document_id: document_id,
+                    expiry_days: expiry_in_days,
+                    signers: signers,
+                    redirect_url: redirect_url
+                }),
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const responseData = await response.json();
+            if (responseData.signing_link) {
+                const signingLink = responseData.signing_link;
+                const newTab = window.open(signingLink, '_blank');
+                this.ui.block();
+                const interval = setInterval(() => {
+                    if (newTab.closed) {
+                        clearInterval(interval);
+                        window.focus();
+                        this.verifyEsignature(verification_id); 
+                    }
+                }, 1000);  
+            } else {
+                console.error("Signing link not found in response!");
+            } 
+        } catch (error) {
+            console.error("Error sending signer details:", error);
+        }
+    },
+
+    async verifyEsignature(verification_id) {
+        try {
+            const response = await fetch(`/sign/verify_esignature?verification_id=${verification_id}`, {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json"
+                }
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+            }
+            const responseData = await response.json();
+            this.ui.unblock();
+            if (responseData.status == 'SUCCESS') {               
+                this._sign();
+            } else {
+                this.dialog.add(ConfirmationDialog, {
+                    title: _t("Verification Failed"),
+                    body: "Your signature verification process via Cashfree portal could not be completed. Please try again..."
+                });
+            }
+            return responseData;
+        } catch (error) {
+            console.error("Error verifying e-signature:", error);
+            alert("An error occurred while verifying e-signature.");
+        }
+    }, 
+});

--- a/cashfree_esign/views/res_config_settings.xml
+++ b/cashfree_esign/views/res_config_settings.xml
@@ -1,0 +1,16 @@
+<odoo>
+  <record id="res_config_settings_view_form_inherit_sign_aadhar" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.sign.aadhar</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="55"/>
+        <field name="inherit_id" ref="sign.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+          <xpath expr="//app[@name='sign']/block[@name='sign']/setting[5]" position="inside">
+            <setting id="esign_enabled"
+              help="Sign your important documents using Aadhaar eSign">
+                <field name="module_cashfree_esign" />
+            </setting>
+          </xpath>
+        </field>
+  </record>
+</odoo>


### PR DESCRIPTION
In this PR, I have implemented Aadhaar-based e-sign verification functionality using the Cashfree portal. The key changes include:

 - Module Settings Control : Added a checkbox in the settings to enable/disable the Aadhaar E-Verification feature. If 
   unchecked, the cashfree_esign module will not run and will uninstall automatically.
- Role-Based Authentication : Introduced a new option "Aadhaar eSign" in the Extra Authentication Step field to 
  enable Aadhaar verification for specific user roles.
- User Input for Verification : When the user clicks to validate the document, they are prompted to enter their mobile number 
  and the last 4 digits of their Aadhaar.
- Redirection to Cashfree Portal : After submitting the details, the user is redirected to the Cashfree portal to complete 
  Aadhaar-based verification.
- Successful Verification Flow : Upon successful verification, the user is allowed to download the final signed document.
- Final Signed Document : The final signed Document includes the user's email  and displays "Aadhaar E-Sign" as the 
  authentication type in the digital certificate.
- Failed Verification Handling : If the Aadhaar verification fails, the user is redirected back to the validation step where they  
  can retry the verification process.