### PR TITLE
[ADD] filter_appointment: add advanced filters to appointment listing page

### DIFF
--- a/filter_appointment/__init__.py
+++ b/filter_appointment/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/filter_appointment/__manifest__.py
+++ b/filter_appointment/__manifest__.py
@@ -9,4 +9,5 @@
     ],
     'installable': True,
     'application': False,
+    'license': 'LGPL-3',
 }

--- a/filter_appointment/__manifest__.py
+++ b/filter_appointment/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Website Appointment Filters',
+    'version': '1.0',
+    'summary': 'Add filters to appointment page on website',
+    'author': 'kame',
+    'depends': ['website', 'appointment'],
+    'data': [
+        'views/appointment_template.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/filter_appointment/controllers/__init__.py
+++ b/filter_appointment/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import appointment

--- a/filter_appointment/controllers/appointment.py
+++ b/filter_appointment/controllers/appointment.py
@@ -1,9 +1,49 @@
 from odoo import http
+from odoo.addons.website_appointment.controllers.appointment import WebsiteAppointment
 from odoo.http import request
 
 
-class WebsiteAppointment(http.Controller):
+class WebsiteAppointmentFilter(WebsiteAppointment):
 
-    @http.route('/appointments', type='http', auth="public", website=True)
-    def website_appointments(self, **kwargs):
-        domain = []
+    @http.route()
+    def appointment_type_index(self, page=1, **kwargs):
+        filter_domain = []
+
+        if kwargs.get("appointment_type"):
+            if kwargs["appointment_type"] == "online":
+                filter_domain.append(("location_id", "=", False))
+            elif kwargs["appointment_type"] == "offline":
+                filter_domain.append(("location_id", "!=", False))
+
+        if kwargs.get("payment_step"):
+            if kwargs["payment_step"] == "required":
+                filter_domain.append(("has_payment_step", "=", True))
+            elif kwargs["payment_step"] == "not_required":
+                filter_domain.append(("has_payment_step", "=", False))
+
+        if kwargs.get("schedule_based_on"):
+            if kwargs["schedule_based_on"] == "users":
+                filter_domain.append(("schedule_based_on", "=", "users"))
+            elif kwargs["schedule_based_on"] == "resources":
+                filter_domain.append(("schedule_based_on", "=", "resources"))
+
+        domain = self._appointments_base_domain(
+            filter_appointment_type_ids=kwargs.get('filter_appointment_type_ids'),
+            search=kwargs.get('search'),
+            additional_domain=filter_domain
+        )
+
+        available_appointment_types = self._fetch_and_check_private_appointment_types(
+            kwargs.get('filter_appointment_type_ids'),
+            kwargs.get('filter_staff_user_ids'),
+            kwargs.get('filter_resource_ids'),
+            kwargs.get('invite_token'),
+            domain=domain
+        )
+
+        return request.render(
+            'website_appointment.appointments_cards_layout',
+            self._prepare_appointments_cards_data(
+                page, available_appointment_types, **kwargs
+            )
+        )

--- a/filter_appointment/controllers/appointment.py
+++ b/filter_appointment/controllers/appointment.py
@@ -1,0 +1,9 @@
+from odoo import http
+from odoo.http import request
+
+
+class WebsiteAppointment(http.Controller):
+
+    @http.route('/appointments', type='http', auth="public", website=True)
+    def website_appointments(self, **kwargs):
+        domain = []

--- a/filter_appointment/views/appointment_template.xml
+++ b/filter_appointment/views/appointment_template.xml
@@ -1,26 +1,26 @@
 <odoo>
-  <template id="appointment_filter_inherit" inherit_id="website_appointment.website_calendar_index_topbar">
-    <xpath expr="//h4[text()='Choose your appointment']" position="after">
-      <div class="d-flex align-items-center flex-wrap gap-2 ms-5">
+    <template id="appointment_website_filter_template" inherit_id="website_appointment.website_calendar_index_topbar">
+        <xpath expr="//h4" position="after">
+            <form method="get" action="/appointment" class="d-flex align-items-center gap-2 px-2" role="search">
 
-        <select class="form-select" style="width: 160px;">
-          <option value="">All Types</option>
-          <option value="online">Online</option>
-          <option value="offline">Offline</option>
-        </select>
+                <select name="appointment_type" class="form-select" style="width: 160px;" onchange="this.form.submit()">
+                    <option value="" t-att-selected="'selected' if not request.params.get('appointment_type') else None">All Types</option>
+                    <option value="online" t-att-selected="'selected' if request.params.get('appointment_type') == 'online' else None">Online</option>
+                    <option value="offline" t-att-selected="'selected' if request.params.get('appointment_type') == 'offline' else None">Offline</option>
+                </select>
 
-        <select class="form-select" style="width: 160px;">
-          <option value="">All Schedules</option>
-          <option value="resource">By Resource</option>
-          <option value="user">By User</option>
-        </select>
+                <select name="payment_step" class="form-select" style="width: 160px;" onchange="this.form.submit()">
+                    <option value="" t-att-selected="'selected' if not request.params.get('payment_step') else None">All Payments</option>
+                    <option value="required" t-att-selected="'selected' if request.params.get('payment_step') == 'required' else None">Required</option>
+                    <option value="not_required" t-att-selected="'selected' if request.params.get('payment_step') == 'not_required' else None">Not Required</option>
+                </select>
 
-        <select class="form-select" style="width: 160px;">
-          <option value="">All Payment</option>
-          <option value="paid">Paid</option>
-          <option value="free">Free</option>
-        </select>
-      </div>
-    </xpath>
-  </template>
+                <select name="schedule_based_on" class="form-select" style="width: 160px;" onchange="this.form.submit()">
+                    <option value="" t-att-selected="'selected' if not request.params.get('schedule_based_on') else None">All</option>
+                    <option value="users" t-att-selected="'selected' if request.params.get('schedule_based_on') == 'users' else None">Users</option>
+                    <option value="resources" t-att-selected="'selected' if request.params.get('schedule_based_on') == 'resources' else None">Resources</option>
+                </select>
+            </form>
+        </xpath>
+    </template>
 </odoo>

--- a/filter_appointment/views/appointment_template.xml
+++ b/filter_appointment/views/appointment_template.xml
@@ -1,0 +1,26 @@
+<odoo>
+  <template id="appointment_filter_inherit" inherit_id="website_appointment.website_calendar_index_topbar">
+    <xpath expr="//h4[text()='Choose your appointment']" position="after">
+      <div class="d-flex align-items-center flex-wrap gap-2 ms-5">
+
+        <select class="form-select" style="width: 160px;">
+          <option value="">All Types</option>
+          <option value="online">Online</option>
+          <option value="offline">Offline</option>
+        </select>
+
+        <select class="form-select" style="width: 160px;">
+          <option value="">All Schedules</option>
+          <option value="resource">By Resource</option>
+          <option value="user">By User</option>
+        </select>
+
+        <select class="form-select" style="width: 160px;">
+          <option value="">All Payment</option>
+          <option value="paid">Paid</option>
+          <option value="free">Free</option>
+        </select>
+      </div>
+    </xpath>
+  </template>
+</odoo>


### PR DESCRIPTION
This commit adds new filtering options to the website appointment page,
improving the user experience by allowing visitors to filter appointments
by type (online/offline), payment requirement, and scheduling method 
(users/resources).
A custom controller extends the base `WebsiteAppointment` to dynamically 
build a filter domain based on user input and combine it with the standard 
appointment domain logic.
In UI part, the `website_calendar_index_topbar` template is extended to include 
three dropdowns that submit on change, making the filtering seamless.