### PR TITLE
[ADD] pos_salesperson: add salesperson dropdown and order field

### DIFF
--- a/pos_salesperson/__init__.py
+++ b/pos_salesperson/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/pos_salesperson/__manifest__.py
+++ b/pos_salesperson/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Pos Salesperson",
+    "depends": ["pos_hr"],
+    "version": "0.1",
+    "license": "LGPL-3",
+    "installable": True,
+    "data": ["views/pos_order_views.xml"],
+    "assets": {
+        "point_of_sale._assets_pos": [
+            "pos_salesperson/static/src/app/**/*"
+        ]
+    }
+}

--- a/pos_salesperson/models/__init__.py
+++ b/pos_salesperson/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_order
+from . import pos_session

--- a/pos_salesperson/models/pos_order.py
+++ b/pos_salesperson/models/pos_order.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    salesperson_id = fields.Many2one("hr.employee", string="Salesperson")

--- a/pos_salesperson/models/pos_session.py
+++ b/pos_salesperson/models/pos_session.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    def _load_pos_data_models(self, config_id):
+        models = super()._load_pos_data_models(config_id)
+        models += ["hr.employee"]
+        return models

--- a/pos_salesperson/static/src/app/components/control_button/control_button.js
+++ b/pos_salesperson/static/src/app/components/control_button/control_button.js
@@ -1,0 +1,11 @@
+import { patch } from "@web/core/utils/patch";
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { SalespersonButton } from "@pos_salesperson/app/components/salesperson_button/salesperson_button";
+
+
+patch(ControlButtons,{
+    components:{
+        ...ControlButtons.components,
+        SalespersonButton
+    }
+})

--- a/pos_salesperson/static/src/app/components/control_button/control_button.xml
+++ b/pos_salesperson/static/src/app/components/control_button/control_button.xml
@@ -1,0 +1,7 @@
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_salesperson.SalesPersonButton" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//OrderlineNoteButton" position="after">
+                <SalespersonButton/>
+        </xpath>
+    </t>
+</templates>

--- a/pos_salesperson/static/src/app/components/salesperson_button/salesperson_button.js
+++ b/pos_salesperson/static/src/app/components/salesperson_button/salesperson_button.js
@@ -1,0 +1,39 @@
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+import { Component, useState } from "@odoo/owl";
+
+
+export class SalespersonButton extends Component{
+    static template = "pos_salesperson.SalespersonButton";
+
+    setup(){
+        this.state = useState({selectedSalesPerson:""})
+        this.dialog = useService("dialog");
+        this.pos = usePos();
+    }
+
+    async chooseSalesPerson(){
+        const order = this.pos.get_order();
+        const allSalesPersonList = this.pos.models?.["hr.employee"];
+
+        let salesPersonList =  allSalesPersonList.map((s)=>({
+            id:s.id,
+            item:s,
+            label:s.name,
+            isSelected:false
+        }))
+
+        const selectedSalesPerson = await makeAwaitable(this.dialog, SelectionPopup, {
+            list: salesPersonList,
+            title: _t("Select the salesperson"),
+        });
+
+        if(selectedSalesPerson){
+            this.state.selectedSalesPerson = selectedSalesPerson;
+            order.salesperson_id = selectedSalesPerson;
+        }
+    }
+}

--- a/pos_salesperson/static/src/app/components/salesperson_button/salesperson_button.xml
+++ b/pos_salesperson/static/src/app/components/salesperson_button/salesperson_button.xml
@@ -1,0 +1,10 @@
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_salesperson.SalespersonButton">
+        <button class="btn btn-light btn-lg lh-lg text-truncate w-auto" t-on-click="chooseSalesPerson">
+            <t t-if="state.selectedSalesPerson">
+                <div class="text-truncate text-action" t-esc="state.selectedSalesPerson.name"/>
+            </t>
+            <t t-else="">SalesPerson</t>            
+        </button>
+    </t>
+</templates>

--- a/pos_salesperson/views/pos_order_views.xml
+++ b/pos_salesperson/views/pos_order_views.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <record id="pos_form_view_salesperson" model="ir.ui.view">
+        <field name="name">pos.order.form</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='order_fields']" position="inside">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+    <record id="pos_list_view_salesperson" model="ir.ui.view">
+        <field name="name">pos.order.list</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before:
-The POS billing screen did not have any option to select a salesperson.
-Salesperson data was not captured or displayed in POS order records.

After:
-Introduced a dropdown menu in the POS billing screen to select a salesperson (employee) from the available list.
-Captured the selected salesperson in each POS order.
-Displayed the salesperson field in both the POS order form view and list view.

Impact:
-Allows tracking of which employee handled each sale.


Task: [4968061]