### PR TITLE
[ADD] zero_stock_blockage: Approval Feature for Orders with Zero Stock

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Zero Stock Blockage',
+    'version': '1.0',
+    'summary': 'Sales Managment Module',
+    'author': 'chirag Gami(chga)',
+    'category': 'Sales',
+    'depends': ['base','sale_management'],
+    'license':'LGPL-3',
+    'data': [
+        # Add your XML/CSV files if any
+        'views/sales_order_views.xml'
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sales_order

--- a/zero_stock_blockage/models/sales_order.py
+++ b/zero_stock_blockage/models/sales_order.py
@@ -1,0 +1,33 @@
+from odoo import models, fields, api
+from odoo.osv import expression
+from odoo.exceptions import UserError
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approvalexchttps = fields.Boolean(
+        string="Zero Stock Approval",
+        help="If enabled, sales users can confirm the order despite zero stock.",
+    )
+
+    # Compute the readonly state based on the user's group
+    is_zero_stock_readonly = fields.Boolean(
+        compute='_compute_is_zero_stock_readonly', 
+        string="Is Zero Stock Readonly"
+    )
+
+    @api.depends_context('uid')
+    def _compute_is_zero_stock_readonly(self):
+        """ Check if the user is part of the Sales Manager group """
+        is_zero_stock_readonly = self.env.user.has_group('sales_team.group_sale_manager')
+        for record in self:
+            record.is_zero_stock_readonly = is_zero_stock_readonly
+
+
+    def action_confirm(self):
+        """ Extend the confirmation logic to add approval functionality """
+        res = super().action_confirm()
+        for order in self:
+            if not order.zero_stock_approvalexchttps:
+                raise UserError("You can't confirm SO when Zero Stock Blockage disable")
+        return res

--- a/zero_stock_blockage/views/sales_order_views.xml
+++ b/zero_stock_blockage/views/sales_order_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_sale_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approvalexchttps" readonly="not is_zero_stock_readonly"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Introduced a new option to allow Sales Administrators to confirm orders even if there is no stock available.
- Made the option only editable by Sales Administrators to ensure control over when zero-stock orders are approved.
- Updated the order form so that the approval option is visible only to the right people, and it becomes read-only for others.

Task: 4686586