### PR TITLE
[ADD] point_of_sale: added salesperson field

### DIFF
--- a/pos_salesperson/__init__.py
+++ b/pos_salesperson/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_salesperson/__manifest__.py
+++ b/pos_salesperson/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': "POS salesperson",
+    'version': '1.0',
+    'license': 'LGPL-3',
+    'depends': ['pos_hr'],
+    'author': "Kalpan Desai",
+    'category': 'Sales/Point of Sale',
+    'description': """
+    Salesperson in POS
+    """,
+    'installable': True,
+    'application': True,
+    'data': [
+        'views/pos_view.xml',
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_salesperson/static/src/**/*'
+        ]
+    },
+}

--- a/pos_salesperson/models/__init__.py
+++ b/pos_salesperson/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_order
+from . import pos_session

--- a/pos_salesperson/models/pos_order.py
+++ b/pos_salesperson/models/pos_order.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    salesperson_id = fields.Many2one(
+        'hr.employee',
+        string='Salesperson',
+        help='The salesperson responsible for this order.'
+    )

--- a/pos_salesperson/models/pos_session.py
+++ b/pos_salesperson/models/pos_session.py
@@ -1,0 +1,12 @@
+from odoo import api, models
+
+
+class PosSession(models.Model):
+    """Inherit the pos.session to load the data of hr.employee model"""
+    _inherit = 'pos.session'
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        data = super()._load_pos_data_models(config_id)
+        data += ['hr.employee']
+        return data

--- a/pos_salesperson/static/src/salesperson_button/salesperson_button.js
+++ b/pos_salesperson/static/src/salesperson_button/salesperson_button.js
@@ -1,0 +1,30 @@
+import { SalespersonList } from '../salesperson_list/salesperson_list';
+import { ControlButtons } from '@point_of_sale/app/screens/product_screen/control_buttons/control_buttons';
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { patch } from '@web/core/utils/patch';
+import { useState } from '@odoo/owl';
+
+patch(ControlButtons.prototype, {
+    setup(){
+        super.setup();
+        this.state = useState({
+            salesperson_id: null,
+        });
+    },
+    async selectSalesperson() {
+        const currentOrder = this.pos.get_order();
+        if (!currentOrder) {
+            return;
+        }
+
+        const currentSalesperson = currentOrder.salesperson_id || null; 
+        const payload = await makeAwaitable(this.dialog, SalespersonList, {
+            salesperson: currentSalesperson,
+            getPayload: (newSalesperson) => newSalesperson || null,
+        });
+        this.state.salesperson_id = payload || null;
+        currentOrder.salesperson_id = payload || null;
+        return currentOrder.salesperson_id;
+
+    }
+})

--- a/pos_salesperson/static/src/salesperson_button/salesperson_button.xml
+++ b/pos_salesperson/static/src/salesperson_button/salesperson_button.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="salesperson_button" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//OrderlineNoteButton" position="after">
+            <button class="btn btn-light btn-lg lh-lg text-truncate w-auto" t-on-click="selectSalesperson">
+                <div t-if="state.salesperson_id" t-out="state.salesperson_id.name" class="text-truncate text-action" />
+                <t t-else="">Salesperson</t>
+            </button>
+        </xpath>
+    </t>
+</templates>
+    

--- a/pos_salesperson/static/src/salesperson_list/salesperson_list.js
+++ b/pos_salesperson/static/src/salesperson_list/salesperson_list.js
@@ -1,0 +1,42 @@
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { Dialog } from "@web/core/dialog/dialog";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { Component, useState } from "@odoo/owl";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+
+
+export class SalespersonList extends Component {
+    static template = "POS_Salesperson.SalespersonList";
+    static components = { Dialog };
+    static props = {
+        salesperson: {
+            optional: true,
+            type: [{ value: null }, Object],
+        },
+        getPayload : { type: Function },
+        close : { type: Function }
+    }
+
+    setup() {
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+        this.dialog = useService("dialog");
+
+        this.state = useState({
+            query: null,
+            previousQuery: "",
+            currentOffset: 0,
+        });
+        useHotkey("enter", () => this.onEnter());
+    }
+    getSalesPerson(){
+        const salesperson = this.pos.models['hr.employee'].getAll();
+        return salesperson;
+    }
+
+    clickSalesPerson(salesperson) {
+        this.props.getPayload(salesperson);
+        this.props.close();
+    }
+}

--- a/pos_salesperson/static/src/salesperson_list/salesperson_list.xml
+++ b/pos_salesperson/static/src/salesperson_list/salesperson_list.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+  <t t-name="POS_Salesperson.SalespersonList">
+    <Dialog bodyClass="'overflow-y-auto'" contentClass="'h-100'">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          <t t-foreach="getSalesPerson()" t-as="salesperson" t-key="salesperson.id">
+            <tr 
+              t-att-class="salesperson.id == props.salesperson?.id ? 'active' : ''" 
+              t-on-click="() => this.clickSalesPerson(salesperson)">
+              <td t-out="salesperson.name"/>
+            </tr>
+          </t>
+        </tbody>
+      </table>
+
+      <t t-set-slot="footer">
+        <div class="d-flex justify-content-start flex-wrap gap-2 w-100">
+          <button 
+            class="btn btn-secondary btn-lg lh-lg o-default-button" 
+            t-on-click="() => this.clickSalesPerson(salesperson)">
+            Discard
+          </button>
+        </div>
+      </t>
+    </Dialog>
+  </t>
+</templates>

--- a/pos_salesperson/views/pos_view.xml
+++ b/pos_salesperson/views/pos_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_pos_form_inherit" model="ir.ui.view">
+        <field name="name">pos.order.form.inherit</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='fiscal_position_id']" position="after">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_pos_list_inherit" model="ir.ui.view">
+        <field name="name">pos.order.list.inherit</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Introduced the functionality to assign a salesperson to a Point of Sale order.

Added new dialog menu, populated with employees from hr.employee, has been added
 to the main POS interface.

A  (Many2one) field was added to the  model to store
 the selected employee.

The POS Order form and list views in the backend have been updated to display the salesperson's name.

Employee data is now loaded into the POS session to make it available in the UI.

Task-4968717