### PR TITLE
[ADD] automatic_invoice: Implemented automated invoice sending by email

### DIFF
--- a/automatic_invoice/__init__.py
+++ b/automatic_invoice/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/automatic_invoice/__manifest__.py
+++ b/automatic_invoice/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Automatic invoicing',
+    'version': '1.0',
+    'category': 'Accounting',
+    'summary': 'Configure a schedule to send customer invoices automatically',
+    'depends': ['account'],
+    'data': [
+        'data/ir_cron.xml',
+        'views/res_config_settings_views.xml'
+    ],
+    'installable': True,
+    'license': 'LGPL-3'
+}

--- a/automatic_invoice/data/ir_cron.xml
+++ b/automatic_invoice/data/ir_cron.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <record id="ir_cron_send_email_invoice" model="ir.cron">
+        <field name="name">Send Automatic Invoice Email</field>
+        <field name="model_id" ref="account.model_account_move" />
+        <field name="state">code</field>
+        <field name="code">model._send_email_invoice()</field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">hours</field>
+        <field name="active">True</field>
+    </record>
+</odoo>

--- a/automatic_invoice/models/__init__.py
+++ b/automatic_invoice/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_config_settings
+from . import account_move

--- a/automatic_invoice/models/account_move.py
+++ b/automatic_invoice/models/account_move.py
@@ -1,0 +1,34 @@
+from odoo import fields, models
+from datetime import timedelta
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    is_auto_email_sent = fields.Boolean(default=False)
+
+    def _send_email_invoice(self):
+        if not self.env['ir.config_parameter'].sudo().get_param('automatic_invoice.enable_auto_invoice_sending'):
+            return
+
+        try:
+            days_str = self.env['ir.config_parameter'].sudo().get_param('automatic_invoice.invoice_send_delay_days')
+            days = int(days_str)
+        except ValueError:
+            return
+
+        target_date = fields.Datetime.now() - timedelta(days=days)
+        invoices_to_send = self.search([
+            ('state', '=', 'posted'),
+            ('move_type', '=', 'out_invoice'),
+            ('is_auto_email_sent', '=', False),
+            ('invoice_date', '<=', target_date)
+        ])
+
+        template = self.env.ref('account.email_template_edi_invoice', raise_if_not_found=False)
+        if not template:
+            return
+
+        for invoice in invoices_to_send:
+            template.send_mail(invoice.id, force_send=True)
+            invoice.is_auto_email_sent = True

--- a/automatic_invoice/models/res_config_settings.py
+++ b/automatic_invoice/models/res_config_settings.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    enable_auto_invoice_sending = fields.Boolean(
+        string="Send invoice by email",
+        config_parameter="automatic_invoice.enable_auto_invoice_sending"
+    )
+    invoice_send_delay_days = fields.Integer(
+        string="Duration of days after the date of invoice",
+        config_parameter="automatic_invoice.invoice_send_delay_days"
+    )

--- a/automatic_invoice/views/res_config_settings_views.xml
+++ b/automatic_invoice/views/res_config_settings_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="res_config_settings_view" model="ir.ui.view">
+        <field name="name">res.config.settings.inherit.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//block//setting[@id='display_invoice_tax_company_currency']" position="after">
+                <setting id="automatic_send_invoice" help="Send invoices automatically through email by configuring the duration">
+                    <field name="enable_auto_invoice_sending" />
+                    <div invisible="not enable_auto_invoice_sending">
+                        <label for="invoice_send_delay_days" />
+                        <field name="invoice_send_delay_days" />
+                    </div>
+                </setting>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR introduces a new feature to automate the sending of customer invoices via email. The system is managed through a new section in the Accounting settings, allowing administrators to enable the functionality and configure a specific delay period in days. A daily cron job has been implemented to handle the automation, which identifies and processes all posted, unpaid customer invoices with an invoice date that has passed the configured delay. To prevent duplicate communications, a new boolean field, 'is_auto_email_sent', has been added to the invoice model to track which invoices have already been sent by this process.

Task ID :- 5020819