### PR TITLE
[ADD] pos_salesperson: salesperson selection and display in POS

### DIFF
--- a/pos_salesperson/__init__.py
+++ b/pos_salesperson/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_salesperson/__manifest__.py
+++ b/pos_salesperson/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Pos Salesperson',
+    'version': '1.0',
+    'category': 'Sales/Point of Sale',
+    'summary': 'Allow selecting salesperson for pos order',
+    'depends': ['point_of_sale', 'hr'],
+    'installable': True,
+    'data': [
+        'views/pos_order_view.xml'
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_salesperson/static/src/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/pos_salesperson/models/__init__.py
+++ b/pos_salesperson/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_order
+from . import pos_session

--- a/pos_salesperson/models/pos_order.py
+++ b/pos_salesperson/models/pos_order.py
@@ -1,0 +1,6 @@
+from odoo import models, fields
+
+
+class InheritedPosOrder(models.Model):
+    _inherit = "pos.order"
+    salesperson_id = fields.Many2one("hr.employee", string="Salesperson")

--- a/pos_salesperson/models/pos_session.py
+++ b/pos_salesperson/models/pos_session.py
@@ -1,0 +1,11 @@
+from odoo import models, api
+
+
+class InheritedPosSession(models.Model):
+    _inherit = "pos.session"
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        data_models = super()._load_pos_data_models(self.config_id.id)
+        data_models.append('hr.employee')
+        return data_models

--- a/pos_salesperson/static/src/models/hr_employee.js
+++ b/pos_salesperson/static/src/models/hr_employee.js
@@ -1,0 +1,19 @@
+import { Base } from "@point_of_sale/app/models/related_models";
+import { registry } from "@web/core/registry";
+
+export class HrEmployee extends Base {
+    static pythonModel = "hr.employee";
+
+    get searchString() {
+        const fields = [
+            "name"
+        ];
+        return fields
+            .map((field) => {
+                return this[field] || "";
+            })
+            .filter(Boolean)
+            .join(" ");
+    }
+}
+registry.category("pos_available_models").add(HrEmployee.pythonModel, HrEmployee);

--- a/pos_salesperson/static/src/overrides/control_button.js
+++ b/pos_salesperson/static/src/overrides/control_button.js
@@ -1,0 +1,7 @@
+import { patch } from "@web/core/utils/patch";
+import { SalespersonButton } from "../salesperson_button/salesperson_button";
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+
+patch(ControlButtons.components, {
+    SalespersonButton
+})

--- a/pos_salesperson/static/src/overrides/control_buttons.xml
+++ b/pos_salesperson/static/src/overrides/control_buttons.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('more-btn')]" position="before">
+            <SalespersonButton t-if="!props.showRemainingButtons" />
+        </xpath>
+    </t>
+</templates>

--- a/pos_salesperson/static/src/overrides/pos_order.js
+++ b/pos_salesperson/static/src/overrides/pos_order.js
@@ -1,0 +1,13 @@
+import { patch } from "@web/core/utils/patch";
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+
+patch(PosOrder.prototype, {
+    set_salesperson(salesperson) {
+        this.assert_editable();
+        this.update({ salesperson_id: salesperson })
+    },
+
+    get_salesperson() {
+        return this.salesperson_id;
+    }
+})

--- a/pos_salesperson/static/src/overrides/pos_store.js
+++ b/pos_salesperson/static/src/overrides/pos_store.js
@@ -1,0 +1,26 @@
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+import { patch } from "@web/core/utils/patch";
+import { SalespersonList } from "../salesperson_list/salesperson_list";
+
+patch(PosStore.prototype, {
+    async selectSalesperson() {
+        const currentOrder = this.get_order();
+        if (!currentOrder) {
+            return false;
+        }
+        const currentSalesperson = currentOrder.get_salesperson();
+        const payload = await makeAwaitable(this.dialog, SalespersonList, {
+            salesperson: currentSalesperson,
+            getPayload: (newSalesperson) => {
+                currentOrder.set_salesperson(newSalesperson)
+            },
+        });
+        if (payload) {
+            currentOrder.set_salesperson(payload);
+        } else {
+            currentOrder.set_salesperson(false);
+        }
+        return currentSalesperson;
+    }
+})

--- a/pos_salesperson/static/src/salesperson_button/salesperson_button.js
+++ b/pos_salesperson/static/src/salesperson_button/salesperson_button.js
@@ -1,0 +1,13 @@
+import { Component, markRaw } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+
+export class SalespersonButton extends Component {
+    static template = 'pos_salesperson.SelectSalespersonButton';
+    setup() {
+        this.pos = usePos();
+    }
+
+    get salesperson() {
+        return this.pos.get_order()?.get_salesperson();
+    }
+}

--- a/pos_salesperson/static/src/salesperson_button/salesperson_button.xml
+++ b/pos_salesperson/static/src/salesperson_button/salesperson_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="pos_salesperson.SelectSalespersonButton">
+        <button class="btn btn-light btn-lg lh-lg flex-grow-1" t-on-click="() => this.pos.selectSalesperson()">
+            <div t-if="this.salesperson" t-esc="this.salesperson?.name" class="text-truncate text-action" />
+            <t t-else="">Salesperson</t>
+        </button>
+    </t>
+</templates>

--- a/pos_salesperson/static/src/salesperson_list/sales_person_list.scss
+++ b/pos_salesperson/static/src/salesperson_list/sales_person_list.scss
@@ -1,0 +1,59 @@
+.salesperson-list {
+    tr {
+        border: $border-width solid $border-color;
+
+        &:hover {
+            cursor: pointer;
+        }
+
+        &:active {
+            background-color: $o-component-active-bg;
+        }
+    }
+}
+
+.salesperson-list table {
+    border-collapse: separate;
+    border-spacing: 0 8px;
+    margin-top: -8px;
+
+    td {
+        border: $border-width solid $border-color;
+        border-style: solid none;
+        padding: map-get($spacers, 3);
+    }
+
+    tr.selected td {
+        border-color: $o-component-active-border;
+    }
+
+    td:first-child {
+        border-left-style: solid;
+        border-top-left-radius: $border-radius-lg;
+        border-bottom-left-radius: $border-radius-lg;
+    }
+
+    td:last-child {
+        border-right-style: solid;
+        border-bottom-right-radius: $border-radius-lg;
+        border-top-right-radius: $border-radius-lg;
+    }
+}
+
+@include media-breakpoint-down(lg) {
+    .salesperson-list {
+        table {
+            border: transparent;
+        }
+
+        .salesperson-list {
+            thead {
+                display: none;
+            }
+
+            td {
+                padding: 0;
+            }
+        }
+    }
+}

--- a/pos_salesperson/static/src/salesperson_list/salesperson_line/salesperson_line.js
+++ b/pos_salesperson/static/src/salesperson_list/salesperson_line/salesperson_line.js
@@ -1,0 +1,17 @@
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class SalespersonLine extends Component {
+    static template = "pos_salesperson.SalespersonLine";
+    static props = [
+        "close",
+        "salesperson",
+        "isSelected",
+        "onClickUnselect",
+        "onClickSalesperson",
+    ];
+
+    setup() {
+        this.ui = useService("ui");
+    }
+}

--- a/pos_salesperson/static/src/salesperson_list/salesperson_line/salesperson_line.scss
+++ b/pos_salesperson/static/src/salesperson_list/salesperson_line/salesperson_line.scss
@@ -1,0 +1,47 @@
+@include media-breakpoint-down(lg) {
+
+    .salesperson-line {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 12px 24px;
+        border-bottom: 1px solid $o-gray-300;
+
+        td {
+            border: 0;
+            flex-basis: 100%;
+            padding: 5px;
+            background-color: transparent;
+        }
+    }
+
+    .salesperson-line .pos-right-align {
+        text-align: left;
+    }
+
+    .edit-salesperson-button-cell {
+        order: 4;
+    }
+}
+
+.salesperson-line {
+    &:hover i.oi-chevron-right {
+        transition: $transition-base;
+        transform: translateX(.5rem);
+        color: $o-main-link-color;
+    }
+
+    &.selected {
+        background-color: $o-component-active-bg;
+        border: $border-width solid $o-component-active-border;
+    }
+
+    &.selected .btn.btn-link:hover .fa-check {
+        display: none;
+    }
+
+    &.selected .btn.btn-link:hover::after {
+        content: "\e852";
+        font-family: 'odoo_ui_icons';
+    }
+}

--- a/pos_salesperson/static/src/salesperson_list/salesperson_line/salesperson_line.xml
+++ b/pos_salesperson/static/src/salesperson_list/salesperson_line/salesperson_line.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="pos_salesperson.SalespersonLine">
+        <t t-if="ui.isSmall">
+            <div class="salesperson-info d-flex flex-column p-1 border-bottom" t-att-class="{'bg-primary-subtle': props.isSelected}" t-att-data-id="props.salesperson.id"
+                t-on-click="() => this.props.onClickSalesperson(props.salesperson)">
+                <div class="d-flex justify-content-between align-items-center p-1">
+                    <div>
+                        <b t-esc="props.salesperson.name or ''" />
+                        <div class="company-field text-bg-muted" t-esc="props.salesperson.parent_name or ''" />
+                    </div>
+                </div>
+                <div class="salesperson-line-email p-1">
+                    <div t-if="props.salesperson.work_contact_id.email" class="email-field mb-1">
+                        <i class="fa fa-fw fa-paper-plane-o me-2" /><t t-esc="props.salesperson.work_contact_id.email" />
+                    </div>
+                </div>
+                <div class="d-flex justify-content-between align-items-center p-1">
+                    <button t-if="props.isSelected" t-on-click.stop="props.onClickUnselect" class="unselect-tag-mobile d-inline-block d-lg-none btn btn-light border ms-2">
+                        <i class="fa fa-times me-1"></i>
+                        <span>UNSELECT</span>
+                    </button>
+                </div>
+            </div>
+        </t>
+        <t t-else="">
+            <tr class="salesperson-line salesperson-info" t-att-class="{'selected': props.isSelected}" t-att-data-id="props.salesperson.id"
+                t-on-click="() => this.props.onClickSalesperson(props.salesperson)">
+                <td>
+                    <b t-esc="props.salesperson.name or ''" />
+                    <div class="company-field text-bg-muted" t-esc="props.salesperson.parent_name or ''" />
+                </td>
+                <td class="salesperson-line-email ">
+                    <div t-if="props.salesperson.work_contact_id.email" class="email-field">
+                        <i class="fa fa-fw fa-paper-plane-o me-2"/><t t-esc="props.salesperson.work_contact_id.email" />
+                    </div>
+                </td>
+                <td class="edit-salesperson-button-cell align-middle pe-0">
+                    <button t-if="props.isSelected" t-on-click.stop="props.onClickUnselect" class="unselect-tag d-lg-inline-block d-none btn btn-link btn-lg mt-1 float-end">
+                        <i class="fa fa-check"/>
+                    </button>
+                </td>
+            </tr>
+        </t>
+    </t>
+
+</templates>

--- a/pos_salesperson/static/src/salesperson_list/salesperson_list.js
+++ b/pos_salesperson/static/src/salesperson_list/salesperson_list.js
@@ -1,0 +1,112 @@
+import { Component, markRaw, useState } from "@odoo/owl";
+import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { Dialog } from "@web/core/dialog/dialog";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { useService } from "@web/core/utils/hooks";
+import { unaccent } from "@web/core/utils/strings";
+import { SalespersonLine } from "./salesperson_line/salesperson_line";
+
+export class SalespersonList extends Component {
+    static components = { Dialog, Input, SalespersonLine };
+    static template = "pos_salesperson.SalespersonList";
+
+    static props = {
+        salesperson: {
+            type: [{ value: null }, Object],
+            optional: true,
+        },
+        getPayload: { type: Function },
+        close: { type: Function },
+    };
+
+    setup() {
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+        this.notification = useService("notification");
+        this.state = useState({
+            query: null,
+            previousQuery: "",
+            currentOffset: 0,
+        });
+        useHotkey("enter", () => this.onEnter());
+    }
+
+    async onEnter() {
+        if (!this.state.query) {
+            return;
+        }
+        const result = await this.searchSalesperson();
+        if (result.length > 0) {
+            this.notification.add(
+                `${result.length} salesperson(s) found for "${this.state.query}".`,
+                3000
+            );
+        } else {
+            this.notification.add(`No more salesperson found for "${this.state.query}"`);
+        }
+    }
+
+    clickSalesperson(salesperson) {
+        this.props.getPayload(salesperson);
+        this.props.close();
+    }
+
+    getSalespersons() {
+        const searchWord = unaccent((this.state.query || "").trim(), false).toLowerCase();
+        const salespersons = this.pos.models["hr.employee"].getAll();
+        const numberString = searchWord.replace(/[+\s()-]/g, "");
+        const isSearchWordNumber = /^[0-9]+$/.test(numberString);
+
+        const availableSalespersons = searchWord
+            ? salespersons.filter((p) =>
+                unaccent(p.searchString, false).includes(isSearchWordNumber ? numberString : searchWord)
+            )
+            : salespersons
+                .slice(0, 1000)
+                .toSorted((a, b) =>
+                    this.props.salesperson?.id === a.id
+                        ? -1
+                        : this.props.salesperson?.id === b.id
+                            ? 1
+                            : (a.name || "").localeCompare(b.name || "")
+                );
+        return availableSalespersons;
+    }
+
+    async searchSalesperson() {
+        if (this.state.previousQuery != this.state.query) {
+            this.state.currentOffset = 0;
+        }
+        const salesperson = await this.getNewSalespersons();
+
+        if (this.state.previousQuery == this.state.query) {
+            this.state.currentOffset += salesperson.length;
+        } else {
+            this.state.previousQuery = this.state.query;
+            this.state.currentOffset = salesperson.length;
+        }
+        return salesperson;
+    }
+
+    async getNewSalespersons() {
+        let domain = [];
+        const limit = 30;
+        if (this.state.query) {
+            const search_fields = [
+                "name",
+            ];
+            domain = [
+                ...Array(search_fields.length - 1).fill("|"),
+                ...search_fields.map((field) => [field, "ilike", this.state.query + "%"]),
+            ];
+        }
+
+        const result = await this.pos.data.searchRead("hr.employee", domain, [], {
+            limit: limit,
+            offset: this.state.currentOffset,
+        });
+
+        return result;
+    }
+}

--- a/pos_salesperson/static/src/salesperson_list/salesperson_list.xml
+++ b/pos_salesperson/static/src/salesperson_list/salesperson_list.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="pos_salesperson.SalespersonList">
+        <Dialog bodyClass="'salesperson-list overflow-y-auto'" contentClass="'h-100'">
+            <t t-set-slot="header">
+                <Input tModel="[state, 'query']"
+                    class="'ms-auto'"
+                    isSmall="ui.isSmall"
+                    placeholder.translate="Search salesperson..."
+                    icon="{type: 'fa', value: 'fa-search'}"
+                    autofocus="true"
+                    debounceMillis="100" />
+            </t>
+            <table class="table table-hover">
+                <thead t-if="!ui.isSmall">
+                    <tr>
+                        <th class="py-2">Name</th>
+                        <th class="salesperson-line-email py-2">Contact</th>
+                        <th class="py-2"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="getSalespersons()" t-as="salesperson" t-key="salesperson.id">
+                        <SalespersonLine
+                            close="props.close"
+                            salesperson="salesperson"
+                            isSelected="props.salesperson?.id === salesperson.id"
+                            onClickUnselect.bind="() => this.clickSalesperson()"
+                            onClickSalesperson.bind="clickSalesperson"/>
+                    </t>
+                </tbody>
+            </table>
+            <div t-if="state.query" class="search-more-button d-flex justify-content-center my-2">
+                <button class="btn btn-lg btn-primary" t-on-click="onEnter">Search more</button>
+            </div>
+        </Dialog>
+    </t>
+</templates>

--- a/pos_salesperson/views/pos_order_view.xml
+++ b/pos_salesperson/views/pos_order_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="pos_order_form_inherit" model="ir.ui.view">
+        <field name="name">pos.order.form.inherit.pos_salesperson</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='fiscal_position_id']" position="after">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="pos_order_list_inherit" model="ir.ui.view">
+        <field name="name">pos.order.list.inherit.pos_salesperson</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="salesperson_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
# Description

This PR introduces the **pos_salesperson** module, enabling salesperson selection directly in the POS interface and ensuring the information is recorded in POS orders.

---

### Key Features

- **Salesperson Field on Orders**  
  Added `salesperson_id` field to `pos.order` referencing `hr.employee` to track the salesperson associated with each order.

- **Data Loading in POS**  
  Updated `pos.session` to load `hr.employee` records into the POS `data_service`, making salesperson data available in the POS frontend.

- **UI Enhancements**  
  - Patched POS control buttons to include a **Salesperson** button in the POS UI.  
  - Created `SalespersonList` and `SalespersonLine` components for selecting a salesperson.  

- **Store Functionality**  
  Patched `pos_order` to define:
    - `get_salesperson()` – retrieve the currently selected salesperson.
    - `set_salesperson()` – set the active salesperson.

- **Backend Views**  
  Inherited `pos.order` form and list views to display the salesperson information for each order.
