### PR TITLE
[ADD] sale: Add `Zero Stock Approvalexchttps` field to allow SO confi…

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': "Zero Stock Blockage",
+    'version': '1.0',
+    'depends': ['base', 'sale_management'],
+    'author': "Rishav Shah",
+    'category': 'sales',
+    'description': """
+    Zero Stock Blockage (Sales Order)
+    """,
+    'installable': True,
+    'application': True,
+    'license': 'LGPL-3',
+    'data': [
+        'views/sale_order_views.xml',
+    ],
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,26 @@
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approvalexchttps = fields.Boolean(string="Approval", default=False)
+
+    def action_confirm(self):
+        res = super().action_confirm()
+        for order in self:
+            if not order.zero_stock_approvalexchttps:
+                raise ValidationError("Please check for approval to confirm SO")
+        return res
+
+    readonly_status = fields.Boolean(
+        compute='_compute_readonly_status',
+        string="Zero Stock Approval Status"
+    )
+
+    @api.depends_context('uid')
+    def _compute_readonly_status(self):
+        readonly_status = self.env.user.has_group('sales_team.group_sale_manager')
+        for record in self:
+            record.readonly_status = readonly_status

--- a/zero_stock_blockage/views/sale_order_views.xml
+++ b/zero_stock_blockage/views/sale_order_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_sale_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approvalexchttps" readonly="not readonly_status"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
…rmation

In this commit
-Added a new boolean field in Sale Order.
-If set to true, it allows sales users to confirm the sale order. -Field is read-only for users in the Sales/User group. -Editable only by users in the Sales/Administrator group.