### PR TITLE
[ADD] pos_receipt: allow custom receipt layout with preview

### DIFF
--- a/pos_receipt/__init__.py
+++ b/pos_receipt/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import wizard

--- a/pos_receipt/__manifest__.py
+++ b/pos_receipt/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'POS receipt',
+    'version': '1.0',
+    'author': 'niyp',
+    'depends': ['point_of_sale'],
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/pos_receipt_wizard_views.xml',
+        'views/res_config_settings_view.xml',
+        'views/boxes_receipt.xml',
+        'views/lined_receipt.xml',
+        'views/light_receipt.xml',
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_receipt/static/src/**/*',
+        ],
+    },
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/pos_receipt/models/__init__.py
+++ b/pos_receipt/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_config
+from . import res_config_settings

--- a/pos_receipt/models/pos_config.py
+++ b/pos_receipt/models/pos_config.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class POSConfig(models.Model):
+    _inherit = 'pos.config'
+
+    receipt_layout = fields.Selection([
+        ('light', 'Light'),
+        ('lined', 'Lined'),
+        ('boxes', 'Boxes'),
+    ], string="Receipt Layout", default='light')
+
+    receipt_logo = fields.Binary(string='Receipt Logo', related='company_id.logo', readonly=False)

--- a/pos_receipt/models/res_config_settings.py
+++ b/pos_receipt/models/res_config_settings.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    receipt_layout = fields.Selection(related='pos_config_id.receipt_layout', readonly=False)
+
+    def action_pos_receipt_layout(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Configure your pos receipt',
+            'res_model': 'pos.receipt.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {'active_pos_config_id': self.pos_config_id.id, 'dialog_size': 'extra-large'},
+        }

--- a/pos_receipt/security/ir.model.access.csv
+++ b/pos_receipt/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+pos_receipt.access_receipt_layout,access_receipt_layout,pos_receipt.model_pos_receipt_wizard,base.group_user,1,1,1,1

--- a/pos_receipt/static/src/order_receipt_inherit.js
+++ b/pos_receipt/static/src/order_receipt_inherit.js
@@ -1,0 +1,22 @@
+import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
+import { patch } from "@web/core/utils/patch";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+
+patch(OrderReceipt, {
+    template: "pos_receipt.order_receipt_inherited"
+});
+
+patch(OrderReceipt.prototype, {
+    setup(){
+        super.setup();
+        this.pos = usePos();
+    },
+
+    get orderQuantity() {
+        return this.props.data.orderlines.reduce((acc, line) => acc + parseFloat(line.qty), 0);
+    },
+
+    get order() {
+        return this.pos.get_order();
+    }
+});

--- a/pos_receipt/static/src/order_receipt_inherit.xml
+++ b/pos_receipt/static/src/order_receipt_inherit.xml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_receipt.order_receipt_inherited">
+        <div class="pos-receipt p-2">
+            <t t-if= "order.config_id.receipt_layout=='light'">
+                    <t t-set="showTaxGroupLabels" t-value="doesAnyOrderlineHaveTaxLabel()"/>
+                    <ReceiptHeader data="props.data.headerData" />
+                    <OrderWidget lines="props.data.orderlines" t-slot-scope="scope" generalNote="props.data.generalNote or ''" screenName="props.data.screenName">
+                        <t t-set="line" t-value="scope.line"/>
+                        <Orderline basic_receipt="props.basic_receipt" line="omit(scope.line, 'customerNote')" class="{ 'px-0': true }" showTaxGroupLabels="showTaxGroupLabels">
+                            <li t-if="line.customerNote" class="customer-note">
+                                <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
+                                <t t-esc="line.customerNote" />
+                            </li>
+                        </Orderline>
+                    </OrderWidget>
+                    <t t-if="!props.basic_receipt">
+                        <div t-if="props.data.tax_details.length > 0" class="pos-receipt-taxes">
+                            <div class="text-center">--------------------------------</div>
+                            <div class="d-flex">
+                                <span t-if="showTaxGroupLabels" class="me-2" style="visibility: hidden;">A</span>
+                                <span class="fw-bolder">Untaxed Amount</span>
+                                <span t-esc="props.formatCurrency(props.data.total_without_tax)" class="ms-auto"/>
+                            </div>
+                            <div t-foreach="props.data.tax_details" t-as="tax" t-key="tax.id" class="d-flex">
+                                <t t-if="showTaxGroupLabels">
+                                    <span t-if="tax.tax_group_id.pos_receipt_label" t-esc="tax.tax_group_id.pos_receipt_label" class="me-2"/>
+                                    <span t-else="" class="me-2" style="visibility: hidden;">A</span>
+                                </t>
+                                <span>
+                                    <span t-esc="tax.name"/>
+                                    on
+                                    <span t-esc="props.formatCurrency(tax.base)"/>
+                                </span>
+                                <span t-esc="props.formatCurrency(tax.amount)" class="ms-auto"/>
+                            </div>
+                        </div>
+                        <div class="text-center">--------------------------------</div>
+                        <div class="pos-receipt-amount">
+                            TOTAL
+                            <span t-esc="props.formatCurrency((props.data.amount_total))" class="pos-receipt-right-align"/>
+                        </div>
+                        <t t-if="props.data.rounding_applied">
+                            <div class="pos-receipt-amount">
+                                Rounding
+                                <span t-esc='props.formatCurrency(props.data.rounding_applied)' class="pos-receipt-right-align"/>
+                            </div>
+                            <div class="pos-receipt-amount">
+                                To Pay
+                                <span t-esc='props.formatCurrency((props.data.amount_total) + props.data.rounding_applied)' class="pos-receipt-right-align"/>
+                            </div>
+                        </t>
+                        <div class="paymentlines text-start" t-foreach="props.data.paymentlines" t-as="line" t-key="line_index">
+                            <t t-esc="line.name" />
+                            <span t-esc="props.formatCurrency(line.amount)" class="pos-receipt-right-align"/>
+                        </div>
+                        <div t-if="props.data.change != 0" class="pos-receipt-amount receipt-change">
+                            CHANGE
+                            <span t-esc="props.formatCurrency(props.data.change)" class="pos-receipt-right-align"/>
+                        </div>
+                        <t t-if="props.data.total_discount">
+                            <div class="text-center">
+                                Discounts
+                                <span t-esc="props.formatCurrency(props.data.total_discount)" class="pos-receipt-right-align"/>
+                            </div>
+                        </t>
+                        <div class="before-footer" />
+                        <div t-if="props.data.pos_qr_code">
+                            <br/>
+                            <div class="pos-receipt-order-data mb-2">
+                                Need an invoice for your purchase? 
+                            </div>
+                        </div>
+                        <div t-if="['qr_code', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code" class="mb-2">
+                            <img id="posqrcode" t-att-src="props.data.pos_qr_code" class="pos-receipt-logo"/>
+                        </div>
+                        <div t-if="props.data.pos_qr_code">
+                            <div class="pos-receipt-order-data">
+                                Unique Code:
+                                <t t-esc="props.data.ticket_code"/>
+                            </div>
+                        </div>
+                        <div t-if="['url', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code">
+                            <div class="pos-receipt-order-data" t-attf-class="{{ props.data.ticket_portal_url_display_mode === 'qr_code_and_url' ? 'mt-3' : '' }}">
+                                Portal URL:
+                                <t t-out="props.data.base_url"/>/pos/ticket
+                            </div>
+                        </div>
+                    </t>
+                    <div t-if="props.data.footer" class="pos-receipt-center-align">
+                        <br/>
+                        <t t-esc="props.data.footer" />
+                        <br/>
+                        <br/>
+                    </div>
+                    <div class="after-footer">
+                        <t t-foreach="props.data.paymentlines" t-as="line" t-key="line_index">
+                            <t t-if="line.ticket">
+                                <br />
+                                <div class="pos-payment-terminal-receipt">
+                                    <pre t-esc="line.ticket" />
+                                </div>
+                            </t>
+                        </t>
+                    </div>
+                    <br/>
+                    <t t-if="props.data.shippingDate">
+                        <div class="pos-receipt-order-data">
+                            Expected delivery:
+                            <div>
+                                <t t-esc="props.data.shippingDate" />
+                            </div>
+                        </div>
+                    </t>
+                    <br/>
+                    <div class="pos-receipt-order-data">
+                        <p>Odoo Point of Sale</p>
+                        <div t-esc="props.data.name" />
+                        <div id="order-date" t-esc="props.data.date" />
+                    </div>
+            </t>
+             <t t-if="order.config_id.receipt_layout=='boxes'">
+                    <ReceiptHeader data="props.data.headerData"/>
+                    <div class="receipt-preview-dark-receipt">
+                        <table class="table table-bordered border-dark table-sm">
+                            <thead>
+                                <tr>
+                                    <th class="text-start small">No</th>
+                                    <th class="text-start small">Item</th>
+                                    <th class="text-end small">Amount</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <t t-foreach="props.data.orderlines" t-as="line" t-key="line_index">
+                                    <tr>
+                                        <td class="small">
+                                            <t t-esc="line_index+1"/>
+                                        </td>
+                                        <td class="small">
+                                            <strong>
+                                                <t t-esc="line.productName"/>
+                                            </strong>
+                                            <br/>
+                                            <span>
+                                                <t t-esc="line.qty"/> X
+                                                <t t-esc="line.unitPrice"/>
+                                            </span>
+                                            <br/>
+                                        </td>
+                                        <td class="text-end small">
+                                            <t t-esc="line.price"/>
+                                        </td>
+                                    </tr>
+                                </t>
+                            </tbody>
+                        </table>
+                        <div class="border-bottom border-dark py-1 mb-2">
+                            <div class="d-flex justify-content-between small">
+                                <span>Total Qty
+                                    <t t-esc="orderQuantity"/>
+                                </span>
+                                <span>Sub Total $
+                                    <t t-esc="(props.data.amount_total).toFixed(2)"/>
+                                </span>
+                            </div>
+                        </div>
+                        <div class="text-end mb-2 fw-bold small border-bottom border-dark" t-foreach="props.data.paymentlines" t-as="line" t-key="line_index">
+                            <t t-esc="line.name" />
+                            <span t-esc="props.formatCurrency(line.amount)"/>
+                        </div>
+                        <t t-if="props.data.tax_details.length > 0">
+                            <table class="table table-borderless table-sm mb-2">
+                                <thead>
+                                    <tr>
+                                        <th class="text-start small">Tax</th>
+                                        <th class="text-start small">Amount</th>
+                                        <th class="text-start small">Base</th>
+                                        <th class="text-end small">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="props.data.tax_details" t-as="tax" t-key="tax.id">
+                                        <td class="small m-0 p-0" t-esc="tax.name"/>
+                                        <td class="small m-0 p-0" t-esc="props.formatCurrency(tax.amount)"/>
+                                        <td class="small m-0 p-0" t-esc="props.formatCurrency(tax.base)"/>
+                                        <td class="text-end small m-0 p-0" t-esc="props.formatCurrency(tax.base + tax.amount)"/>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </t>
+                        <div t-if="props.data.footer" class="pos-receipt-center-align small">
+                            <br/>
+                            <t t-esc="props.data.footer"/>
+                            <br/>
+                            <br/>
+                        </div>
+                        <div class="after-footer">
+                            <t t-foreach="props.data.paymentlines" t-as="line" t-key="line_index">
+                                <t t-if="line.ticket">
+                                    <br/>
+                                    <div class="pos-payment-terminal-receipt">
+                                        <pre t-esc="line.ticket"/>
+                                    </div>
+                                </t>
+                            </t>
+                        </div>
+                        <br/>
+                        <t t-if="props.data.shippingDate">
+                            <div class="pos-receipt-order-data small">
+                                Expected delivery:
+                                <div>
+                                    <t t-esc="props.data.shippingDate"/>
+                                </div>
+                            </div>
+                        </t>
+                        <br/>
+                        <div class="pos-receipt-order-data small">
+                            <p>Odoo Point of Sale</p>
+                            <div t-esc="props.data.name"/>
+                            <div id="order-date" t-esc="props.data.date"/>
+                        </div>
+                    </div>
+            </t>
+ 
+            <t t-if="order.config_id.receipt_layout=='lined'">
+                    <ReceiptHeader data="props.data.headerData"/>
+                    <div class="receipt-preview-dark-receipt">
+                        <table class="table table-borderless table-sm mb-2">
+                            <thead class="border-top border-bottom border-dark">
+                                <tr>
+                                    <th class="text-start small">No</th>
+                                    <th class="text-start small">Item</th>
+                                    <th class="text-start small">Qty</th>
+                                    <th class="text-start small">Price</th>
+                                    <th class="text-end small">Amount</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <t t-foreach="props.data.orderlines" t-as="line" t-key="line_index">
+                                    <tr>
+                                        <td class="small">
+                                            <t t-esc="line_index+1"/>
+                                        </td>
+                                        <td class="small">
+                                            <t t-esc="line.productName"/>
+                                        </td>
+                                        <td class="small">
+                                            <t t-esc="line.qty"/>
+                                        </td>
+                                        <td class="small">
+                                            <t t-esc="line.unitPrice"/>
+                                        </td>
+                                        <td class="text-end small">
+                                            <t t-esc="line.price"/>
+                                        </td>
+                                    </tr>
+                                </t>
+                            </tbody>
+                        </table>
+                        <div class="border-top border-dark py-1 mb-2">
+                            <div class="d-flex justify-content-between small">
+                                <span>Total Qty
+                                    <t t-esc="orderQuantity"/>
+                                </span>
+                                <span class="bg-dark text-white">Sub Total $
+                                    <t t-esc="(props.data.amount_total).toFixed(2)"/>
+                                </span>
+                            </div>
+                        </div>
+                        <div class="text-end mb-2 fw-bold small">
+                            Bank
+                            <t t-esc="(props.data.amount_total).toFixed(2)"/>
+                        </div>
+                        <t t-if="props.data.tax_details.length > 0">
+                            <table class="table table-borderless table-sm mb-2">
+                                <thead>
+                                    <tr>
+                                        <th class="text-start small">Tax</th>
+                                        <th class="text-start small">Amount</th>
+                                        <th class="text-start small">Base</th>
+                                        <th class="text-end small">Total</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="props.data.tax_details" t-as="tax" t-key="tax.id">
+                                        <td class="small m-0 p-0" t-esc="tax.name"/>
+                                        <td class="small m-0 p-0" t-esc="props.formatCurrency(tax.amount)"/>
+                                        <td class="small m-0 p-0" t-esc="props.formatCurrency(tax.base)"/>
+                                        <td class="text-end small m-0 p-0" t-esc="props.formatCurrency(tax.base + tax.amount)"/>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </t>
+                        <div t-if="props.data.footer" class="pos-receipt-center-align small">
+                            <br/>
+                            <t t-esc="props.data.footer"/>
+                            <br/>
+                            <br/>
+                        </div>
+                        <div class="after-footer">
+                            <t t-foreach="props.data.paymentlines" t-as="line" t-key="line_index">
+                                <t t-if="line.ticket">
+                                    <br/>
+                                    <div class="pos-payment-terminal-receipt">
+                                        <pre t-esc="line.ticket"/>
+                                    </div>
+                                </t>
+                            </t>
+                        </div>
+                        <br/>
+                        <t t-if="props.data.shippingDate">
+                            <div class="pos-receipt-order-data small">
+                                Expected delivery:
+                                <div>
+                                    <t t-esc="props.data.shippingDate"/>
+                                </div>
+                            </div>
+                        </t>
+                        <br/>
+                        <div class="pos-receipt-order-data small">
+                            <p>Odoo Point of Sale</p>
+                            <div t-esc="props.data.name"/>
+                            <div id="order-date" t-esc="props.data.date"/>
+                        </div>
+                    </div>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/pos_receipt/views/boxes_receipt.xml
+++ b/pos_receipt/views/boxes_receipt.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="custom_pos_receipt_boxes">
+        <div style="text-align: center; width: 300px; margin: auto; border: 1px solid black; padding: 10px;">
+            <img t-if="logo" t-att-src="image_data_uri(logo)" alt="Logo" style="height: 70px; " />
+            <p style="margin: 5px 0;">Odoo India Pvt Ltd<br />Infocity Gandhinagar<br />Tax Id:
+            233300990223</p>
+            <t t-esc="header" />
+            <h2 style="margin: 5px 0;">701</h2>
+            <t t-if="is_restaurant"> Served by MOG <br /> Table 5 Guest 3 </t>
+            <table style="width: 100%; border-collapse: collapse; text-align: left;">
+                <tr>
+                    <th style="border: 1px solid black;">No</th>
+                    <th style="border: 1px solid black;">Item</th>
+                    <th style="border: 1px solid black;">Amount</th>
+                </tr>
+                <tr>
+                    <td style="border: 1px solid black;">1</td>
+                    <td style="border: 1px solid black;">Margarita Pizza<br />3 X 200<br />HSN:
+                        2300976</td>
+                    <td style="border: 1px solid black;">$600</td>
+                </tr>
+                <tr>
+                    <td style="border: 1px solid black;">2</td>
+                    <td style="border: 1px solid black;">Bacon Burger<br />5 X 150</td>
+                    <td style="border: 1px solid black;">$750</td>
+                </tr>
+                <tr>
+                    <td style="border: 1px solid black;">3</td>
+                    <td style="border: 1px solid black;">Apple Pie<br />3 X 80<br />HSN: 2300976</td>
+                    <td style="border: 1px solid black;">$240</td>
+                </tr>
+                <tr>
+                    <td style="border: 1px solid black;">4</td>
+                    <td style="border: 1px solid black;">Cheese Burger<br />5 X 150<br />HSN:
+                        2300976</td>
+                    <td style="border: 1px solid black;">$750</td>
+                </tr>
+            </table>
+            <div class="border-bottom border-dark py-1 mb-2" style="font-size: 12px;">
+                <div class="d-flex justify-content-between small">
+                    <span>Total Qty 12</span>
+                    <span>Sub Total $1625</span>
+                </div>
+            </div>
+            <div class="text-end mb-2 fw-bold small border-bottom border-dark"
+                style="font-size: 12px;">
+                Cash $1625
+            </div>
+            <table style="width: 100%; border-collapse: collapse; text-align: left;">
+                <tr>
+                    <th>Tax</th>
+                    <th>Amount</th>
+                    <th>Base</th>
+                    <th>Total</th>
+                </tr>
+                <tr>
+                    <td>SGST 2.5%</td>
+                    <td>40.2</td>
+                    <td>1584.8</td>
+                    <td>1625</td>
+                </tr>
+                <tr>
+                    <td>CGST 2.5%</td>
+                    <td>40.2</td>
+                    <td>1584.8</td>
+                    <td>1625</td>
+                </tr>
+            </table>
+            <t t-esc="footer" />
+            <p style="margin: 5px 0;">Odoo Point of Sale</p>
+            <p style="margin: 5px 0;">Order 0001-003-0004</p>
+            <p style="margin: 5px 0;">04/06/2024 08:30:24</p>
+        </div>
+    </template>
+</odoo>

--- a/pos_receipt/views/light_receipt.xml
+++ b/pos_receipt/views/light_receipt.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="custom_receipt_static_light" t-name="custom_receipt_static">
+        <div style="font-family: Arial, sans-serif; width: 350px; margin: auto; text-align: center; border: 1px solid #ddd; padding: 10px;">
+            <img t-if="logo" t-att-src="image_data_uri(logo)" alt="Logo" style="height: 70px; "/>
+            <p style="margin: 5px 0; font-size: 12px;">
+                Tel: +1 555-555-5556<br/>
+                info@yourcompany.com<br/>
+                http://www.example.com
+            </p>
+            <t t-esc="header"/>
+            <h1 style="margin: 10px 0;">301</h1>
+            <t t-if="is_restaurant">
+            Served by MOG <br/>
+            Table 5 Guest 3
+            </t>
+            <table style="width: 100%; text-align: left; font-size: 14px;">
+                <tr><td><b>Margarita Pizza</b></td><td style="text-align: right;">$ 140.00</td></tr>
+                <tr><td><span style="border: 1px solid #000; padding: 2px 5px;">1.00</span> x $140.00 / Units</td></tr>
+                
+                <tr><td><b>Bacon Burger</b></td><td style="text-align: right;">$ 33.00</td></tr>
+                <tr><td><span style="border: 1px solid #000; padding: 2px 5px;">1.00</span> x $33.00 / Units</td></tr>
+                
+                <tr><td><b>Apple Pie</b></td><td style="text-align: right;">$ 85.00</td></tr>
+                <tr><td><span style="border: 1px solid #000; padding: 2px 5px;">1.00</span> x $85.00 / Units</td></tr>
+            </table>
+            <hr/>
+            <table style="width: 100%; text-align: left; font-size: 14px;">
+                <tr><td>TOTAL</td><td style="text-align: right;">$ 258.00</td></tr>
+                <tr><td>Cash</td><td style="text-align: right;">$ 258.00</td></tr>
+            </table>
+            <t t-esc="footer"/>
+            <p style="margin-top: 10px; font-size: 12px;">Powered by Odoo</p>
+            <p style="font-size: 12px;">Order 00003-001-0001<br/>03/19/2025 17:55:58</p>
+        </div>
+    </template>
+</odoo>

--- a/pos_receipt/views/lined_receipt.xml
+++ b/pos_receipt/views/lined_receipt.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="custom_receipt_lined" t-name="custom_receipt_handwritten">
+        <div style="width: 320px; margin: auto; border: 2px solid black; padding: 10px; text-align: center;">
+            <img t-if="logo" t-att-src="image_data_uri(logo)" alt="Logo" style="height: 70px; "/>
+            <div style="font-size: 12px; line-height: 1.5;">
+            Odoo India pvt ltd<br/>
+            Infocity Gandhinagar<br/>
+            <strong>Tax Id: 2233004900223</strong>
+            </div>
+            <t t-esc="header"/>
+            <h1 style="margin: 10px 0; font-size: 22px; font-weight: bold;">701</h1>
+            <t t-if="is_restaurant">
+            Served by MOG <br/>
+            Table 5 Guest 3
+            </t> 
+            <table style="width: 100%; font-size: 12px; text-align: left; border-collapse: collapse; margin-top: 10px;">
+                <thead class="border-top border-bottom border-dark">
+                    <tr>
+                        <th>No</th>
+                        <th>Item</th>
+                        <th>Qty</th>
+                        <th>Prices</th>
+                        <th>Amount</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>1</td>
+                        <td>Margarita Pizza</td>
+                        <td>3</td>
+                        <td>200</td>
+                        <td>600</td>
+                    </tr>
+                    <tr>
+                        <td>2</td>
+                        <td>Bacon Burger</td>
+                        <td>5</td>
+                        <td>150</td>
+                        <td>750</td>
+                    </tr>
+                    <tr>
+                        <td>3</td>
+                        <td>Apple Pie</td>
+                        <td>2</td>
+                        <td>100</td>
+                        <td>200</td>
+                    </tr>
+                    <tr>
+                        <td>4</td>
+                        <td>Cheese Burger</td>
+                        <td>1</td>
+                        <td>75</td>
+                        <td>75</td>
+                    </tr>
+                </tbody>
+            </table> 
+            <div class="border-top border-dark py-1 mb-2">
+                <div class="d-flex justify-content-between small">
+                    <span>Total Qty
+                        12
+                    </span>
+                    <span class="bg-dark text-white">Sub Total $
+                        1625
+                    </span>
+                </div>
+            </div>
+            <div class="text-end mb-2 fw-bold small">
+                Bank
+                1625
+            </div>
+            
+            <table style="width: 100%; font-size: 12px; text-align: left; border-collapse: collapse; margin-top: 10px;">
+                <thead>
+                    <tr>
+                        <th>Tax</th>
+                        <th>Amount</th>
+                        <th>Base</th>
+                        <th>Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><i>SGST 2.5%</i></td>
+                        <td>40.2</td>
+                        <td>1584.8</td>
+                        <td>1625</td>
+                    </tr>
+                    <tr>
+                        <td><i>CGST 2.5%</i></td>
+                        <td>40.2</td>
+                        <td>1584.8</td>
+                        <td>1625</td>
+                    </tr>
+                </tbody>
+            </table>
+            <t t-esc="footer"/>
+            <div style="text-align: center; font-size: 12px; margin-top: 10px;">
+                <strong>Odoo Point of Sale</strong><br/>
+                Order 0001-003-0004<br/>
+                04/06/2024 08:30:24
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/pos_receipt/views/res_config_settings_view.xml
+++ b/pos_receipt/views/res_config_settings_view.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <data>
+        <record id="view_pos_receipt_settings_inherited" model="ir.ui.view">
+            <field name="name">pos.reciept.settings.form.inherit</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//block[@id='pos_bills_and_receipts_section']/setting" position="replace">
+                    <setting id="document_layout_setting" string="Receipt Layout" help="Choose the layout of your receipt">
+                    <field name="receipt_layout"/>
+                    <br/>
+                    <button name="action_pos_receipt_layout" string="Configure receipt" type="object" class="oe_link" icon="oi-arrow-right"/>
+                    </setting>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/pos_receipt/wizard/__init__.py
+++ b/pos_receipt/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_receipt_wizard

--- a/pos_receipt/wizard/pos_receipt_wizard.py
+++ b/pos_receipt/wizard/pos_receipt_wizard.py
@@ -1,0 +1,50 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class PosReceiptWizard(models.TransientModel):
+    _name = 'pos.receipt.wizard'
+    _description = 'POS Receipt Layout'
+
+    def _get_default_pos_config(self):
+        return self.env['pos.config'].browse([self.env.context.get('active_pos_config_id')])
+
+    pos_config_id = fields.Many2one('pos.config', string='Point of Sale', default=_get_default_pos_config, required=True)
+    receipt_layout = fields.Selection(related='pos_config_id.receipt_layout', readonly=False, required=True)
+    receipt_logo = fields.Binary(related='pos_config_id.receipt_logo', readonly=False)
+    receipt_header = fields.Text(related='pos_config_id.receipt_header', readonly=False)
+    receipt_footer = fields.Text(related='pos_config_id.receipt_footer', readonly=False)
+    receipt_preview = fields.Html(compute='_compute_receipt_preview')
+
+    @api.depends('receipt_layout', 'receipt_header', 'receipt_footer', 'receipt_logo')
+    def _compute_receipt_preview(self):
+        if self.receipt_layout == "lined":
+            self.receipt_preview = self.env['ir.ui.view']._render_template(
+            'pos_receipt.custom_receipt_lined',
+                    {
+                        'header': self.receipt_header,
+                        'footer': self.receipt_footer,
+                        'logo': self.receipt_logo,
+                    }
+                )
+
+        elif self.receipt_layout == "boxes":
+            self.receipt_preview = self.env['ir.ui.view']._render_template(
+            'pos_receipt.custom_pos_receipt_boxes',
+                    {
+                        'header': self.receipt_header,
+                        'footer': self.receipt_footer,
+                        'logo': self.receipt_logo,
+                    }
+                )
+
+        else:
+            self.receipt_preview = self.env['ir.ui.view']._render_template(
+            'pos_receipt.custom_receipt_static_light',
+                    {
+                        'header': self.receipt_header,
+                        'footer': self.receipt_footer,
+                        'logo': self.receipt_logo,
+                    }
+                )

--- a/pos_receipt/wizard/pos_receipt_wizard_views.xml
+++ b/pos_receipt/wizard/pos_receipt_wizard_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_pos_receipt_layout" model="ir.ui.view">
+            <field name="name">Receipt Layout</field>
+            <field name="model">pos.receipt.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <group>
+                        <group>
+                            <field name="pos_config_id" invisible="1"/>
+                            <field name="receipt_layout" widget="selection_badge" options="{'size': 'sm'}"/>
+                            <field name="receipt_logo" string="Logo" widget="image" options="{'size': [0, 50]}"/>
+                            <field name="receipt_header" string="Header" placeholder="e.g. Shop Name, Location" />
+                            <field name="receipt_footer" string="Footer" placeholder="Thanks, visit again ..." />
+                        </group>
+                        <div class="o_preview">
+                            <field name="receipt_preview" />
+                        </div>  
+                    </group>
+                    <footer>
+                        <button string="Continue" class="btn-primary" special="save"/>
+                        <button special="cancel" string="Discard" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Before this commit:
POS receipts had only one fixed layout.
Logo, header, and footer fields were not in one place.

After this commit:
Users can choose from 3 receipt layouts: light, lined, and boxes.
Header, footer, and logo can be updated from POS settings.
A live preview shows how the receipt will look.

Impact:
Easier receipt setup for users.
Helps businesses match their branding.
Reduces errors by showing preview before saving.