### PR TITLE
[ADD] sale_pricelist_price: add "Book Price" field on SO and Invoice lines.

### DIFF
--- a/sale_pricelist_price/__init__.py
+++ b/sale_pricelist_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_pricelist_price/__manifest__.py
+++ b/sale_pricelist_price/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Pricelist Price",
+    "description": "Client will have the ability to see the original price(book price) on sale order and incoice line.",
+    "depends": ["sale_management"],
+    "data": [
+        "views/sale_order_views.xml",
+        "views/account_move_views.xml",
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/sale_pricelist_price/models/__init__.py
+++ b/sale_pricelist_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_line
+from . import account_move_line

--- a/sale_pricelist_price/models/account_move_line.py
+++ b/sale_pricelist_price/models/account_move_line.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(
+        string="Book Price", related="sale_line_ids.book_price", readonly=True
+    )

--- a/sale_pricelist_price/models/sale_order_line.py
+++ b/sale_pricelist_price/models/sale_order_line.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(
+        string="Book Price", compute="_compute_book_price", store=True
+    )
+
+    @api.depends("product_id", "product_uom_qty", "order_id.pricelist_id")
+    def _compute_book_price(self):
+        for line in self:
+            if line.product_id and line.order_id.pricelist_id:
+                line.book_price = line.order_id.pricelist_id._get_product_price(
+                    product=line.product_id, quantity=line.product_uom_qty
+                )
+            else:
+                line.book_price = 0.0

--- a/sale_pricelist_price/views/account_move_views.xml
+++ b/sale_pricelist_price/views/account_move_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">view.move.form.inherit.sale.pricelist.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='quantity']" position="before">
+                <field name="book_price" readonly="1" column_invisible="parent.move_type != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_pricelist_price/views/sale_order_views.xml
+++ b/sale_pricelist_price/views/sale_order_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form_inherit_sale_pricelist_price" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.sale.pricelist.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']" position="before">
+                <field name="book_price" readonly="1"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list" position="attributes">
+                <attribute name="decoration-success">price_unit &gt; book_price</attribute>
+                <attribute name="decoration-danger">price_unit &lt; book_price</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Currently users cannot currently see the original pricelist price when editing sales order lines or invoice lines, making it difficult to compare with manually adjusted prices.

This change introduces a new module `sale_pricelist_price` that adds a computed field `book_price` on `sale.order.line` and `account.move.line`. The field calculates the original pricelist price based on the selected pricelist, product, and quantity.

Views updated:
* Sales Order Lines tree view to display `book_price`.
* Invoice Lines tree view (customer invoices) to display `book_price`.
* Sale order lines are now color-coded: green if `unit_price` > `book_price`, red if `unit_price` < `book_price`.

This ensures visibility of baseline pricelist prices for better decision-making and easier verification of manual adjustments.

task-5072748