### PR TITLE
[ADD] book_price: add book price to sale order and invoice lines

### DIFF
--- a/book_price/__init__.py
+++ b/book_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/book_price/__manifest__.py
+++ b/book_price/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'Book Price',
+    'version': '1.0',
+    'depends': ['sale_management'],
+    'installable': True,
+    'data': [
+        'views/sale_order_view.xml',
+        'views/account_move_view.xml',
+    ],
+    'license': 'AGPL-3'
+}

--- a/book_price/models/__init__.py
+++ b/book_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_line
+from . import account_move_line

--- a/book_price/models/account_move_line.py
+++ b/book_price/models/account_move_line.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(string="Book Price", compute="_compute_book_price")
+
+    @api.depends('product_id', 'quantity', 'product_uom_id', 'sale_line_ids.order_id.pricelist_id')
+    def _compute_book_price(self):
+        for line in self:
+            line.book_price = 0.0
+            if not line.product_id:
+                continue
+
+            sale_line = line.sale_line_ids[:1]
+            if sale_line:
+                pricelist = sale_line.order_id.pricelist_id
+                if pricelist:
+                    line.book_price = pricelist._get_product_price(
+                        line.product_id, line.quantity, line.product_uom_id
+                    )
+                    continue
+            line.book_price = line.product_id.lst_price

--- a/book_price/models/sale_order_line.py
+++ b/book_price/models/sale_order_line.py
@@ -1,0 +1,21 @@
+from odoo import api, fields, models
+
+
+class SalesOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(string="Book price", compute="_compute_book_price")
+
+    @api.depends('product_id', 'product_uom_qty', 'order_id.pricelist_id')
+    def _compute_book_price(self):
+        for rec in self:
+            if not rec.product_id:
+                rec.book_price = 0
+                continue
+            pricelist = rec.order_id.pricelist_id
+            if rec.product_id and pricelist:
+                rec.book_price = pricelist._get_product_price(
+                    rec.product_id, rec.product_uom_qty
+                )
+            else:
+                rec.book_price = rec.product_id.lst_price

--- a/book_price/views/account_move_view.xml
+++ b/book_price/views/account_move_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_move_form_inherit_book_price" model="ir.ui.view">
+        <field name="name">account.move.form.inherite.book.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//field[@name='invoice_line_ids']//list//field[@name='quantity']" position="before">
+                <field name="book_price" readonly="True" column_invisible="context.get('default_move_type') != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/book_price/views/sale_order_view.xml
+++ b/book_price/views/sale_order_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_form_inherit_book_price" model="ir.ui.view">
+        <field name="name">sale.order.form.inherite.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//list//field[@name='product_uom_qty']" position="before">
+                <field name="book_price" readonly="True"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
It's important for users to see the original price of a product with applied pricelist when creating a sale order or invoice. Without this, it's hard to know if the price being charged is correct or if a discount has been applied. Showing the book price helps sales and accounting teams compare the price with pricelist with the charged one, making it easier to catch mistakes, explain price differences, and ensure consistency between sales and invoicing.