### PR TITLE
[ADD] pos_customer_display: create the pos customer display module 

### DIFF
--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -2,8 +2,16 @@
     "name": "POS Customer Display",
     "version": "1.0",
     "author": "Ravij Parikh (snrav)",
-    "Description": "Display customer name, amount/guest and refund lines in POS",
+    "description": "Display customer name, amount/guest and refund lines in POS",
     "depends": ["point_of_sale"],
     "application": True,
-    "license": "LGPL-3"
+    "license": "LGPL-3",
+    "assets": {
+        "point_of_sale.assets": [
+            "pos_customer_display/static/src/pos_order.js",
+        ],
+        "point_of_sale.customer_display_assets": [
+            "pos_customer_display/static/src/customer_display/*",
+        ],
+    }
 }

--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    "name": "POS Customer Display",
+    "author": "Ravij Parikh (snrav)",
+    "summary": "Display customer name, amount/guest and refund lines in POS",
+    "version": "1.0",
+    "depends": ["point_of_sale"],
+    "license": "LGPL-3"
+}

--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -1,8 +1,9 @@
 {
     "name": "POS Customer Display",
-    "author": "Ravij Parikh (snrav)",
-    "summary": "Display customer name, amount/guest and refund lines in POS",
     "version": "1.0",
+    "author": "Ravij Parikh (snrav)",
+    "Description": "Display customer name, amount/guest and refund lines in POS",
     "depends": ["point_of_sale"],
+    "application": True,
     "license": "LGPL-3"
 }

--- a/pos_customer_display/__manifest__.py
+++ b/pos_customer_display/__manifest__.py
@@ -2,16 +2,16 @@
     "name": "POS Customer Display",
     "version": "1.0",
     "author": "Ravij Parikh (snrav)",
-    "description": "Display customer name, amount/guest and refund lines in POS",
+    "description": "Display customer name, amount/guest and refund in POS",
     "depends": ["point_of_sale"],
     "application": True,
     "license": "LGPL-3",
     "assets": {
-        "point_of_sale.assets": [
-            "pos_customer_display/static/src/pos_order.js",
+        "point_of_sale.assets_prod": [
+            "pos_customer_display/static/src/customer_display/customer_display_adapter.js",
         ],
         "point_of_sale.customer_display_assets": [
-            "pos_customer_display/static/src/customer_display/*",
+            "pos_customer_display/static/src/customer_display/customer_display.xml",
         ],
     }
 }

--- a/pos_customer_display/static/src/customer_display/customer_display.xml
+++ b/pos_customer_display/static/src/customer_display/customer_display.xml
@@ -4,22 +4,30 @@
 	<t t-inherit="point_of_sale.CustomerDisplay" t-inherit-mode="extension">
 		<xpath expr="//div[hasclass('o_customer_display_main')]//div[@t-if='order.change']" position="after">
 			<div>
-				<t t-if="order.customerName">
-					<div class="row">
-						<div class="col text-end">Customer: </div>
+				<t t-if="order.partner_id">
+					<div class="row fs-2 fw-bolder">
+						<div class="col text-end">Customer </div>
 						<div class="col text-end">
-							<t t-esc="order.customerName"/>
+							<t t-esc="order.partner_id"/>
 						</div>
 					</div>
 				</t>
-				<div class="row">
+				<div class="row fs-2 fw-bolder">
 					<t t-if="order.amountPerGuest">
-						<div class="message text-center">
-							<t t-esc="order.amountPerGuest" /> / Guest      
+						<div class="message text-end">
+							<t t-esc="order.amountPerGuest.toFixed(2)" /> / Guest      
 						</div>
-					</t>
+					</t> 
 				</div>
 			</div>
 		</xpath>
+		<xpath expr="//div[hasclass('o_line_container')]" position="before">
+            <div>
+				<t t-if="order.is_refund">
+                	<p class="p-2 fw-bolder">Refund</p>
+					<seperator />
+            	</t>
+			</div>
+        </xpath>
 	</t>
 </templates>

--- a/pos_customer_display/static/src/customer_display/customer_display.xml
+++ b/pos_customer_display/static/src/customer_display/customer_display.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates id="template" xml:space="preserve">
+	<t t-inherit="point_of_sale.CustomerDisplay" t-inherit-mode="extension">
+		<xpath expr="//div[hasclass('o_customer_display_main')]//div[@t-if='order.change']" position="after">
+			<div>
+				<t t-if="order.customerName">
+					<div class="row">
+						<div class="col text-end">Customer: </div>
+						<div class="col text-end">
+							<t t-esc="order.customerName"/>
+						</div>
+					</div>
+				</t>
+				<div class="row">
+					<t t-if="order.amountPerGuest">
+						<div class="message text-center">
+							<t t-esc="order.amountPerGuest" /> / Guest      
+						</div>
+					</t>
+				</div>
+			</div>
+		</xpath>
+	</t>
+</templates>

--- a/pos_customer_display/static/src/customer_display/customer_display.xml
+++ b/pos_customer_display/static/src/customer_display/customer_display.xml
@@ -15,7 +15,8 @@
 				<div class="row fs-2 fw-bolder">
 					<t t-if="order.amountPerGuest">
 						<div class="message text-end">
-							<t t-esc="order.amountPerGuest.toFixed(2)" /> / Guest      
+   							<span t-esc="order.currency_symbol" style="margin-right:4px;"/>
+    						 <t t-esc="order.amountPerGuest.toFixed(2)" /> / Guest      
 						</div>
 					</t> 
 				</div>

--- a/pos_customer_display/static/src/customer_display/customer_display_adapter.js
+++ b/pos_customer_display/static/src/customer_display/customer_display_adapter.js
@@ -2,10 +2,15 @@ import { patch } from "@web/core/utils/patch";
 import { CustomerDisplayPosAdapter } from "@point_of_sale/app/customer_display/customer_display_adapter";
 
 patch(CustomerDisplayPosAdapter.prototype, {
+    getCurrencySymbol(order) {
+        return order.currency?.symbol || "";
+    },
+
     formatOrderData(order) {
         super.formatOrderData(order);
         this.data.partner_id = order.getPartnerName();
         this.data.amountPerGuest = order.amountPerGuest();
         this.data.is_refund = order.is_refund;
+        this.data.currency_symbol = this.getCurrencySymbol(order);
     },
 });

--- a/pos_customer_display/static/src/customer_display/customer_display_adapter.js
+++ b/pos_customer_display/static/src/customer_display/customer_display_adapter.js
@@ -1,0 +1,11 @@
+import { patch } from "@web/core/utils/patch";
+import { CustomerDisplayPosAdapter } from "@point_of_sale/app/customer_display/customer_display_adapter";
+
+patch(CustomerDisplayPosAdapter.prototype, {
+    formatOrderData(order) {
+        super.formatOrderData(order);
+        this.data.partner_id = order.getPartnerName();
+        this.data.amountPerGuest = order.amountPerGuest();
+        this.data.is_refund = order.is_refund;
+    },
+});


### PR DESCRIPTION
pos_customer_display: enhance order details visibility

Before:

The customer display lacked important order information.

The customer’s name was not shown.

Refund items were mixed with regular sale lines.

Pricing per guest was not available on the display.

After:

The selected customer’s name is now visible on the customer display.

The amount charged per guest is displayed clearly.

Refund items are shown in a dedicated section, separate from standard order lines.

Impact:

Customers can now view clearer and more complete order information.

Refunds are easier to identify at a glance.

Overall customer display readability and user experience are improved.

Task : 5453440