### PR TITLE
[ADD] estate: initial Real Estate module with models, views, and rela…

### DIFF
--- a/estate/__init__.py
+++ b/estate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': 'Real Estate',
+    'version': '1.0',
+    'depends': ['base'],
+    'author': 'Rajeev Aanjana',
+    'category': 'Real Estate',
+    'description': 'A module for managing real estate properties',
+    'data':[
+        'security/ir.model.access.csv',
+        'views/estate_property_views.xml',
+        'views/estate_property_type_views.xml',
+        'views/estate_property_tag_views.xml',
+        'views/estate_property_offer_views.xml',
+        'views/estate_menus.xml',
+    ],
+    'license': 'LGPL-3',
+    'application': True,
+    'installable': True,
+}

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,0 +1,4 @@
+from . import estate_property
+from . import estate_property_type
+from . import estate_property_tag
+from . import estate_property_offer

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,0 +1,76 @@
+from odoo import fields, models
+from dateutil.relativedelta import relativedelta
+
+class EstateProperty(models.Model):
+    _name = "estate.property"
+    _description = "Real Estate Property"
+
+    # Basic Fields
+    name = fields.Char(string="Name", required=True)
+    description = fields.Text(string="Description")
+    postcode = fields.Char(string="Postcode")
+    
+    # Date Fields
+    date_availability = fields.Date(
+        string="Available From",
+        copy=False,
+        default=lambda self: fields.Date.today() + relativedelta(months=3)
+    )
+    
+    # Price Fields
+    expected_price = fields.Float(string="Expected Price", required=True)
+    selling_price = fields.Float(string="Selling Price", readonly=True, copy=False)
+    
+    # Property Details
+    bedrooms = fields.Integer(string="Bedrooms", default=2)
+    living_area = fields.Integer(string="Living Area (sqm)")
+    facades = fields.Integer(string="Facades")
+    garage = fields.Boolean(string="Garage")
+    garden = fields.Boolean(string="Garden")
+    garden_area = fields.Integer(string="Garden Area (sqm)")
+    
+    # Selection Fields
+    garden_orientation = fields.Selection(
+        selection=[
+            ('north', 'North'),
+            ('south', 'South'),
+            ('east', 'East'),
+            ('west', 'West'),
+        ],
+        string="Garden Orientation"
+    )
+    
+    state = fields.Selection(
+        selection=[
+            ('new', 'New'),
+            ('offer_received', 'Offer Received'),
+            ('offer_accepted', 'Offer Accepted'),
+            ('sold', 'Sold'),
+            ('cancelled', 'Cancelled'),
+        ],
+        string="Status",
+        required=True,
+        copy=False,
+        default='new'
+    )
+    
+    active = fields.Boolean(string="Active", default=True)
+    
+    # Many2one, Many2many, One2many Relation to Property Type
+    property_type_id = fields.Many2one("estate.property.type", string="Property Type")
+    
+    buyer_id = fields.Many2one("res.partner", string="Buyer", copy=False)
+    
+    salesperson_id = fields.Many2one(
+    "res.users", 
+    string="Salesperson", 
+    default=lambda self: self.env.user
+    )
+    
+    offer_ids = fields.One2many(
+    "estate.property.offer",  
+    "property_id",           
+    string="Offers"
+    )
+    
+    tag_ids = fields.Many2many("estate.property.tag", string="Tags", widget="many2many_tags" )

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+class EstatePropertyOffer(models.Model):
+    _name = "estate.property.offer"
+    _description = "Real Estate Property Offer"
+    
+    price = fields.Float()
+    status = fields.Selection(
+        selection=[('accepted', 'Accepted'), ('refused', 'Refused')],
+        copy=False
+    )
+    partner_id = fields.Many2one("res.partner",  string="Partner", required=True)
+    property_id = fields.Many2one("estate.property", string="Property", required=True)

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+class EstatePropertyTag(models.Model):
+    _name = "estate.property.tag"
+    _description = "Real Estate Property Tag"
+    
+    name = fields.Char(required=True)

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+class EstatePropertyType(models.Model):
+    _name = "estate.property.type"
+    _description = "Real Estate Property Type"
+    
+    # Basic Fields
+    name = fields.Char(required=True)
+    

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_estate_property_user,access_estate_property_user,model_estate_property,base.group_user,1,1,1,1
+access_estate_property_type,access_estate_property_type,model_estate_property_type,base.group_user,1,1,1,1
+access_estate_property_tag,estate.property.tag,model_estate_property_tag,base.group_user,1,1,1,1
+access_estate_property_offer,estate.property.offer,model_estate_property_offer,base.group_user,1,1,1,1

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="estate_menu_root" name="Real Estate"/>
+
+    <!-- Properties Menu -->
+    <menuitem id="estate_property_menu_root" name="Properties" parent="estate_menu_root"/>
+    <menuitem id="estate_property_menu" name="Properties" parent="estate_property_menu_root"
+              action="estate_property_action"/>
+
+    <!-- Configuration Menu -->
+    <menuitem id="estate_config_menu_root" name="Settings" parent="estate_menu_root" sequence="10"/>
+    
+    <!-- Property Types -->
+    <menuitem id="estate_property_type_menu" name="Property Types" parent="estate_config_menu_root"
+              action="estate_property_type_action" sequence="10"/>
+    
+    <!-- Property Tags -->
+    <menuitem id="estate_property_tag_menu" name="Property Tags" parent="estate_config_menu_root"
+              action="estate_property_tag_action" sequence="20"/>
+
+</odoo>
+
+
+
+
+
+
+<!--  "Both are correct" 
+
+<odoo>
+    <menuitem id="estate_menu_root" name="Real Estate" />
+
+    <menuitem id="estate_menu_property" name="Properties"
+        parent="estate_menu_root" />
+
+    <menuitem id="estate_menu_property_action"
+        parent="estate_menu_property"
+        action="estate_property_action" />
+</odoo>
+
+________________________________________________________________________________________________
+
+<odoo>
+<menuitem id="estate_menu_root" name="Real Estate">
+    <menuitem id="estate_first_level_menu" name="Properties">
+        <menuitem id="estate_property_menu_action" action="estate_property_action"/>
+    </menuitem>
+</menuitem>
+</odoo>
+
+-->

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="estate_property_offer_list_view" model="ir.ui.view">
+        <field name="name">estate.property.offer.list</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="price"/>
+                <field name="partner_id"/>
+                <field name="status"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_offer_form_view" model="ir.ui.view">
+        <field name="name">estate.property.offer.form</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="price"/>
+                        <field name="partner_id"/>
+                        <field name="status"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="estate_property_tag_action" model="ir.actions.act_window">
+        <field name="name">Property Tags</field>
+        <field name="res_model">estate.property.tag</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <record id="estate_property_tag_list_view" model="ir.ui.view">
+        <field name="name">estate.property.tag.list</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_tag_form_view" model="ir.ui.view">
+        <field name="name">estate.property.tag.form</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="estate_property_type_action" model="ir.actions.act_window">
+        <field name="name">Property Types</field>
+        <field name="res_model">estate.property.type</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <record id="estate_property_type_list_view" model="ir.ui.view">
+        <field name="name">estate.property.type.list</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_type_form_view" model="ir.ui.view">
+        <field name="name">estate.property.type.form</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,0 +1,128 @@
+<odoo>
+    <record id="estate_property_action" model="ir.actions.act_window">
+        <field name="name">Properties</field>
+        <field name="res_model">estate.property</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <!-- List View -->
+    <record id="view_estate_property_list" model="ir.ui.view">
+        <field name="name">estate.property.list</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            
+            <list string="Properties">
+                <field name="name" string="Name"/>
+                <field name="postcode" string="Postcode"/>
+                <field name="expected_price" string="Expected Price"/>
+                <field name="selling_price" string="Selling Price"/>
+                <field name="bedrooms" string="Bedrooms"/>
+                <field name="living_area" string="Living Area"/>
+                <field name="state" string="Status"/>
+                <field name="property_type_id" string="Property Type"/>
+                <field name="tag_ids"/>
+                <field name="buyer_id" string="Buyer"/>
+                <field name="salesperson_id"/>
+
+            </list>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="view_estate_property_form" model="ir.ui.view">
+        <field name="name">estate.property.form</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <form string="Property">
+            
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" class="oe_inline"/>
+                        </h1>
+                        <h6>
+                            <field name="tag_ids" widget="many2many_tags"/>
+                        </h6>
+                    </div>
+                    <group>
+                        <group>
+                            <!-- <field name="name"/> -->
+                            <field name="property_type_id"/>
+                            <field name="state"/>
+                            <field name="postcode"/>
+
+                            <!-- <field name="buyer_id"/> -->
+                            <!-- <field name="salesperson_id"/> -->
+                        </group>
+                        <group>
+                            <field name="date_availability"/>
+                            <field name="expected_price"/>
+                            <field name="selling_price"/>
+
+                        </group>
+                    </group>
+                    <notebook>
+                        
+                        <page string="Description">
+                            <group>
+                                <group>
+                                    <field name="bedrooms"/>
+                                    <field name="living_area"/>
+                                    <field name="facades"/>
+                                    <field name="garage"/>
+                                </group>
+                                <group>
+                                    <field name="garden"/>
+                                    <field name="garden_area"/>
+                                    <field name="garden_orientation"/>
+                                </group>
+                                
+                            </group>
+                        </page>
+                        <page string="Offers">
+                            <field name="offer_ids">
+                                <list>
+                                    <field name="price"/>
+                                    <field name="partner_id"/>
+                                    <field name="status"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Other Info">
+                            <group>
+                                <field name="salesperson_id"/>
+                                <field name="property_type_id"/>
+                                <field name="buyer_id"/>
+                                <field name="tag_ids" widget="many2many_tags"/>
+                            </group>
+                        </page>
+                        
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Search View -->
+    <record id="view_estate_property_search" model="ir.ui.view">
+        <field name="name">estate.property.search</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="postcode"/>
+                <field name="property_type_id"/>
+                <field name="buyer_id"/>
+                <field name="tag_ids"/>
+                <filter string="Available" name="available" domain="[('state','in',['new','offer_received'])]"/>
+                <group string="Group By">
+                    <filter string="Postcode" name="postcode" context="{'group_by':'postcode'}"/>
+                    <filter string="Property Type" name="property_type" context="{'group_by':'property_type_id'}"/>
+                    <filter string="Buyer" name="buyer" context="{'group_by':'buyer_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+    
+
+</odoo>


### PR DESCRIPTION
…tions

Introduce the base structure of the Real Estate application as per Odoo 18 developer tutorial, covering the foundational data model, views, menus, access rights, and key relationships.

This commit adds:

- A new module named `estate`.
- The main model `estate.property` with relevant business fields (name, price, expected price, description, living area, garden, garage, etc.).
- Custom menus, actions, form and list views for `estate.property`.
- Field attributes like `readonly`, `copy`, `required`, and default values.
- Access rights through `ir.model.access.csv` for developers.
- Multiple record filtering using `domain`, `search`, and view buttons.
- Related models:
  - estate.property.type`: Many2one for property types.
  - estate.property.tag`: Many2many tags with selection UI.
  - estate.property.offer`: One2many offer list per property with inline editing
  - Links to existing models: `res.partner` (buyer), `res.users` (salesperson).
- Navigation enhancements through related fields and smart buttons.
- Search enhancements using filters for related fields like tags and type.

The goal of this commit is to build a working foundation of the real estate sales module including a robust data model, basic UI, and relations required for future business logic and workflow implementation.

task-001 (Chapter 1–7 Odoo 18 Developer Tutorial)