### PR TITLE
[ADD] zero_stock_blockage: add module with stock approval field and access

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -5,8 +5,8 @@
     'description': """
         This module adds a zero stock approval feature to sale orders.
         """,
-    'data' : [
+    'data': [
         'views/sale_order_view.xml'
     ],
-    'license' : 'LGPL-3'
+    'license': 'LGPL-3'
 }

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Zero Stock Approval',
+    'version': '1.0',
+    'depends': ['sale_management'],
+    'description': """
+        This module adds a zero stock approval feature to sale orders.
+        """,
+    'data' : [
+        'views/sale_order_view.xml'
+    ],
+    'license' : 'LGPL-3'
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,6 +1,7 @@
 from odoo import api, models, fields
 from odoo.exceptions import UserError
 
+
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
@@ -10,7 +11,6 @@ class SaleOrder(models.Model):
     @api.depends_context('uid')
     def _compute_stock_approval_readonly(self):
         self.stock_approval_readonly = self.env.user.has_group('sales_team.group_sale_manager')
-
 
     def action_confirm(self):
         for records in self:

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,19 @@
+from odoo import api, models, fields
+from odoo.exceptions import UserError
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    stock_approval = fields.Boolean(string='Zero Stock Approvalexchttps')
+    stock_approval_readonly = fields.Boolean(compute='_compute_stock_approval_readonly')
+
+    @api.depends_context('uid')
+    def _compute_stock_approval_readonly(self):
+        self.stock_approval_readonly = self.env.user.has_group('sales_team.group_sale_manager')
+
+
+    def action_confirm(self):
+        for records in self:
+            if not records.stock_approval:
+                raise UserError("You are not allowed to confirm this order unless 'Zero Stock Approvalexchttps' is enabled.")
+        return super().action_confirm()

--- a/zero_stock_blockage/views/sale_order_view.xml
+++ b/zero_stock_blockage/views/sale_order_view.xml
@@ -1,0 +1,12 @@
+<odoo>
+  <record id="view_order_form_inherit_zero_stock" model="ir.ui.view">
+    <field name="name">sale.order.form.zero.stock</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.view_order_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//field[@name='payment_term_id']" position="after">
+        <field name="stock_approval" readonly="not stock_approval_readonly"/>
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
This commit introduces the zero_stock_blockage module.
Added a new field to handle zero stock approval logic in sale.order
Implemented access control conditions to restrict field behavior 
based on user roles.
This provides a foundation for managing stock-related approvals and 
ensuring proper permissions are enforced.