### PR TITLE
[ADD] purchase_discount: add global discount functionality.

### DIFF
--- a/purchase_discount/__init__.py
+++ b/purchase_discount/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_discount/__manifest__.py
+++ b/purchase_discount/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'author': 'Odoo S.A.',
+    'name': 'Purchase Discount',
+    "description": """
+    This module introduces a global discount feature for Purchase Orders,
+    allowing users to apply either value-based or percentage-based discounts.
+    """,
+    'depends': ['purchase'],
+    'license': 'LGPL-3',
+    'data': [
+        'views/purchase_order_views.xml'
+    ],
+    'application': True,
+    'installable': True
+}

--- a/purchase_discount/models/__init__.py
+++ b/purchase_discount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -1,0 +1,53 @@
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+from odoo.tools import _
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    discount_type = fields.Selection(
+        selection=[
+            ("value", "$"),
+            ("percentage", "%"),
+        ],
+        default="percentage",
+    )
+    discount_in_value = fields.Float(string="Discount")
+    discount_in_percentage = fields.Float(compute="_compute_discount_percentage", store=True, readonly=True)
+
+    @api.depends("discount_type", "discount_in_value")
+    def _compute_discount_percentage(self):
+        for record in self:
+            if record.discount_type == "value" and record.amount_total > 0:
+                record.discount_in_percentage = (record.discount_in_value * 100) / (record.amount_total)
+            elif record.discount_type == "percentage":
+                record.discount_in_percentage = record.discount_in_value
+            else:
+                record.discount_in_percentage = 0.0
+
+    @api.constrains("discount_in_value", "discount_type", "amount_total")
+    def _check_discount_price(self):
+        for record in self:
+            if record.discount_type == "percentage":
+                if record.discount_in_value < 0 or record.discount_in_value > 100:
+                    raise ValidationError("discount value is not valid please check again")
+            if record.discount_type == "value":
+                if record.discount_in_value < 0 or record.discount_in_value > record.amount_total:
+                    raise ValidationError("discount value is not valid please check again")
+
+    def apply_discount(self):
+        self.order_line.discount = self.discount_in_percentage
+
+    def action_discount(self):
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Discount"),
+            "res_model": "purchase.order",
+            "view_mode": "form",
+            "view_id": self.env.ref(
+                "purchase_discount.view_purchase_order_discount_form"
+            ).id,
+            "res_id": self.id,
+            "target": "new",
+        }

--- a/purchase_discount/views/purchase_order_views.xml
+++ b/purchase_discount/views/purchase_order_views.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="view_purchase_order_discount_form" model="ir.ui.view">
+        <field name="name">purchase.order.discount.form</field>
+        <field name="model">purchase.order</field>
+        <field name="priority">17</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="d-flex flex-row gap-2">
+                        <label for="discount_in_value">Discount</label>
+                        <div style="max-width:150px;">
+                            <field name="discount_in_value"/>
+                        </div>
+                        <div style="max-width:50px;">
+                            <field name="discount_type"/>
+                        </div>
+                        <span class="text-muted" invisible="discount_type == 'percentage'">
+                            (<field name="discount_in_percentage"/>%)
+                        </span>
+                    </div>
+                </sheet>
+                <footer>
+                    <button name="apply_discount" type="object" string="Apply" class="oe_highlight"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="purchase_order_form_inherit" model="ir.ui.view">
+        <field name="name">purchase.order.view.form.inherit</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//*[hasclass('oe_subtotal_footer')]" position="replace">
+                <div class="d-flex flex-column align-items-end">
+                    <button name="action_discount" type="object" class="oe_highlight" string="Discount" invisible="state in ('purchase', 'cancel')"/>
+                    <group class="oe_subtotal_footer">
+                        <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" readonly="1"/>
+                    </group>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose:
When you have a big RFQ (with a lot of lines) and you receive a Quote from the
vendor with a global discount (% or amount), it's very time consuming to apply
it to all lines.

Technical changes:
Add discount_type, discount_in_value and computed discount_in_percentage fields
on purchase.order.
Add constraints for validate discount percentage.
Add discount button in purchase order view form.
Add action_discount to open a popup and apply_discount to apply the global
discount on all order lines.
Discount can be entered either as a percentage or as a fixed amount.

task-5366796