### PR TITLE
[ADD] salesperson_in_pos: adding salesperson button in POS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+website_airproof/

--- a/salesperson_in_pos/__init__.py
+++ b/salesperson_in_pos/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/salesperson_in_pos/__manifest__.py
+++ b/salesperson_in_pos/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': "Salesperson_Pos",
+    'version': "1.0",
+    'summary': "Add salesperson field in POS app",
+    'description': "This module adds a button in the POS dashboard to assign a salesperson to respective orders.",
+    'author': "Priyansi Borda",
+    'depends': ['base', 'point_of_sale', 'hr'],
+    'data': [
+        "views/pos_view.xml",
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'salesperson_in_pos/static/src/**/*',
+        ],
+    },
+    'application': False,
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/salesperson_in_pos/models/__init__.py
+++ b/salesperson_in_pos/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import pos_order
+from . import pos_session

--- a/salesperson_in_pos/models/pos_order.py
+++ b/salesperson_in_pos/models/pos_order.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    salesperson_id = fields.Many2one('hr.employee', string='Salesperson', help='Salesperson who created the order')

--- a/salesperson_in_pos/models/pos_session.py
+++ b/salesperson_in_pos/models/pos_session.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class PosSession(models.Model):
+    _inherit = 'pos.session'
+
+    def _load_pos_data_models(self, config_id):
+        data = super()._load_pos_data_models(config_id)
+        data.append("hr.employee")
+        return data

--- a/salesperson_in_pos/static/src/salesperson_button/salesperson_button.js
+++ b/salesperson_in_pos/static/src/salesperson_button/salesperson_button.js
@@ -1,0 +1,30 @@
+import { SalespersonList } from '@salesperson_in_pos/salesperson_list/salesperson_list';
+import { ControlButtons } from '@point_of_sale/app/screens/product_screen/control_buttons/control_buttons';
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { patch } from '@web/core/utils/patch';
+import { useState } from '@odoo/owl';
+
+patch(ControlButtons.prototype, {
+    setup(){
+        super.setup();
+        this.state = useState({
+            salesperson_id: null,
+        });
+    },
+    async selectSalesperson() {
+        const currentOrder = this.pos.get_order();
+        if (!currentOrder) {
+            return;
+        }
+
+        const currentSalesperson = currentOrder.salesperson_id || null; 
+        const payload = await makeAwaitable(this.dialog, SalespersonList, {
+            salesperson: currentSalesperson,
+            getPayload: (newSalesperson) => newSalesperson || null,
+        });
+        this.state.salesperson_id = payload || null;
+        currentOrder.salesperson_id = payload || null;
+        return currentOrder.salesperson_id;
+
+    }
+})

--- a/salesperson_in_pos/static/src/salesperson_button/salesperson_button.xml
+++ b/salesperson_in_pos/static/src/salesperson_button/salesperson_button.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="salesperson_button" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//OrderlineNoteButton" position="after">
+            <button class="btn btn-light btn-lg lh-lg text-truncate w-auto" t-on-click="selectSalesperson">
+                <div t-if="state.salesperson_id" t-out="state.salesperson_id.name" class="text-truncate text-action" />
+                <t t-else="">Salesperson</t>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/salesperson_in_pos/static/src/salesperson_list/salesperson_list.js
+++ b/salesperson_in_pos/static/src/salesperson_list/salesperson_list.js
@@ -1,0 +1,42 @@
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { Dialog } from "@web/core/dialog/dialog";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { Component, useState } from "@odoo/owl";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+
+
+export class SalespersonList extends Component {
+    static template = "POS_Salesperson.SalespersonList";
+    static components = { Dialog };
+    static props = {
+        salesperson: {
+            optional: true,
+            type: [{ value: null }, Object],
+        },
+        getPayload : { type: Function },
+        close : { type: Function }
+    }
+
+    setup() {
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+        this.dialog = useService("dialog");
+
+        this.state = useState({
+            query: null,
+            previousQuery: "",
+            currentOffset: 0,
+        });
+        useHotkey("enter", () => this.onEnter());
+    }
+    getSalesPerson(){
+        const salesperson = this.pos.models['hr.employee'].getAll();
+        return salesperson;
+    }
+
+    clickSalesPerson(salesperson) {
+        this.props.getPayload(salesperson);
+        this.props.close();
+    }
+}

--- a/salesperson_in_pos/static/src/salesperson_list/salesperson_list.xml
+++ b/salesperson_in_pos/static/src/salesperson_list/salesperson_list.xml
@@ -1,0 +1,32 @@
+<templates id="template" xml:space="preserve">
+  <t t-name="POS_Salesperson.SalespersonList">
+    <Dialog bodyClass="'overflow-y-auto'" contentClass="'h-100'">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          <t t-foreach="getSalesPerson()" t-as="salesperson" t-key="salesperson.id">
+            <tr 
+              t-att-class="salesperson.id == props.salesperson?.id ? 'active' : ''" 
+              t-on-click="() => this.clickSalesPerson(salesperson)">
+              <td t-out="salesperson.name"/>
+            </tr>
+          </t>
+        </tbody>
+      </table>
+
+      <t t-set-slot="footer">
+        <div class="d-flex justify-content-start flex-wrap gap-2 w-100">
+          <button 
+            class="btn btn-secondary btn-lg lh-lg o-default-button" 
+            t-on-click="() => this.clickSalesPerson(salesperson)">
+            Discard
+          </button>
+        </div>
+      </t>
+    </Dialog>
+  </t>
+</templates>

--- a/salesperson_in_pos/views/pos_view.xml
+++ b/salesperson_in_pos/views/pos_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_pos_form_inherit" model="ir.ui.view">
+        <field name="name">pos.order.form.inherit</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='fiscal_position_id']" position="after">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_pos_list_inherit" model="ir.ui.view">
+        <field name="name">pos.order.list.inherit</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- In this PR, the pos.order model was inherited to enable the use of the custom app point_of_sale module within the form and list views of POS orders.
- Also a salesperson button was added to the POS dashboard to allow quick access and better user interaction with salesperson-related functionalities.

Task-4958100