### PR TITLE
[FIX] website_airproof: load templates in correct order

### DIFF
--- a/website_airproof/__manifest__.py
+++ b/website_airproof/__manifest__.py
@@ -7,6 +7,9 @@
     'license': 'LGPL-3',
     'depends': ['website_sale', 'website_sale_wishlist', 'website_blog', 'website_mass_mailing'],
     'data': [
+        # Snippets
+        'views/snippets/options.xml',
+        'views/snippets/s_airproof_carousel.xml',
         # Options
         'data/presets.xml',
         'data/website.xml',
@@ -24,9 +27,6 @@
         'views/website_templates.xml',
         'views/website_sale_templates.xml',
         'views/website_sale_wishlist_templates.xml',
-        # Snippets
-        'views/snippets/options.xml',
-        'views/snippets/s_airproof_carousel.xml',
         # Images
         'data/images.xml',
     ],


### PR DESCRIPTION
## Description
Fixes the loading order issue in the Airproof tutorial that causes module installation to fail.

## Problem
The `s_airproof_carousel` template was referenced in `new_page_templates` before being loaded into the database, causing:
```
ValueError: External ID not found in the system: website_airproof.s_airproof_carousel
```

## Solution
Moved `'views/snippets/options.xml',` and `views/snippets/s_airproof_carousel.xml` to the beginning of the data list in `__manifest__.py` to ensure the template is loaded before being referenced.

## Changes
- Reordered data files in `__manifest__.py` to load templates first
- No functional changes to the template or other files

## Testing
- [x] Module installs without errors
- [x] Tutorial can be completed successfully 
- [x] All existing functionality preserved

## Related Issues
Closes #981 

## Checklist
- [x] The fix addresses the root cause
- [x] No breaking changes introduced
- [x] Commit message follows conventional format
- [x] Documentation (tutorial) remains accurate