### PR TITLE
[FIX] awesome_owl: Fix missing css variables

### DIFF
--- a/awesome_dashboard/controllers/controllers.py
+++ b/awesome_dashboard/controllers/controllers.py
@@ -9,7 +9,7 @@ from odoo.http import request
 logger = logging.getLogger(__name__)
 
 class AwesomeDashboard(http.Controller):
-    @http.route('/awesome_dashboard/statistics', type='json', auth='user')
+    @http.route('/awesome_dashboard/statistics', type='jsonrpc', auth='user')
     def get_statistics(self):
         """
         Returns a dict of statistics about the orders:

--- a/awesome_owl/__manifest__.py
+++ b/awesome_owl/__manifest__.py
@@ -29,8 +29,10 @@
     'assets': {
         'awesome_owl.assets_playground': [
             ('include', 'web._assets_helpers'),
+            ('include', 'web._assets_backend_helpers'),
             'web/static/src/scss/pre_variables.scss',
             'web/static/lib/bootstrap/scss/_variables.scss',
+            'web/static/lib/bootstrap/scss/_maps.scss',
             ('include', 'web._assets_bootstrap'),
             ('include', 'web._assets_core'),
             'web/static/src/libs/fontawesome/css/font-awesome.css',


### PR DESCRIPTION
Some imports are missing in the manifest causing some warnings and the css doesn't load properly.
Fix was fixed in the master branch, backporting it in 19.0 for the onboarding classes that always happen in the lastest stable.

[See](https://github.com/odoo/tutorials/blame/2eef68071d786c91520ac9e25b514577730df142/awesome_owl/__manifest__.py#L32)

task-none