### PR TITLE
[ADD] vc_tagging: automate dropshipping by tagging vendor and customer.

### DIFF
--- a/vc_tagging/__init__.py
+++ b/vc_tagging/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/vc_tagging/__manifest__.py
+++ b/vc_tagging/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'V&C Tagging',
+    'version': '1.0',
+    'description' : """
+Automates dropshipping by tagging vendor and customer in SO, PO and Picking.
+""",
+    'depends': ['contacts', 'purchase', 'sale_management', 'stock'],
+    'data': [
+        'views/purchase_order_views.xml',
+        'views/res_partner_views.xml',
+        'views/sale_order_views.xml',
+        'views/stock_picking_views.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/vc_tagging/models/__init__.py
+++ b/vc_tagging/models/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import purchase_order
+from . import purchase_order_line
+from . import res_partner
+from . import sale_order
+from . import sale_order_line
+from . import stock_picking
+from . import stock_rule

--- a/vc_tagging/models/purchase_order.py
+++ b/vc_tagging/models/purchase_order.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    sale_order_id = fields.Many2one('sale.order', string='Source Sales Order')
+    warehouse_partner_id = fields.Many2one("res.partner", string="Warehouse")
+    is_dropshipping = fields.Boolean(string="Is Dropshipping", compute="_compute_is_dropshipping", store=True)
+
+    @api.depends('sale_order_id')
+    def _compute_is_dropshipping(self):
+        for order in self:
+            order.is_dropshipping = order.sale_order_id

--- a/vc_tagging/models/purchase_order_line.py
+++ b/vc_tagging/models/purchase_order_line.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    @api.model
+    def _prepare_purchase_order_line(self, product_id, product_qty, product_uom, company_id, supplier, po):
+        """Prepare purchase order line with vendor-specific pricing if available."""
+        values = super()._prepare_purchase_order_line(product_id, product_qty, product_uom, company_id, supplier, po)
+
+        vendor = next((supplier for supplier in product_id.seller_ids if supplier.partner_id == po.partner_id), None)
+        values['price_unit'] = vendor.price if vendor else product_id.standard_price
+
+        return values

--- a/vc_tagging/models/res_partner.py
+++ b/vc_tagging/models/res_partner.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    is_vendor = fields.Boolean(string="Is a vendor")

--- a/vc_tagging/models/sale_order.py
+++ b/vc_tagging/models/sale_order.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    vendor_id = fields.Many2one("res.partner", string="Vendor", domain="[('is_vendor', '=', True)]")
+    warehouse_partner_id = fields.Many2one("res.partner", string="Warehouse", domain="[('parent_id', '=', vendor_id), ('type', '=', 'delivery')]")
+           
+    @api.onchange('vendor_id', 'warehouse_partner_id')
+    def _onchange_vendor_warehouse(self):
+        for line in self.order_line:
+            line.vendor_id = self.vendor_id
+            line.warehouse_partner_id = self.warehouse_partner_id
+        
+    @api.onchange('vendor_id')
+    def _onchange_vendor(self):
+        if not self.vendor_id:
+            self.warehouse_partner_id = False;
+        else:
+            warehouse_partner = self.env["res.partner"].search([("parent_id", "=", self.vendor_id.id), ("type", "=", "delivery")])
+            self.warehouse_partner_id = warehouse_partner[0] if warehouse_partner else False;
+
+    @api.onchange('warehouse_partner_id')
+    def _onchange_warehouse(self):
+        if not self.warehouse_partner_id:
+            self.vendor_id = False
+
+    def action_confirm(self):  
+        """Link confirmed sale orders to corresponding purchase orders by setting the sale_order_id field"""
+        res = super().action_confirm()
+        for order in self:
+            purchase_orders = self.env["purchase.order"].search([("origin", "=", order.name)])
+            for po in purchase_orders:
+                po.write({"sale_order_id": order.id})
+        return res

--- a/vc_tagging/models/sale_order_line.py
+++ b/vc_tagging/models/sale_order_line.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    vendor_id = fields.Many2one('res.partner', string="Vendor", domain="[('is_vendor', '=', True)]")
+    warehouse_partner_id = fields.Many2one('res.partner', string="Warehouse", domain="[('parent_id', '=', vendor_id), ('type', '=', 'delivery')]")
+    is_readonly = fields.Boolean(string="Is readonly", compute="_compute_readonly")
+
+    @api.depends('order_id.vendor_id', 'order_id.warehouse_partner_id')
+    def _compute_readonly(self):
+        for line in self:
+            line.is_readonly = not (line.order_id.vendor_id and line.order_id.warehouse_partner_id)
+
+    @api.onchange('order_id')
+    def _onchange_order_id(self):
+        self.vendor_id = self.order_id.vendor_id
+        self.warehouse_partner_id = self.order_id.warehouse_partner_id
+
+    @api.onchange('vendor_id')
+    def _onchange_vendor(self):
+        warehouse_partner = self.env["res.partner"].search([("parent_id", "=", self.vendor_id.id), ("type", "=", "delivery")])
+        self.warehouse_partner_id = warehouse_partner[0] if warehouse_partner else False;
+
+    @api.onchange('warehouse_partner_id')
+    def _onchange_warehouse(self):
+        if not self.warehouse_partner_id:
+            self.vendor_id = False

--- a/vc_tagging/models/stock_picking.py
+++ b/vc_tagging/models/stock_picking.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    vendor_id = fields.Many2one('res.partner', string="Vendor", related="move_ids.sale_line_id.vendor_id", store=True)
+    warehouse_partner_id = fields.Many2one('res.partner', string="Warehouse", related="move_ids.sale_line_id.warehouse_partner_id", store=True)
+    is_dropshipping = fields.Boolean(string="Is Dropshipping", compute="_compute_is_dropshipping", store=True)
+
+    @api.depends('picking_type_id')
+    def _compute_is_dropshipping(self):
+        for record in self:
+            record.is_dropshipping = record.picking_type_id.code == 'dropship'

--- a/vc_tagging/models/stock_rule.py
+++ b/vc_tagging/models/stock_rule.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _make_po_get_domain(self, company_id, values, partner):
+        """Modify the purchase order domain to ensure the correct vendor is selected based on the sale order line."""
+        domain = super()._make_po_get_domain(company_id, values, partner)
+        sale_line_id = values.get('sale_line_id') if values else False
+        if sale_line_id:
+            sale_order_line = self.env['sale.order.line'].browse(sale_line_id)
+            if sale_order_line and sale_order_line.vendor_id:
+                domain = list(domain)
+                domain[0] = ('partner_id', '=', sale_order_line.vendor_id.id)
+        return tuple(domain)
+
+    def _prepare_purchase_order(self, company_id, origins, values):
+        """Prepare purchase order with vendor and warehouse details based on the sale order line."""
+        res = super()._prepare_purchase_order(company_id, origins, values)
+        sale_line_id = values[0].get('sale_line_id') if values else False
+        if sale_line_id:
+            sale_order_line = self.env['sale.order.line'].browse(sale_line_id)
+            if sale_order_line and sale_order_line.vendor_id:
+                res.update({
+                    'partner_id': sale_order_line.vendor_id.id,
+                    'warehouse_partner_id': sale_order_line.warehouse_partner_id.id
+                })
+        return res

--- a/vc_tagging/views/purchase_order_views.xml
+++ b/vc_tagging/views/purchase_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_order_form_inherit" model="ir.ui.view">
+        <field name="name">purchase.order.form.inherit.dropshipping</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_ref']" position="after">
+                <field name="warehouse_partner_id" invisible="is_dropshipping == False"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/vc_tagging/views/res_partner_views.xml
+++ b/vc_tagging/views/res_partner_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_partner_view_form" model="ir.ui.view">
+        <field name="name">res.partner.view.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='category_id']" position="after">
+                <field name="is_vendor"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/vc_tagging/views/sale_order_views.xml
+++ b/vc_tagging/views/sale_order_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">sale.order.view.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="vendor_id" options="{'no_create': True}"/>
+                <field name="warehouse_partner_id" options="{'no_create': True}"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='name']" position="after">
+                <field name="vendor_id" readonly="is_readonly == True" force_save="1" options="{'no_create': True}"/>
+                <field name="warehouse_partner_id" readonly="is_readonly == True" force_save="1" options="{'no_create': True}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/vc_tagging/views/stock_picking_views.xml
+++ b/vc_tagging/views/stock_picking_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_form_inherit_vendor" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit.vendor</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='picking_type_id']" position="after">
+                <field name="vendor_id" invisible="is_dropshipping == False"/>
+                <field name="warehouse_partner_id" invisible="is_dropshipping == False"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this commit:
- res.partner model
  - Added is_vendor (Boolean) field to identify vendors.
- sale.order model
  - Added vendor_id field (Many2one to res.partner) filtered by is_vendor = True
  - Added warehouse_partner_id (Many2one to res.partner) filtered by parent vendor's delievery location
  - On sale order confirmation, linked confirmed SO to corresponding PO by setting the sale_order_id field
- sale.order.line model
  - Added vendor_id and warehouse_partner_id, according to sale order
- stock.rule model
  - Modify the purchase order domain to ensure the correct vendor is selected based on the sale order line by overriding _make_po_get_domain method.
  - Prepare purchase order with vendor and warehouse details based on the sale order line by overriding _prepare_purchase_order method
- purchase.order.line model
  - Prepare purchase order line with vendor-specific pricing by overriding _prepare_purchase_order_line method.
- stock.picking model
  - Added vendor_id and warehouse_partner_id as related fields from sale.order.line (Visible only if dropship is enabled)