### PR TITLE
[ADD] zero_stock_approval: add "zero_stock_approval" field in SO

### DIFF
--- a/zero_stock_approval/__init__.py
+++ b/zero_stock_approval/__init__.py
@@ -1,0 +1,2 @@
+
+from . import models

--- a/zero_stock_approval/__manifest__.py
+++ b/zero_stock_approval/__manifest__.py
@@ -1,0 +1,23 @@
+
+{
+    'name': "Zero Stock Approval",
+    'version': '1.0',
+    'depends': [
+        'base',
+        'sale',
+        'sales_team',
+        'account_payment',
+        'utm',
+    ],
+    'author': "Sanket Tank",
+    'category': 'Sales/Sales',
+    'description': """
+    This module contains feature of zero stock blockage for Sales Module
+    """,
+    "data": [
+        "views/sale_order_views.xml",
+    ],
+    'license': 'LGPL-3',
+    'application': True,
+    'installable': True
+}

--- a/zero_stock_approval/models/__init__.py
+++ b/zero_stock_approval/models/__init__.py
@@ -1,0 +1,2 @@
+
+from . import sale_order

--- a/zero_stock_approval/models/sale_order.py
+++ b/zero_stock_approval/models/sale_order.py
@@ -1,0 +1,29 @@
+
+from odoo import models, fields
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(
+        string="Approval",
+        default=False,
+        readonly=False,
+        help="If checked then sales user can confirm the sale order",
+    )
+    is_manager = fields.Boolean(default=False, compute="_compute_access_approval")
+
+    def action_confirm(self):
+        self.ensure_one()
+        if (not self.zero_stock_approval and self.is_manager):
+            raise UserError("You are not allowed to confirm this order as Zero Stock Approval is required.")
+        return super().action_confirm()
+
+    def _compute_access_approval(self):
+        self.ensure_one()
+        if self.env.user.has_group("sales_team.group_sale_manager"):
+            self.is_manager = False
+        else:
+            self.is_manager = True

--- a/zero_stock_approval/views/sale_order_views.xml
+++ b/zero_stock_approval/views/sale_order_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form_inherit_sale_order" model="ir.ui.view">
+        <field name="name">sale.order.view.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <group name="order_details">
+                <field name="zero_stock_approval" string="Approval" readonly="is_manager" />
+            </group>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Currently, Sales/Users can confirm quotations without any approval.

This change introduces a new module "zero_stock_approval" which adds:
- A boolean field "zero_stock_approval" on sales orders
- A computed field "is_manager" to identify whether the current user is a Sales/Administrator

Behavior:
- If "zero_stock_approval" is checked, Sales/Users can confirm the quotation
- If unchecked, Sales/Users cannot confirm the quotation
- The "zero_stock_approval" field is read-only for Sales/Users and can only be set by Sales/Administrators

This ensures proper approval control and restricts confirmation rights based on the approval status.

task-5081749