### PR TITLE
[ADD] pos_salesperson: added salesperson choosing button in POS

### DIFF
--- a/pos_salesperson/__init__.py
+++ b/pos_salesperson/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_salesperson/__manifest__.py
+++ b/pos_salesperson/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'pos_salesperson',
+    'version': '1.0',
+    'category': 'Point of Sale',
+    'website': "https://www.odoo.com/odoo/point-of-sale",
+    'summary': 'Add a salesperson selection dropdown in POS',
+    'depends': ['point_of_sale', 'hr'],
+    'author': 'Abhishek Patel(abpa)',
+    'license': 'LGPL-3',
+    'data': [
+        'views/pos_salesperson_view.xml'
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_salesperson/static/src/**/*',
+        ],
+    },
+    
+    'installable': True,
+    'application': True,
+}

--- a/pos_salesperson/models/__init__.py
+++ b/pos_salesperson/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_order
+from . import pos_session

--- a/pos_salesperson/models/pos_order.py
+++ b/pos_salesperson/models/pos_order.py
@@ -1,0 +1,8 @@
+#type: ignore
+from odoo import api,fields,models
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    salesperson_id = fields.Many2one('hr.employee', string="Salesperson")

--- a/pos_salesperson/models/pos_session.py
+++ b/pos_salesperson/models/pos_session.py
@@ -1,0 +1,12 @@
+#type:ignore
+from odoo import api,models
+
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        res = super()._load_pos_data_models(config_id)
+        res.append('hr.employee')
+        return res

--- a/pos_salesperson/static/src/control_button.js
+++ b/pos_salesperson/static/src/control_button.js
@@ -1,0 +1,10 @@
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { patch } from "@web/core/utils/patch";
+import { SelectSalesperson } from "./select_salesperson/select_salesperson";
+
+patch(ControlButtons, {
+    components: {
+        ...ControlButtons.components,
+        SelectSalesperson,
+    },
+});

--- a/pos_salesperson/static/src/control_button.xml
+++ b/pos_salesperson/static/src/control_button.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_salesperson.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//button[@t-if='!props.showRemainingButtons and !ui.isSmall and props.onClickMore']" position="before">
+            <SelectSalesperson />
+        </xpath>
+    </t>
+</templates>

--- a/pos_salesperson/static/src/models/pos_order.js
+++ b/pos_salesperson/static/src/models/pos_order.js
@@ -1,0 +1,18 @@
+import { patch } from "@web/core/utils/patch";
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+
+patch(PosOrder.prototype, {
+    setSalesperson(salesperson) {
+        if (salesperson) {
+            this.salesperson_id = salesperson.id;
+            this.salesperson_name = salesperson.name;
+        } else {
+            this.salesperson_id = null;
+            this.salesperson_name = null;
+        }
+    },
+
+    getSalesperson() {
+        return this.salesperson_id ? { id: this.salesperson_id, name: this.salesperson_name } : null;
+    },
+});

--- a/pos_salesperson/static/src/select_salesperson/select_salesperson.js
+++ b/pos_salesperson/static/src/select_salesperson/select_salesperson.js
@@ -1,0 +1,47 @@
+import { Component, useState } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+
+export class SelectSalesperson extends Component {
+    static template = "point_of_sale.SelectSalesperson";
+    // static props = ["salesperson?"];
+
+    setup() {
+        this.pos = usePos();
+        this.dialog = useService("dialog");
+
+        // Get the current order and initialize salesperson state
+        const currentOrder = this.pos.get_order();
+        this.state = useState({
+            salesperson: currentOrder ? currentOrder.getSalesperson() : null,
+        });
+    }
+
+    async selectSalesperson() {
+        const currentOrder = this.pos.get_order();
+        if (!currentOrder) {
+            return false;
+        }
+        const employees = this.pos.models["hr.employee"] ;
+
+        const employeeList = employees.map((emp) => ({
+            id: emp.id,
+            label:emp.name,
+            item: emp,
+            isSelected: currentOrder.getSalesperson()?.id === emp.id || false,
+        }));
+
+        const selectedEmployee = await makeAwaitable(this.dialog, SelectionPopup,{
+            title: _t("Select a Salesperson"),
+            list: employeeList
+        });
+        console.log(selectedEmployee)
+        if(selectedEmployee){
+            currentOrder.setSalesperson(selectedEmployee);
+            this.state.salesperson = selectedEmployee;
+        }
+    }
+}

--- a/pos_salesperson/static/src/select_salesperson/select_salesperson.xml
+++ b/pos_salesperson/static/src/select_salesperson/select_salesperson.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.SelectSalesperson">
+        <button class="btn btn-light btn-lg lh-lg text-truncate w-auto" t-on-click="() => this.selectSalesperson()">
+            <div t-if="state.salesperson" t-esc="state.salesperson.name" class="text-truncate text-action" />
+            <t t-else="">Salesperson</t>
+        </button>
+    </t>
+</templates> 

--- a/pos_salesperson/views/pos_salesperson_view.xml
+++ b/pos_salesperson/views/pos_salesperson_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="view_pos_order_form_inherit" model="ir.ui.view">
+            <field name="name">view.pos.order.form.inherit</field>
+            <field name="model">pos.order</field>
+            <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"></field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='fiscal_position_id']" position="after">
+                    <field name="salesperson_id"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_pos_order_tree_inherit" model="ir.ui.view">
+            <field name="name">view.pos.order.tree.inherit</field>
+            <field name="model">pos.order</field>
+            <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"></field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='partner_id']" position="after">
+                    <field name="salesperson_id"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
- inherited pos.order and pos.session  add a  Salesperson_id field in pos.order model to track assigned sales representatives.
- Loaded the hr.employee model in pos.session to access salesperson data.
- Created a 'SelectSalesperson' Button component for selecting a salesperson.
- Patched  ControlButtons to include the salesperson selection option.
- created setSalesperson and getSalesperson functions in POS Order to manage salesperson .
- Displayed the salesperson on  the billing screen .