### PR TITLE
[ADD] sale: Auto-recalculate global discount on order line changes

### DIFF
--- a/discount_price/__init__.py
+++ b/discount_price/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/discount_price/__manifest__.py
+++ b/discount_price/__manifest__.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Discount Price',
+    'version': '1.0',
+    'depends': ['sale_management'],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/discount_price/models/__init__.py
+++ b/discount_price/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order
+from . import sale_order_line

--- a/discount_price/models/sale_order.py
+++ b/discount_price/models/sale_order.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    wizard_ids = fields.One2many(
+        "sale.order.discount", "sale_order_id", string="Discount Wizards"
+    )
+
+    def _update_discount(self):
+        discount_product = self.env["product.product"].search([("name", "=", "Discount")], limit=1)
+        if not discount_product:
+            return
+
+        total_amount = sum(line.price_subtotal for line in self.order_line if not line.is_discount_line())
+        discount_lines = self.order_line.filtered(lambda l: l.is_discount_line())
+        if not total_amount:
+            discount_lines.unlink()
+            return
+
+        if self.wizard_ids and discount_lines:
+            discount_percentage = self.wizard_ids[-1].discount_percentage
+        else:
+            discount_lines.unlink()
+            return
+
+        discount_amount = total_amount * discount_percentage
+        if len(discount_lines) > 1:
+            discount_lines[1:].unlink()
+            discount_line = discount_lines[0]
+        elif discount_lines:
+            discount_line = discount_lines[0]
+        else:
+            discount_line = False
+
+        vals = {
+            "price_unit": -discount_amount,
+            "name": f"Discount {discount_percentage * 100:.2f}%",
+        }
+
+        if discount_line:
+            discount_line.write(vals)

--- a/discount_price/models/sale_order_line.py
+++ b/discount_price/models/sale_order_line.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def is_discount_line(self):
+        discount_product = self.order_id.env["product.product"].search([("name", "=", "Discount")], limit=1)
+        return self.product_id == discount_product
+
+    def unlink(self):
+        order_ids = self.mapped("order_id")
+        res = super().unlink()
+        for order in order_ids:
+            order._update_discount()
+        return res
+
+    @api.model_create_multi
+    def create(self, vals):
+        lines = super().create(vals)
+        for line in lines:
+            if line.order_id and not line.is_discount_line():
+                line.order_id._update_discount()
+        return lines
+
+    def write(self, vals):
+        res = super().write(vals)
+        for line in self:
+            if not line.is_discount_line():
+                line.order_id._update_discount()
+        return res


### PR DESCRIPTION
Before:
- Global discount remained unchanged even after modifying, deleting, or adding sale order lines.
- Discount lines were not automatically removed when no product lines existed.
-This could result in incorrect order totals or stale discount values, requiring manual updates.

After:
- Global discount is now automatically recalculated whenever sale order lines are changed.
- Discount line is removed if all product lines are deleted.
- 
Impact:
-Ensures consistent and accurate pricing aligned with the current order state.
-Ensures accurate and reliable order totals.

task-4962389