### PR TITLE
[ADD] pos_order_salesperson: add salesperson selection in POS

### DIFF
--- a/pos_order_salesperson/__init__.py
+++ b/pos_order_salesperson/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_order_salesperson/__manifest__.py
+++ b/pos_order_salesperson/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "Point of Sale Salesperson",
+    "description": """
+    Point of Sale Salesperson Module to add Salesperson in pos order, form and billing in session.
+    """,
+    "version": "1.0",
+    "depends": ["pos_hr"],
+    "author": "danal",
+    "category": "Category",
+    "license": "LGPL-3",
+    "data": [
+        "views/pos_order_view.xml",
+    ],
+    "assets": {
+        "point_of_sale._assets_pos": [
+            "pos_order_salesperson/static/src/**/*"
+        ]
+    },
+}

--- a/pos_order_salesperson/models/__init__.py
+++ b/pos_order_salesperson/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_order
+from . import pos_session

--- a/pos_order_salesperson/models/pos_order.py
+++ b/pos_order_salesperson/models/pos_order.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class PosOrder(models.Model):
+    _inherit = 'pos.order'
+
+    salesperson_id = fields.Many2one("hr.employee", string="Salesperson")

--- a/pos_order_salesperson/models/pos_session.py
+++ b/pos_order_salesperson/models/pos_session.py
@@ -1,0 +1,11 @@
+from odoo import api, models
+
+
+class PosSession(models.Model):
+    _inherit = 'pos.session'
+
+    @api.model
+    def _load_pos_data_models(self, config_id):
+        data = super()._load_pos_data_models(config_id)
+        data += ["hr.employee"]
+        return data

--- a/pos_order_salesperson/static/src/salesperson_button/select_salesperson_button.js
+++ b/pos_order_salesperson/static/src/salesperson_button/select_salesperson_button.js
@@ -1,0 +1,32 @@
+import { SalespersonList } from '../salesperson_list/salesperson_list';
+import { ControlButtons } from '@point_of_sale/app/screens/product_screen/control_buttons/control_buttons';
+import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
+import { patch } from '@web/core/utils/patch';
+import { useState } from '@odoo/owl';
+
+patch(ControlButtons.prototype, {
+    setup() {
+        super.setup();
+        const order = this.pos.getOrder();
+        this.state = useState({
+            salesperson_id: order ? order.salesperson_id : null,
+        });
+
+    },
+
+    async selectSalesperson() {
+        const currentOrder = this.pos.getOrder();
+        if (!currentOrder) {
+            return;
+        }
+
+        const currentSalesperson = currentOrder.salesperson_id || null;
+        const payload = await makeAwaitable(this.dialog, SalespersonList, {
+            salesperson: currentSalesperson,
+            getPayload: (newSalesperson) => newSalesperson || null,
+        });
+        this.state.salesperson_id = payload || null;
+        currentOrder.salesperson_id = payload || null;
+        return currentOrder.salesperson_id;
+    }
+})

--- a/pos_order_salesperson/static/src/salesperson_button/select_salesperson_button.xml
+++ b/pos_order_salesperson/static/src/salesperson_button/select_salesperson_button.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="SelectSalespersonButton" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//InternalNoteButton" position="after">
+            <t t-name="point_of_sale.SelectSalespersonButton" owl="1">
+                <button class="set-partner btn btn-secondary btn-lg lh-lg text-truncate w-auto" t-on-click="selectSalesperson">
+                 <div t-if="state.salesperson_id" t-out="state.salesperson_id?.name" class="text-truncate text-action" />
+                    <span t-else="">Salesperson</span>
+                </button>
+            </t>
+      </xpath>
+    </t>
+</templates>

--- a/pos_order_salesperson/static/src/salesperson_line/salesperson_line.js
+++ b/pos_order_salesperson/static/src/salesperson_line/salesperson_line.js
@@ -1,0 +1,23 @@
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+
+export class SalespersonLine extends Component {
+    static template = "point_of_sale.SalespersonLine";
+    static components = { Dropdown, DropdownItem };
+    static props = [
+        "close",
+        "salesperson",
+        "isSelected",
+        "onClickEdit",
+        "onClickUnselect",
+        "clickSalesPerson"
+    ];
+
+    setup() {
+        this.pos = usePos();
+        this.ui = useService("ui");
+    }
+}

--- a/pos_order_salesperson/static/src/salesperson_line/salesperson_line.xml
+++ b/pos_order_salesperson/static/src/salesperson_line/salesperson_line.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.SalespersonLine">
+        <tr class="partner-line partner-info" 
+            t-att-class="{'selected': props.isSelected}" 
+            t-on-click="() => props.clickSalesPerson(props.salesperson)">
+                                    
+            <td class="text-break w-25">
+                <b t-out="props.salesperson.name or ''" />
+                <div t-if="props.salesperson.parent_name" class="company-field text-bg-muted" t-out="props.salesperson.parent_name" />
+            </td>
+
+            <td>
+                <div class="partner-line-adress" t-if="props.salesperson.work_contact_id.pos_contact_address" t-out="props.salesperson.work_contact_id.pos_contact_address" />
+            </td>
+
+            <td class="partner-line-email">
+                <div t-if="props.salesperson.work_contact_id.phone">
+                    <i class="fa fa-fw fa-phone me-2"/><t t-out="props.salesperson.work_contact_id.phone"/>
+                </div>
+                <div t-if="props.salesperson.work_contact_id.email" class="email-field">
+                    <i class="fa fa-fw fa-paper-plane-o me-2"/><t t-out="props.salesperson.work_contact_id.email" />
+                </div>
+            </td>
+
+            <td class="edit-partner-button-cell align-middle pe-0">
+                <button t-if="props.isSelected" t-on-click.stop="props.onClickUnselect" class="unselect-tag d-lg-inline-block d-none btn btn-link btn-lg mt-1 float-end">
+                    <i class="fa fa-check"/>
+                </button>
+            </td>
+
+            <td class="edit-partner-button-cell align-middle">
+                <Dropdown>
+                    <button class="btn btn-light btn-lg lh-lg border float-end">
+                        <i class="fa fa-fw fa-bars"/>
+                    </button>
+                    <t t-set-slot="content">
+                        <t t-if="!props.isSelected">
+                            <DropdownItem onSelected="() => props.clickSalesPerson(props.salesperson)">
+                                Select
+                            </DropdownItem>
+                        </t>
+                        <t t-if="props.isSelected">
+                            <DropdownItem onSelected="props.onClickUnselect">
+                                unselect
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+            </td>
+        </tr>
+    </t>
+</templates>

--- a/pos_order_salesperson/static/src/salesperson_list/salesperson_list.js
+++ b/pos_order_salesperson/static/src/salesperson_list/salesperson_list.js
@@ -1,0 +1,45 @@
+import { useService } from "@web/core/utils/hooks";
+import { Dialog } from "@web/core/dialog/dialog";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+import { Component, useState } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { SalespersonLine } from "../salesperson_line/salesperson_line";
+
+export class SalespersonList extends Component {
+    static template = "point_of_sale.SalespersonList";
+    static components = { Dialog, Dropdown, DropdownItem, SalespersonLine };
+    static props = {
+        salesperson: {
+            optional: true,
+            type: [{ value: null }, Object],
+        },
+        getPayload: { type: Function },
+        close: { type: Function }
+    }
+
+    setup() {
+        this.pos = usePos();
+        this.ui = useService("ui");
+        this.dialog = useService("dialog");
+        this.state = useState({
+            query: null,
+            previousQuery: "",
+            currentOffset: 0,
+            totalSalespersons: 0,
+            isLoading: false,
+            query: ''
+        });
+    }
+
+    getSalesPerson() {
+        const salesperson = this.pos.models['hr.employee'].getAll();
+        this.state.totalSalespersons = salesperson.length
+        return salesperson;
+    }
+
+    clickSalesPerson(salesperson) {
+        this.props.getPayload(salesperson);
+        this.props.close();
+    }
+}

--- a/pos_order_salesperson/static/src/salesperson_list/salesperson_list.xml
+++ b/pos_order_salesperson/static/src/salesperson_list/salesperson_list.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.SalespersonList">
+        <Dialog bodyClass="'partner-list p-0'" modalRef="modalRef" contentClass="'h-100'">
+            <t t-set-slot="header">
+                <span class="modal-title fs-4">Choose Salesperson</span>
+            </t>
+             <t t-set="nbrSalesPersons" t-value="this.state.totalSalespersons"/>
+            <div class="h-100">
+                <table class="table table-hover">
+                    <tbody class="h-100" t-att-class="{'d-none': !nbrSalesPersons}">
+                        <t t-foreach="getSalesPerson()" t-as="salesperson" t-key="salesperson.id">
+                            <SalespersonLine
+                                close="props.close"
+                                salesperson="salesperson"
+                                isSelected="props.salesperson?.id === salesperson.id"
+                                onClickUnselect.bind="() => this.clickSalesPerson()"
+                                onClickEdit.bind="(s) => this.editSalesPerson(s)"
+                                clickSalesPerson.bind="clickSalesPerson"
+                            />
+                        </t>
+                    </tbody>
+                </table>
+                <div class="text-center" t-if="!nbrSalesPersons">
+                    <div class="text-muted mt-5">
+                        <i class="fa fa-users fa-3x"></i>
+                        <p class="mt-3">No Salesperson found.</p>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <div class="d-flex flex-row gap-2 w-100">
+                    <button class="btn btn-secondary btn-lg lh-lg flex-fill" t-on-click="() => this.clickSalesPerson(this.props.salesperson)">Discard</button>
+                </div>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/pos_order_salesperson/views/pos_order_view.xml
+++ b/pos_order_salesperson/views/pos_order_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_pos_order_tree_inherit" model="ir.ui.view">
+        <field name="name">pos.order.tree.inherit</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="salesperson_id"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_pos_order_form_inherit" model="ir.ui.view">
+        <field name="name">pos.order.form.inherit</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="salesperson_id" readonly="account_move"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before, POS orders were linked to the user logged into
the session or the active cashier.
There was no functionality to assign a specific salesperson to the
transaction.

This limitation made it difficult to calculate commissions or audit
sales performance by employee, particularly in scenarios where the
person operating the register is different from the person who
advised the customer.

This adds the ability to select a specific salesperson directly
from the Point of Sale interface. This selection is stored on the
order and is visible in the backend views.

Technical details:
- Model (`pos.order`): Added `salesperson_id` field to store the
  selected employee on the order record.
- Session (`pos_session`): Inherited to load `hr.employee` data into
  the frontend context upon initialization.
- UI Components:
  - Added `SalespersonList` and `SalespersonLine` to display
    available employees in a selection modal.
  - Added a 'Salesperson' button to the `ControlButtons` area of
    the `ProductScreen`.
- Views: Added `salesperson_id` to the `pos.order` form and list
  views to ensure the data is visible in the backend.

task-4680845