### PR TITLE
[ADD] estate: created a new module 'estate'

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'estate',
+    'version': '1.0',
+    'sequence': 15,
+    'summary': 'estate summary',
+    'description': "",
+    'depends': [
+        'base'
+    ],
+    'data': [
+    ],
+    'demo': [
+    ],
+    # 'css': ['static/src/css/crm.css'],
+    'installable': True,
+    'application': True,
+    'auto_install': False
+}


### PR DESCRIPTION
This is an exercise on the tutorial "Server Framework 101: Chapter 2"

The commit introduces the bare minimum files for creating a new odoo module:
- __init__.py (empty for now)
- __manifest__.py