### PR TITLE
[ADD] zero stock blockage: added zero stock block approval functionality

### DIFF
--- a/zero_stock_blockage/__init__.py
+++ b/zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_blockage/__manifest__.py
+++ b/zero_stock_blockage/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "ZERO STOCK BLOCKAGE",
+    "version": "1.0",
+    "summary": "Restrict Sales Order Confirmation if stock is zero",
+    "description": "Adds approval mechanism for sales orders with zero stock.",
+    "category": "Sales",
+    "application": True,
+    "depends": ["base", "sale"],
+    "data": [
+        "views/zero_stock_blockage_views.xml",
+    ],
+    "license": "LGPL-3",
+    "installable": True,
+}

--- a/zero_stock_blockage/models/__init__.py
+++ b/zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/zero_stock_blockage/models/sale_order.py
+++ b/zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,25 @@
+from odoo import fields, models, api
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    zero_stock_approval = fields.Boolean(string="Approval", default="false")
+
+    def action_confirm(self):
+        result = super().action_confirm()
+        for order in self:
+            if not order.zero_stock_approval:
+                raise UserError(
+                    "This sale order cannot be confirmed without zero stock approval"
+                )
+        return result
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if not self.env.user.has_group("sales_team.group_sale_manager"):
+            if "zero_stock_approval" in res:
+                res["zero_stock_approval"]["readonly"] = True
+        return res

--- a/zero_stock_blockage/views/zero_stock_blockage_views.xml
+++ b/zero_stock_blockage/views/zero_stock_blockage_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_form_inherit_zero_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.zero.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In the Sale application, a added Boolean field zero stock Approval, has been added to the Sale Order. When it is enabled, sales users will be able to approve sales orders even when there is zero inventory. Salesperson can only read in the field, whereas administrator only can modify it.
task-4896347