### PR TITLE
[ADD] project_recognition_date_sync: add sync option for recognition date

### DIFF
--- a/project_recognition_date_sync/__init__.py
+++ b/project_recognition_date_sync/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/project_recognition_date_sync/__manifest__.py
+++ b/project_recognition_date_sync/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Link project date with analytical account',
+    'version': '1.0',
+    'author': 'Aaryan Parpyani (aarp)',
+    'depends': ['sale_project', 'account'],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+    'description': '''
+        Changing the project start date will show a button to sync recognition dates
+        across invoices and journal entries.
+        Ensuring accounting accuracy without manual intervention.
+    ''',
+    'data': [
+        'views/project_project_views.xml',
+    ]
+}

--- a/project_recognition_date_sync/models/__init__.py
+++ b/project_recognition_date_sync/models/__init__.py
@@ -1,0 +1,2 @@
+from . import project_project
+from . import account_move_line

--- a/project_recognition_date_sync/models/account_move_line.py
+++ b/project_recognition_date_sync/models/account_move_line.py
@@ -1,0 +1,24 @@
+# imports of odoo
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    date_changed = fields.Date(string="Changed Date")
+
+    def action_automatic_entry(self, default_action=None):
+        """
+        If account move line is linked to a saled order that is
+        connected to a project with a defined start date, that date
+        is set as default date in wizard context.
+        """
+        action = super().action_automatic_entry(default_action)
+        ctx = dict(action.get('context', {}))
+
+        project = self.move_id.line_ids.sale_line_ids.order_id.project_id
+        if project and project.date_start:
+            ctx['default_date'] = project.date_start
+
+        action['context'] = ctx
+        return action

--- a/project_recognition_date_sync/models/project_project.py
+++ b/project_recognition_date_sync/models/project_project.py
@@ -1,0 +1,47 @@
+# imports of odoo
+from odoo import api, fields, models
+
+
+class Project(models.Model):
+    _inherit = 'project.project'
+
+    is_sync_required = fields.Boolean(compute="_compute_is_sync_required", string="Is sync required?")
+    move_lines = fields.One2many('account.move.line', compute="_compute_is_sync_required", string="Move lines")
+
+    # Method returns account move lines (invoice lines) that needs synchronization.
+    def _get_sync_required_move_lines(self):
+        return self.env['account.move.line'].search([
+            ('move_id', 'in', self.sale_order_id.invoice_ids.ids),
+            ('date_changed', '!=', self.date_start),
+            ('move_type', '!=', 'entry'),
+            ('parent_state', '=', 'posted'),
+            ('account_internal_group', 'in', ['income', 'expense'])
+        ])
+
+    # Computes if synchronization is required based on related invoices and start date.
+    @api.depends('sale_order_id.invoice_ids', 'date_start')
+    def _compute_is_sync_required(self):
+        self.move_lines = self._get_sync_required_move_lines()
+        self.is_sync_required = bool(self.move_lines)
+
+    def open_recognition_date_sync_wizard(self):
+        """
+        Open the recognition date synchronization wizard for related account move lines.
+
+        This method prepares the context with the relevant move line IDs and
+        date and action values before launching the
+        `account.account_automatic_entry_wizard_action` wizard.
+        """
+        action = self.env.ref('account.account_automatic_entry_wizard_action').read()[0]
+
+        # Force the values of the move line in the context to avoid issues
+        ctx = dict(self.env.context)
+        ctx.pop('active_ids', None)
+        ctx.pop('default_journal_id', None)
+        ctx['active_ids'] = self.move_lines.ids
+        ctx['active_model'] = 'account.move.line'
+        ctx['default_action'] = 'change_period'
+        ctx['default_date'] = self.date_start
+
+        action['context'] = ctx
+        return action

--- a/project_recognition_date_sync/views/project_project_views.xml
+++ b/project_recognition_date_sync/views/project_project_views.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <data>
+        <record id="project_project_form_inherit_view" model="ir.ui.view">
+            <field name="name">project.project.form.inherit.view</field>
+            <field name="model">project.project</field>
+            <field name="inherit_id" ref="project.edit_project"/>
+            <field name="arch" type="xml">
+                <xpath expr="//form/header" position="after">
+                    <div class="alert alert-info" role="alert" invisible="not is_sync_required">
+                        You have still journal items needs to be recognised from <field name="date_start" class="fw-bold" readonly="1"></field>
+                    </div>
+                </xpath>
+
+                <xpath expr="//field[@name='date']" position="after">
+                    <button name="open_recognition_date_sync_wizard" type="object"
+                        string="Sync Recognition Date" help="Recompute the recognition date based on the project start date"
+                        icon="fa-refresh" class="btn-link mb-1 px-0" invisible="not is_sync_required"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/project_recognition_date_sync/wizard/__init__.py
+++ b/project_recognition_date_sync/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import recognition_date_sync_wizard

--- a/project_recognition_date_sync/wizard/recognition_date_sync_wizard.py
+++ b/project_recognition_date_sync/wizard/recognition_date_sync_wizard.py
@@ -1,0 +1,17 @@
+# imports of odoo
+from odoo import models
+
+
+class RecognitionDateSyncWizard(models.TransientModel):
+    _inherit = 'account.automatic.entry.wizard'
+
+    def do_action(self):
+        """
+        Set the date_changed field of the related account move lines
+        with the wizard's date, then call the parent method.
+        """
+        self.env['account.move.line'].browse(self._context.get('active_ids', [])).write({
+            'date_changed': self.date
+        })
+
+        return super().do_action()


### PR DESCRIPTION
When the project start date and recognition date differ, a button is shown to allow syncing them. This ensures recognition dates across invoices and journal entries remain consistent with the project start date

- Added a button to sync recognition date with project start date.
- Ensures consistency across invoices and journal entries.
- Reduces manual adjustments for accounting accuracy.