### PR TITLE
[ADD] sale_pricelist: add book price to sale order and invoice lines

### DIFF
--- a/sale_pricelist/__init__.py
+++ b/sale_pricelist/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_pricelist/__manifest__.py
+++ b/sale_pricelist/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'author': 'Odoo S.A.',
+    'name': 'Sale Pricelist',
+    'description': """
+    Add a "Book Price" field on Sales Order Lines and Invoice Lines to display the original
+    pricelist price of a product. This helps users compare the standard pricelist amount
+    with any manually adjusted line price, ensuring pricing transparency and better control
+    over discount or custom price modifications.
+    """,
+    'depends': ['sale_management'],
+    'license': 'LGPL-3',
+    'data': [
+        'views/sale_order_views.xml',
+        'views/account_move_views.xml',
+    ],
+    'application': True,
+    'installable': True
+}

--- a/sale_pricelist/models/__init__.py
+++ b/sale_pricelist/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_line
+from . import account_move_line

--- a/sale_pricelist/models/account_move_line.py
+++ b/sale_pricelist/models/account_move_line.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(related="sale_line_ids.book_price", readonly=True)

--- a/sale_pricelist/models/sale_order_line.py
+++ b/sale_pricelist/models/sale_order_line.py
@@ -1,0 +1,17 @@
+from odoo import models, fields, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(compute="_compute_pricelist", readonly=True)
+
+    @api.depends("product_id", "product_uom_qty", "order_id.pricelist_id", "product_template_id.list_price")
+    def _compute_pricelist(self):
+        for record in self:
+            if not record.product_id:
+                record.book_price = 0.0
+            elif not record.order_id.pricelist_id:
+                record.book_price = record.product_template_id.list_price
+            else:
+                record.book_price = record.order_id.pricelist_id._get_product_price(record.product_id, record.product_uom_qty)

--- a/sale_pricelist/views/account_move_views.xml
+++ b/sale_pricelist/views/account_move_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.view.form.inherit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='quantity']" position="before">
+                <field name="book_price" invisible="move_type != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_pricelist/views/sale_order_views.xml
+++ b/sale_pricelist/views/sale_order_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="sale_order_from_pricelist" model="ir.ui.view">
+        <field name="name">sale.order.view.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list//field[@name='product_uom_qty']" position="before">
+                <field name="book_price"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose:
Client requires the ability to see the original pricelist on sale order lines and invoice order lines. This will used to compare between pricelist and any manually adjusted price on the lines.

Technical changes:
1. Add a new field book_price on both sale.order.line and account.move.line models.
2. Display the book_price field:
- On the Sales Order form (order lines).
- On the Account Move form (invoice lines).
- In Account Move, the field is visible only when move.type is a Customer Invoice.
3. Business Logic for book_price Calculation:
- If no product is not exist then book_price should be 0.0.
- If a product exists but is not included in the selected pricelist, book_price should be set to the product’s original sales price.
- If the product exists in the selected pricelist, compute book_price based on the pricelist rule, using Selected pricelist, product, quantity

task-5382732