### PR TITLE
[ADD] pos_customer_display: add customer name, amount / guest and separated refunds section

### DIFF
--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'POS Customer Display',
+    'version': '1.0',
+    'category': 'Point of Sale',
+    'author': 'Mayankkumar Patel (pmad)',
+    'depends': ['point_of_sale'],
+    'installable': True,
+    'assets': {
+        'point_of_sale.assets_prod': [
+            'pos_customer_display/static/src/pos_customer_display.js'
+        ],
+        'point_of_sale.customer_display_assets': [
+            'pos_customer_display/static/src/customer_display/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/pos_customer_display/static/src/customer_display/customer_display.xml
+++ b/pos_customer_display/static/src/customer_display/customer_display.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.CustomerDisplay" t-inherit="point_of_sale.CustomerDisplay" t-inherit-mode="extension">
+        <xpath expr="//div[@class='row' and @t-if='order.change']" position="after">
+           <div class="row">
+                <div class="col text-end">
+                    Customer
+                </div>
+                <div class="col text-end text-muted"> <t t-esc="order.customerName" /> </div>
+            </div>
+
+            <div class="row mayank">
+                <t t-if="order.amountPerGuest">
+                    <div class="col text-end">Amount</div>
+                    <div class="col text-end text-muted"> 
+                        <t t-esc="order.amountPerGuest.toFixed(2)" /> 
+                        / Guest
+                    </div>
+                </t>
+             </div>
+        </xpath>
+
+        <xpath expr="//div[hasclass('o_customer_display_main')]/OrderWidget" position="replace">
+           <OrderWidget t-if="!order.finalized" lines="order.orderLines"/>
+                <t t-if="order.refundedOrderLines and order.isRefundOrder">
+                    <p class="fs-3"> Refunds </p>
+                    <OrderWidget lines="order.refundedOrderLines"/>
+                </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/pos_customer_display/static/src/pos_customer_display.js
+++ b/pos_customer_display/static/src/pos_customer_display.js
@@ -1,0 +1,30 @@
+import { patch } from "@web/core/utils/patch";
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+
+patch(PosOrder.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.guest_count = this.guest_count || 1;
+    },
+
+    getGuestCount() {
+        return this.guest_count || 1;
+    },
+
+    getCustomerDisplayData() {
+        const allOrderlines = this.getSortedOrderlines();
+        const refundedOrderLines = allOrderlines.filter((order) => order.refunded_orderline_id);
+        const nonRefundOrderLines = allOrderlines.filter((order) => !order.refunded_orderline_id);
+        const guestCount = this.getGuestCount();
+        const amountPerGuest = this.get_total_with_tax() / guestCount;
+
+        return {
+            ...super.getCustomerDisplayData(),
+            customerName: this.get_partner_name() ? this.get_partner_name() : "Guest",
+            isRefundOrder: this._isRefundOrder(),
+            refundedOrderLines: refundedOrderLines.map((x) => x.getDisplayData()),
+            orderLines: nonRefundOrderLines.map((x) => x.getDisplayData()),
+            amountPerGuest: amountPerGuest,
+        };
+    },
+});


### PR DESCRIPTION
Adds the customer's name and the total amount per guest to the POS customer display. This change provides clarity for both the cashier and the customer, offering immediate confirmation that the correct customer is selected and that the order is being billed to the right number of people with a clear breakdown of the cost per person.

I've also separated refunded lines into their own subsection. This makes the receipt easier to understand for the customer, as it clearly distinguishes returned items from new purchases. Without this separation, refunded items can be confusing and make it difficult for the customer to verify the total amount due.

Task - 5005551