### PR TITLE
[IMP] inventory: improve stock info and UI in product form

### DIFF
--- a/update_on_hand/__init__.py
+++ b/update_on_hand/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/update_on_hand/__manifest__.py
+++ b/update_on_hand/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'Update Quantity On Hand',
+    'version': '1.0',
+    'author': 'niyp',
+    'depends': ['stock'],
+    'data': [
+        'views/product_template_views.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/update_on_hand/models/__init__.py
+++ b/update_on_hand/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/update_on_hand/models/product_template.py
+++ b/update_on_hand/models/product_template.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    is_multilocation = fields.Boolean(compute="_compute_is_multilocation")
+
+    @api.depends('product_variant_ids.stock_quant_ids.location_id')
+    def _compute_is_multilocation(self):
+        for record in self:
+            internal_location_ids = {
+                loc.id
+                for loc in record.mapped(
+                    'product_variant_ids.stock_quant_ids.location_id'
+                )
+                if loc.usage == 'internal'
+            }
+            record.is_multilocation = len(internal_location_ids) > 1

--- a/update_on_hand/views/product_template_views.xml
+++ b/update_on_hand/views/product_template_views.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_product_template_form_inherited" model="ir.ui.view">
+        <field name="name">product.template.form.custom.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
+        <field name="arch" type="xml">
+
+            <xpath expr="//button[@name='action_update_quantity_on_hand']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
+            <xpath expr="//button[@invisible='not show_on_hand_qty_status_button']"
+                position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='virtual_available']"
+                position='attributes'>
+                <attribute name='decoration-danger'>virtual_available &lt; 0</attribute>
+                <attribute name='decoration-primary'>virtual_available == 0</attribute>
+            </xpath>
+
+            <xpath
+                expr="//button[@name='action_product_tmpl_forecast_report']/div/span[hasclass('o_stat_value', 'd-flex', 'gap-1')]/field[@name='uom_name']"
+                position='replace'>
+                <span>Forecasted</span>
+            </xpath>
+
+            <xpath
+                expr="//button[@name='action_product_tmpl_forecast_report']/div/span[hasclass('o_stat_value', 'd-flex', 'gap-1')]"
+                position='before'>
+                <span class="o_stat_value d-flex gap-1">
+                    <field name="qty_available" nolabel="1" class="oe_inline" />
+                    <field name="uom_name" class="oe_inline" />
+                </span>
+            </xpath>
+
+            <xpath
+                expr="//button[@name='action_product_tmpl_forecast_report']/div/span[hasclass('o_stat_text')]"
+                position='attributes'>
+                <attribute name='invisible'>1</attribute>
+            </xpath>
+
+        </field>
+    </record>
+
+    <record id="product_template_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.template.common.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='product_tooltip']" position='attributes'>
+                <attribute name='invisible'>type == 'consu'</attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='product_tooltip']" position="after">
+                <label for="qty_available" invisible='not is_storable'>Quantity On Hand</label>
+                <span class="d-flex gap-3">
+                    <field name="qty_available"
+                        readonly="is_multilocation"
+                        class="oe_inline"
+                        invisible='not is_storable'
+                    />
+                    <field name="uom_name" class="oe_inline" invisible='not is_storable' />
+                    <button type="action"
+                        name="%(stock.action_product_stock_view)d"
+                        class="oe_stat_button oe_inline opacity-0 opacity-100-hover"
+                        invisible="not is_storable">
+                        Update
+                    </button>
+                </span>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This change addresses UX consistency and operational safety for users managing inventory in multi-company environments. By conditionally disabling the "Quantity On Hand" field and hiding stock-related actions, we reduce the risk of unintended stock updates by users switching across companies.

Additionally, visual cues were introduced to help users interpret stock availability at a glance using decorations on forecast fields. Simplified labels and stat displays aim to streamline the interface and enhance clarity, especially for forecast-related buttons and values.

These updates prioritize user context awareness, clean visual hierarchy, and help prevent data inconsistencies in environments with multiple active companies.

task-4965097