### PR TITLE
[ADD] Event Tickets Limit: Limit the Number of Tickets Per Registration

### DIFF
--- a/event_tickets_limit/__init__.py
+++ b/event_tickets_limit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/event_tickets_limit/__manifest__.py
+++ b/event_tickets_limit/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'Event Tickets Limit',
+    'license': 'LGPL-3',
+    'category': 'Events/Event Tickets Limit',
+    'installable': True,
+    'depends': ['event', 'website_event'],
+    'data': [
+        'views/event_event_views.xml',
+        'views/event_templates_page_registration.xml',
+    ]
+}

--- a/event_tickets_limit/models/__init__.py
+++ b/event_tickets_limit/models/__init__.py
@@ -1,0 +1,1 @@
+from . import event_event

--- a/event_tickets_limit/models/event_event.py
+++ b/event_tickets_limit/models/event_event.py
@@ -1,0 +1,16 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class EventEvent(models.Model):
+    _inherit = 'event.event'
+
+    tickets_limited = fields.Boolean(string="Ticket Limit", default=False)
+    max_ticket = fields.Integer(string="Tickets per Registration", default=9)
+
+    @api.constrains('max_ticket')
+    def _check_max_ticket(self):
+        for record in self:
+            if record.tickets_limited:
+                if record.max_ticket == 0:
+                    raise UserError("Maximum tickets must be grater than 0!!!")

--- a/event_tickets_limit/views/event_event_views.xml
+++ b/event_tickets_limit/views/event_event_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="view_event_form" model="ir.ui.view">
+        <field name="name">event.event.form.inherit.ticket.limit</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='address_id']" position="after">
+                <label for="tickets_limited" string="Limit Tickets"/>
+                <div>
+                    <field name="tickets_limited"/>
+                    <span invisible="not tickets_limited" required="not tickets_limited">to <field name="max_ticket" class="oe_inline o_input_9ch"/> per Registration</span>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/event_tickets_limit/views/event_templates_page_registration.xml
+++ b/event_tickets_limit/views/event_templates_page_registration.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <template id="event_tickets_limit_template" inherit_id="website_event.modal_ticket_registration">
+
+        <!-- implementing ticket limit per registration -->
+        <xpath expr="//div[hasclass('o_wevent_registration_single_select')]//select" position="replace">
+            <select t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)" class="d-inline w-auto form-select">
+                <t t-set="seats_max_ticket" t-value="(not tickets or not tickets.seats_limited or tickets.seats_available &gt; 9) and 10 or tickets.seats_available + 1"/>
+                <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
+                <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event) if tickets else seats_max_event"/>
+                <t t-set="seats_max" t-value="min(seats_max, event.max_ticket + 1) if event.tickets_limited else seats_max"/>
+                <t t-foreach="range(0, seats_max)" t-as="nb">
+                    <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
+                </t>
+            </select>
+        </xpath>
+
+        <!-- implementing ticket limit per registration on multiple select -->
+        <xpath expr="//div[@id='o_wevent_tickets_collapse']//select" position="replace">
+            <select t-if="not ticket.is_expired and ticket.sale_available" t-attf-name="nb_register-#{ticket.id}" class="w-auto form-select">
+                <t t-set="seats_max_ticket" t-value="(not ticket.seats_limited or ticket.seats_available &gt; 9) and 10 or ticket.seats_available + 1"/>
+                <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
+                <t t-set="seats_max" t-value="min(seats_max_ticket, seats_max_event)"/>
+                <t t-set="seats_max" t-value="min(seats_max, event.max_ticket + 1) if event.tickets_limited else seats_max"/>
+                <t t-foreach="range(0, seats_max)" t-as="nb">
+                    <option t-out="nb" t-att-selected="len(ticket) == 0 and nb == 0 and 'selected'"/>
+                </t>
+            </select>
+        </xpath>
+        
+    </template>
+
+</odoo>


### PR DESCRIPTION
- Inherited the event model and added two new fields
- Implemented an option to enable or disable ticket limits
- Required ticket quantity input when the limit option is enabled
- Modified ticket selection logic to enforce the ticket limit