### PR TITLE
[ADD] account_automate_invoice_mail: add invoice email settings and cron job

### DIFF
--- a/account_automate_invoice_mail/__init__.py
+++ b/account_automate_invoice_mail/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/account_automate_invoice_mail/__manifest__.py
+++ b/account_automate_invoice_mail/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    "name": "Account automate invoice mail",
+    "version": "0.1",
+    "depends": ["account"],
+    "installable": True,
+    "license": "LGPL-3",
+    "data": ["views/res_config_settings_views.xml", "data/send_invoice_cron.xml"]
+}

--- a/account_automate_invoice_mail/data/send_invoice_cron.xml
+++ b/account_automate_invoice_mail/data/send_invoice_cron.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="send_automated_email_cron" model="ir.cron">
+        <field name="name">Send Invoices by email automatically</field>
+        <field name="model_id" ref="account.model_account_move"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_send_invoice_by_email()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="active">True</field>
+    </record>
+</odoo>

--- a/account_automate_invoice_mail/models/__init__.py
+++ b/account_automate_invoice_mail/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import res_config_settings
+from . import account_move

--- a/account_automate_invoice_mail/models/account_move.py
+++ b/account_automate_invoice_mail/models/account_move.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date, timedelta
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model
+    def _cron_send_invoice_by_email(self):
+        """
+        Uses `sudo()` to securely access system configuration parameters.
+        """
+        send_invoice_days = int(self.env["ir.config_parameter"].sudo().get_param("send_email_invoice_days"))
+        target_invoice_date = date.today() - timedelta(days=send_invoice_days)
+        invoices = self.search([('state', '=', 'posted'), ('invoice_date', '=', target_invoice_date)])
+        template = self.env.ref("account.email_template_edi_invoice")
+        self.env['account.move.send']._generate_and_send_invoices(invoices, mail_template=template)

--- a/account_automate_invoice_mail/models/res_config_settings.py
+++ b/account_automate_invoice_mail/models/res_config_settings.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    send_email_invoice_days = fields.Integer(string="Send invoice by email", config_parameter="send_email_invoice_days")

--- a/account_automate_invoice_mail/views/res_config_settings_views.xml
+++ b/account_automate_invoice_mail/views/res_config_settings_views.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form_automate_mail" model="ir.ui.view">
+            <field name="name">res.config.settings.view.inherit.invoice_automate_mail</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//setting[@id='display_invoice_tax_company_currency']" position="after">
+                    <setting help="Duration in days after the date of invoice">
+                        <field name="send_email_invoice_days"/>
+                    </setting>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Description:
This PR introduces functionality to automate invoice email delivery based on a configurable delay.

Before:
There was no way to configure how many days in advance invoices should be emailed automatically. No cron existed to handle this.

After:
Added a settings field send_email_invoice_days in invoice configuration. Created a cron that runs daily and sends emails (with PDF attachment) for posted invoices whose invoice_date is exactly N days before today, as per config.

Impact:
Automates invoice email sending based on configurable delay, improving billing workflows.

Task:[4968898]