### PR TITLE
[ADD] pos_ticket_payment: add payment button on TicketScreen

### DIFF
--- a/pos_ticket_payment/__manifest__.py
+++ b/pos_ticket_payment/__manifest__.py
@@ -1,0 +1,29 @@
+{
+    "name": "POS Ticket Payment",
+    "summary": "Enable direct payment from the ticket screen in POS",
+    "description": """
+POS Ticket Payment
+==================
+
+This module enhances the Point of Sale interface by allowing users to initiate payment directly from the ticket (order) screen.
+
+Key Features:
+-------------
+- Adds a "Payment" button next to the "Load" button on the ticket screen.
+- Clicking "Payment" will load the selected order and navigate to the payment screen.
+- Speeds up the checkout process for saved orders.
+
+Ideal for fast-paced retail environments where quick payment access is essential.
+""",
+    "license": "AGPL-3",
+    "application": True,
+    "installable": True,
+    "depends": ["point_of_sale"],
+    "author": "Dhruvrajsinh Zala (zadh)",
+    "version": "0.1",
+    "assets": {
+        "point_of_sale._assets_pos": [
+            "pos_ticket_payment/static/src/app/**/*"
+        ]
+    }
+}

--- a/pos_ticket_payment/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/pos_ticket_payment/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -1,0 +1,9 @@
+import { TicketScreen } from '@point_of_sale/app/screens/ticket_screen/ticket_screen';
+import { patch } from '@web/core/utils/patch';
+
+patch(TicketScreen.prototype, {
+    async onPayClick() {
+        this.pos.set_order(this.getSelectedOrder());
+        this.pos.pay();
+    },
+});

--- a/pos_ticket_payment/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/pos_ticket_payment/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_ticket_payment.PaymentButton" t-inherit="point_of_sale.TicketScreen" t-inherit-mode="extension">
+        <xpath expr="//div[@t-if='ui.isSmall']//button[hasclass('load-order-button')]" position="after">
+            <button class="button btn-primary pay-order-button btn btn-lg w-50" t-on-click="onPayClick">Payment</button>
+        </xpath>
+        <xpath expr="//div[@t-else='']//button[hasclass('load-order-button')]" position="after">
+            <button class="button btn-primary pay-order-button btn btn-lg w-100" t-on-click="onPayClick">Payment</button>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Before:
Users had to manually:
1. Click the "Load Order" button to load a ticket.
2. Then click the "Payment" button to proceed to the PaymentScreen.
This made the payment flow slower and more manual.

After:
- Introduced a new "Payment" button beside the "Load Order" button on the TicketScreen.
- On click, it directly loads the selected order and opens the PaymentScreen.

Impact:
Reduces steps in the cashier workflow by allowing users to immediately proceed to payment with a single click from the TicketScreen.

Task:[4982532]
