### PR TITLE
[ADD] pricelist_price: add book price to sale order and invoice lines

### DIFF
--- a/pricelist_price/__init__.py
+++ b/pricelist_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pricelist_price/__manifest__.py
+++ b/pricelist_price/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': "Product Book Price",
+    'version': '1.0',
+    'depends': ['sale_management'],
+    'author': 'niyp',
+    'category': 'Category',
+    'data': [
+       'views/sale_order_line_views.xml',
+       'views/account_move_line_views.xml',
+    ],
+    'installable': True,
+    'license': "LGPL-3",
+}

--- a/pricelist_price/models/__init__.py
+++ b/pricelist_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_line
+from . import account_move_line

--- a/pricelist_price/models/account_move_line.py
+++ b/pricelist_price/models/account_move_line.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(related='sale_line_ids.book_price')

--- a/pricelist_price/models/sale_order_line.py
+++ b/pricelist_price/models/sale_order_line.py
@@ -1,0 +1,23 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(string="Book Price", compute='_compute_book_price')
+
+    @api.depends('product_id', 'product_uom_qty', 'order_id.pricelist_id')
+    def _compute_book_price(self):
+        for record in self:
+            if not record.product_id:
+                record.book_price = 0.0
+                continue
+
+            pricelist = record.order_id.pricelist_id if record.order_id else None
+
+            if pricelist:
+                record.book_price = pricelist._get_product_price(
+                    record.product_id, record.product_uom_qty
+                )
+            else:
+                record.book_price = record.product_id.lst_price

--- a/pricelist_price/views/account_move_line_views.xml
+++ b/pricelist_price/views/account_move_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_move_form_inherit_book_price" model="ir.ui.view">
+        <field name="name">account.move.form.inherite.book.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//field[@name='invoice_line_ids']//list//field[@name='quantity']" position="before">
+                <field name="book_price" readonly="True" column_invisible="context.get('default_move_type') != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/pricelist_price/views/sale_order_line_views.xml
+++ b/pricelist_price/views/sale_order_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_form_inherit_book_price" model="ir.ui.view">
+        <field name="name">sale.order.form.inherite.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//list//field[@name='product_uom_qty']" position="before">
+                <field name="book_price" readonly="True"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This pull request introduces pricing transparency and support decision-making during the sales and invoicing processes, it’s important for users to have visibility into the reference or book price of products. This allows sales and accounting teams to validate discounts, monitor pricing consistency, and detect discrepancies early in the transaction flow. By making the book price visible at the order and invoice line level, we aim to enhance control and accountability, particularly in environments where pricing decisions are influenced by predefined reference values. This change is intended to support better operational accuracy and informed pricing actions across teams.

task-4958277