### PR TITLE
[ADD] product_warranty: add warranty management feature and validations

### DIFF
--- a/product_warranty/__init__.py
+++ b/product_warranty/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/product_warranty/__manifest__.py
+++ b/product_warranty/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': 'Product Warranty',
+    'version': '1.0',
+    'depends': ['sale_management'],
+    'description': """
+        This module adds warranty availabe feature for products.
+        """,
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/add_warranty_wizard_views.xml',
+        'views/product_template_views.xml',
+        'views/warranty_config_views.xml',
+        'views/warranty_config_menu.xml',
+        'views/sale_order_views.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3'
+}

--- a/product_warranty/models/__init__.py
+++ b/product_warranty/models/__init__.py
@@ -1,0 +1,4 @@
+from . import product_template
+from . import warranty_config
+from . import sale_order
+from . import sale_order_line

--- a/product_warranty/models/product_template.py
+++ b/product_warranty/models/product_template.py
@@ -1,5 +1,6 @@
 from odoo import models, fields
 
+
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 

--- a/product_warranty/models/product_template.py
+++ b/product_warranty/models/product_template.py
@@ -1,0 +1,6 @@
+from odoo import models, fields
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    is_warranty_available = fields.Boolean(string="Is Warranty Available")

--- a/product_warranty/models/sale_order.py
+++ b/product_warranty/models/sale_order.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import models
 
 
 class SaleOrder(models.Model):

--- a/product_warranty/models/sale_order.py
+++ b/product_warranty/models/sale_order.py
@@ -1,0 +1,17 @@
+from odoo import api, fields, models
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+
+    def open_warranty_wizard(self):
+
+        return {
+        'type': 'ir.actions.act_window',
+        'name': 'Add Warranty',
+        'res_model': 'add.warranty.wizard',
+        'view_mode': 'form',
+        'target': 'new',
+        'context': {'default_sale_order_id': self.id},
+        }
+

--- a/product_warranty/models/sale_order.py
+++ b/product_warranty/models/sale_order.py
@@ -1,8 +1,8 @@
-from odoo import api, fields, models
+from odoo import fields, models
+
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
-
 
     def open_warranty_wizard(self):
 
@@ -14,4 +14,3 @@ class SaleOrder(models.Model):
         'target': 'new',
         'context': {'default_sale_order_id': self.id},
         }
-

--- a/product_warranty/models/sale_order_line.py
+++ b/product_warranty/models/sale_order_line.py
@@ -14,7 +14,6 @@ class SaleOrderLine(models.Model):
         for line in self:
             if line.is_warranty and line.order_line_linked_to_warranty:
                 linked_line = line.order_line_linked_to_warranty
-                print(f"Checking warranty quantity: {line.product_uom_qty} > linked product quantity: {linked_line.product_uom_qty}")
                 if line.product_uom_qty > linked_line.product_uom_qty:
                     raise ValidationError(
                         f"The warranty quantity ({line.product_uom_qty}) cannot be more than the linked product quantity ({linked_line.product_uom_qty})."

--- a/product_warranty/models/sale_order_line.py
+++ b/product_warranty/models/sale_order_line.py
@@ -1,21 +1,36 @@
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     has_warranty = fields.Boolean(string="Has Warranty")
-    order_line_linked_to_warranty = fields.Many2one(comodel_name="sale.order.line", copy=False , string="Warranty Product", ondelete="cascade")
+    order_line_linked_to_warranty = fields.Many2one(comodel_name="sale.order.line", copy=False, string="Warranty Product", ondelete="cascade")
     is_warranty = fields.Boolean('Is Warranty')
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        clean_vals_list = []
-        for vals in vals_list:
-            if vals.get('is_warranty') and not vals.get('order_line_linked_to_warranty'):
-                continue
-            clean_vals_list.append(vals)
-        return super().create(clean_vals_list)
+    @api.constrains('product_uom_qty')
+    def _check_warranty_qty_limit(self):
+        for line in self:
+            if line.is_warranty and line.order_line_linked_to_warranty:
+                linked_line = line.order_line_linked_to_warranty
+                print(f"Checking warranty quantity: {line.product_uom_qty} > linked product quantity: {linked_line.product_uom_qty}")
+                if line.product_uom_qty > linked_line.product_uom_qty:
+                    raise ValidationError(
+                        f"The warranty quantity ({line.product_uom_qty}) cannot be more than the linked product quantity ({linked_line.product_uom_qty})."
+                    )
+
+            elif not line.is_warranty:
+                warranty_line = self.search([
+                    ('order_line_linked_to_warranty', '=', line.id),
+                    ('is_warranty', '=', True)
+                ], limit=1)
+
+                if warranty_line:
+                    if line.product_uom_qty < warranty_line.product_uom_qty:
+                        raise ValidationError(
+                            f"The quantity of the product ({line.product_uom_qty}) cannot be less than the linked warranty quantity ({warranty_line.product_uom_qty})."
+                        )
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_confirmed(self):

--- a/product_warranty/models/sale_order_line.py
+++ b/product_warranty/models/sale_order_line.py
@@ -1,0 +1,25 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    has_warranty = fields.Boolean(string="Has Warranty")
+    order_line_linked_to_warranty = fields.Many2one(comodel_name="sale.order.line", copy=False , string="Warranty Product", ondelete="cascade")
+    is_warranty = fields.Boolean('Is Warranty')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        clean_vals_list = []
+        for vals in vals_list:
+            if vals.get('is_warranty') and not vals.get('order_line_linked_to_warranty'):
+                continue
+            clean_vals_list.append(vals)
+        return super().create(clean_vals_list)
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_confirmed(self):
+        super()._unlink_except_confirmed()
+        for line in self:
+            if line.is_warranty:
+                line.order_line_linked_to_warranty.write({'has_warranty': False})

--- a/product_warranty/models/warranty_config.py
+++ b/product_warranty/models/warranty_config.py
@@ -1,5 +1,6 @@
 from odoo import models, fields
 
+
 class WarrantyConfig(models.Model):
     _name = 'warranty.config'
     _description = 'Warranty Configuration'

--- a/product_warranty/models/warranty_config.py
+++ b/product_warranty/models/warranty_config.py
@@ -1,0 +1,10 @@
+from odoo import models, fields
+
+class WarrantyConfig(models.Model):
+    _name = 'warranty.config'
+    _description = 'Warranty Configuration'
+
+    name = fields.Char(string="Name")
+    product = fields.Many2one('product.product', string="Warranty Product")
+    period = fields.Float(string='Period (in years)', default=1)
+    percentage = fields.Float(string="Percentage (%)")

--- a/product_warranty/security/ir.model.access.csv
+++ b/product_warranty/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_warranty_config,access.warranty.config,model_warranty_config,base.group_user,1,1,1,1
+access_add_warranty_wizard,access.add.warranty.wizard,model_add_warranty_wizard,base.group_user,1,1,1,1
+access_add_warranty_lines_wizard,access.add.warranty.lines.wizard,model_add_warranty_lines_wizard,base.group_user,1,1,1,1

--- a/product_warranty/views/product_template_views.xml
+++ b/product_warranty/views/product_template_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_product_form_inherit_warranty" model="ir.ui.view">
+        <field name="name">product.template.form.warranty.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='extra_info']" position="inside">
+                <field name="is_warranty_available"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_warranty/views/sale_order_views.xml
+++ b/product_warranty/views/sale_order_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="sale_order_list_view_add_warranty" model="ir.ui.view">
+        <field name="name">sale.order.list.view.inherit.add.warranty</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_open_discount_wizard']" position="before">
+                <button name="open_warranty_wizard"
+                        type="object"
+                        string="Add warranty"
+                        class="btn btn-secondary"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_warranty/views/warranty_config_menu.xml
+++ b/product_warranty/views/warranty_config_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="menu_warranty_config"
+              name="Warranty Configuration"
+              parent="sale.menu_sale_config"
+              action="action_warranty_config"/>
+</odoo>

--- a/product_warranty/views/warranty_config_views.xml
+++ b/product_warranty/views/warranty_config_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_warranty_config_list" model="ir.ui.view">
+        <field name="name">warranty.config.list</field>
+        <field name="model">warranty.config</field>
+        <field name="arch" type="xml">
+            <list string="Warranty Configurations" editable="bottom">
+                <field name="name"/>
+                <field name="product"/>
+                <field name="period"/>
+                <field name="percentage"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="action_warranty_config" model="ir.actions.act_window">
+        <field name="name">Warranty Configuration</field>
+        <field name="res_model">warranty.config</field>
+        <field name="view_mode">list</field>
+    </record>
+</odoo>

--- a/product_warranty/wizard/__init__.py
+++ b/product_warranty/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import warranty_wizard

--- a/product_warranty/wizard/add_warranty_wizard_views.xml
+++ b/product_warranty/wizard/add_warranty_wizard_views.xml
@@ -7,7 +7,7 @@
             <form>
                 <field name="wizard_line_ids">
                     <list editable="bottom" create="false" delete="false">
-                        <field name="sale_order_line_id" invisible="1"/>
+                        <field name="sale_order_line_id" column_invisible="1"/>
                         <field name="product_id" readonly="1"/>
                         <field name="warranty_name"/>
                         <field name="end_date"/>

--- a/product_warranty/wizard/add_warranty_wizard_views.xml
+++ b/product_warranty/wizard/add_warranty_wizard_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="add_warranty_wizard_form" model="ir.ui.view">
+        <field name="name">add.warranty.wizard.form</field>
+        <field name="model">add.warranty.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="wizard_line_ids">
+                    <list editable="bottom" create="false" delete="false">
+                        <field name="sale_order_line_id" invisible="1"/>
+                        <field name="product_id" readonly="1"/>
+                        <field name="warranty_name"/>
+                        <field name="end_date"/>
+                    </list>
+                </field>
+                <footer>
+                    <button name="action_add" string="Add Warranty" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="add_warranty_wizard_action" model="ir.actions.act_window">
+        <field name="name">Add Warranty</field>
+        <field name="res_model">add.warranty.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/product_warranty/wizard/warranty_wizard.py
+++ b/product_warranty/wizard/warranty_wizard.py
@@ -1,0 +1,79 @@
+from dateutil.relativedelta import relativedelta
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AddWarrantyLinesWizard(models.TransientModel):
+    _name = "add.warranty.lines.wizard"
+    _description = "Warranty Line Wizard"
+
+    wizard_id = fields.Many2one('add.warranty.wizard', string="Wizard Reference", ondelete="cascade")
+    product_id = fields.Many2one(comodel_name="product.product", string="Product")
+    sale_order_line_id = fields.Many2one(comodel_name="sale.order.line", string="Sale Order Line")
+    warranty_name = fields.Many2one(comodel_name="warranty.config", string="Warranty Configuration")
+    end_date = fields.Date(readonly=True, string="End Date", compute="_compute_end_date")
+
+    @api.depends('warranty_name')
+    def _compute_end_date(self):
+        for record in self:
+            if record.warranty_name:
+                # Calculate the warranty end date based on the period in years
+                record.end_date = fields.Date.today() + relativedelta(years=record.warranty_name.period)
+            else:
+                record.end_date = False
+
+
+class AddWarrantyWizard(models.TransientModel):
+    _name = "add.warranty.wizard"
+    _description = "Add Warranty Wizard"
+
+    # This field will hold the warranty lines for products
+    wizard_line_ids = fields.One2many(
+        comodel_name='add.warranty.lines.wizard',
+        inverse_name='wizard_id',
+        string="Warranty Lines"
+    )
+
+    # Default get method to populate the wizard with sale order lines eligible for warranty
+    # res is dictionary to store the default value
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+
+        # Get the sale order ID from the context, id was passed in sale_order.py open_warranty_wizard function
+        sale_order = self.env['sale.order'].browse(self.env.context.get("default_sale_order_id"))
+
+        # Get sale order lines with warranty available and not yet having a warranty
+        sale_order_lines = sale_order.order_line.filtered(
+            lambda line: line.product_id.is_warranty_available and not line.has_warranty
+        )
+
+        # Populate the wizard lines
+        res.update({
+                'wizard_line_ids': [(0, 0, {
+                'sale_order_line_id': line.id,
+                'product_id': line.product_id.id,
+            }) for line in sale_order_lines]
+        })
+        return res
+
+    # Action to add warranty for the products
+    def action_add(self):
+        sale_order_line = self.env['sale.order.line']
+        warranty_lines = self.wizard_line_ids
+
+        for line in warranty_lines:
+            if line.warranty_name:
+                # Create a new sale order line for warranty
+                sale_order_line.create({
+                    'order_id': line.sale_order_line_id.order_id.id,
+                    'product_id':  line.warranty_name.product.id,  # warranty product
+                    'product_uom_qty': 1,
+                    'price_unit': line.warranty_name.percentage / 100 * line.sale_order_line_id.price_unit,  # price based on percentage
+                    'name': f"{line.sale_order_line_id.product_id.name} Warranty, End Date: {line.end_date}",
+                    'order_line_linked_to_warranty': line.sale_order_line_id.id,
+                    'is_warranty': True,
+                })
+
+                # Update the original sale order line to mark it as having a warranty
+                line.sale_order_line_id.write({'has_warranty': True})
+        return True

--- a/product_warranty/wizard/warranty_wizard.py
+++ b/product_warranty/wizard/warranty_wizard.py
@@ -1,6 +1,5 @@
 from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models
-from odoo.exceptions import ValidationError
 
 
 class AddWarrantyLinesWizard(models.TransientModel):
@@ -17,7 +16,6 @@ class AddWarrantyLinesWizard(models.TransientModel):
     def _compute_end_date(self):
         for record in self:
             if record.warranty_name:
-                # Calculate the warranty end date based on the period in years
                 record.end_date = fields.Date.today() + relativedelta(years=record.warranty_name.period)
             else:
                 record.end_date = False
@@ -27,27 +25,21 @@ class AddWarrantyWizard(models.TransientModel):
     _name = "add.warranty.wizard"
     _description = "Add Warranty Wizard"
 
-    # This field will hold the warranty lines for products
     wizard_line_ids = fields.One2many(
         comodel_name='add.warranty.lines.wizard',
         inverse_name='wizard_id',
         string="Warranty Lines"
     )
 
-    # Default get method to populate the wizard with sale order lines eligible for warranty
-    # res is dictionary to store the default value
     def default_get(self, fields_list):
         res = super().default_get(fields_list)
 
-        # Get the sale order ID from the context, id was passed in sale_order.py open_warranty_wizard function
         sale_order = self.env['sale.order'].browse(self.env.context.get("default_sale_order_id"))
 
-        # Get sale order lines with warranty available and not yet having a warranty
         sale_order_lines = sale_order.order_line.filtered(
             lambda line: line.product_id.is_warranty_available and not line.has_warranty
         )
 
-        # Populate the wizard lines
         res.update({
                 'wizard_line_ids': [(0, 0, {
                 'sale_order_line_id': line.id,
@@ -56,24 +48,21 @@ class AddWarrantyWizard(models.TransientModel):
         })
         return res
 
-    # Action to add warranty for the products
     def action_add(self):
         sale_order_line = self.env['sale.order.line']
         warranty_lines = self.wizard_line_ids
 
         for line in warranty_lines:
             if line.warranty_name:
-                # Create a new sale order line for warranty
                 sale_order_line.create({
                     'order_id': line.sale_order_line_id.order_id.id,
-                    'product_id':  line.warranty_name.product.id,  # warranty product
+                    'product_id':  line.warranty_name.product.id,
                     'product_uom_qty': 1,
-                    'price_unit': line.warranty_name.percentage / 100 * line.sale_order_line_id.price_unit,  # price based on percentage
+                    'price_unit': line.warranty_name.percentage / 100 * line.sale_order_line_id.price_unit,
                     'name': f"{line.sale_order_line_id.product_id.name} Warranty, End Date: {line.end_date}",
                     'order_line_linked_to_warranty': line.sale_order_line_id.id,
                     'is_warranty': True,
                 })
 
-                # Update the original sale order line to mark it as having a warranty
                 line.sale_order_line_id.write({'has_warranty': True})
         return True


### PR DESCRIPTION
Introduced a new module product_warranty that enables warranty management 
within sale quotations. 
Added a menu option to list available warranties.
In product template, added a boolean field to mark whether a product supports 
warranty. 
In the sale order form, added a button to open a wizard that lists order lines 
with 
warranty availability. 
Users can select a warranty from predefined options.
Also implemented logic to ensure that the warranty quantity cannot exceed the 
quantity of the linked product line.