### PR TITLE
[ADD] send_invoice: add send invoice automatically by email module

### DIFF
--- a/send_invoice/__init__.py
+++ b/send_invoice/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/send_invoice/__manifest__.py
+++ b/send_invoice/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "send invoice via mail",
+    "version": "1.0",
+    "author": "gasa",
+    "license": "LGPL-3",
+    "depends": ["account"],
+    "application": True,
+    "installable": True,
+    "data": [
+        "views/res_config_settings.xml"
+    ]
+}

--- a/send_invoice/models/__init__.py
+++ b/send_invoice/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import res_config_settings
+from . import send_email

--- a/send_invoice/models/res_config_settings.py
+++ b/send_invoice/models/res_config_settings.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    send_invoice_via_email = fields.Integer(String="send invoice by email", config_parameter="send_invoice.send_invoice_via_email"
+)

--- a/send_invoice/models/send_email.py
+++ b/send_invoice/models/send_email.py
@@ -1,0 +1,35 @@
+
+from odoo import models, fields
+from datetime import timedelta
+
+
+class SendEmail(models.Model):
+    _inherit = "account.move"
+
+    def _send_email_invoice(self):
+        """
+        Use sudo() to bypass access rights when reading system parameters.
+        Using sudo ensures the method can always retrieve the configuration
+        value regardless of the user's permissions.
+        """
+        hour = self.env['ir.config_parameter'].sudo().get_param('send_invoice.send_invoice_via_email')
+        if not hour:
+            return
+
+        try:
+            hour = int(hour)
+        except ValueError:
+            return
+
+        target_date = fields.Datetime.now() - timedelta(hours=hour)
+        invoices = self.search([
+            ('invoice_date', '=', target_date),
+            ('payment_state', '!=', 'paid'),
+            ('state', '=', 'posted')
+        ])
+        template = self.env.ref('account.email_template_edi_invoice', raise_if_not_found=False)
+        if not template:
+            return
+
+        for invoice in invoices:
+            template.send_mail(invoice.id, force_send=True)

--- a/send_invoice/views/ir_corn_send_email.xml
+++ b/send_invoice/views/ir_corn_send_email.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <record id="ir_cron_send_email_invoice" model="ir.cron">
+        <field name="name">Send Invoice Email</field>
+        <field name="model_id" ref="account.model_account_move" />
+        <field name="state">code</field>
+        <field name="code">model._send_email_invoice()</field>
+        <field name="interval_number">6</field>
+        <field name="interval_type">hours</field>
+        <field name="active" eval="True" />
+    </record>
+</odoo>

--- a/send_invoice/views/res_config_settings.xml
+++ b/send_invoice/views/res_config_settings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="res_config_settings_view" model="ir.ui.view">
+        <field name="name">res.config.settings.inherit.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//block//setting[@id='total_amount_words']"
+                position="after">
+                <setting id="automatic_send_invoice" >
+                    <label for="send_invoice_via_email" />
+                    <div>
+                        <field name="send_invoice_via_email" class="oe_inline" />
+                        <span>hours</span>
+                    </div>
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this task,
add module which send invoice by email automatically. in settings fill field enter the number of days to send email after the invoice date. the purpose of the task is that do not need to send invoice by manually it will automatically send by email depend upon how many days will be selected.

task: 4963414
