### PR TITLE
[ADD] pos_improvements: create the pos improvements module

### DIFF
--- a/pos_improvements/__manifest__.py
+++ b/pos_improvements/__manifest__.py
@@ -5,5 +5,11 @@
     "author": "Ravij Parikh (snrav)",
     "application": True,
     "depends": ["point_of_sale"],
-    "license": "LGPL-3"
+    "license": "LGPL-3",
+     "assets": {
+        "point_of_sale.assets_prod": [
+            "pos_improvements/static/src/pos_ticket_screen/js/pos_ticket_screen.js",
+            "pos_improvements/static/src/pos_ticket_screen/xml/pos_ticket_screen.xml"
+        ],
+    }
 }

--- a/pos_improvements/__manifest__.py
+++ b/pos_improvements/__manifest__.py
@@ -1,0 +1,9 @@
+{
+    "name": "POS - Improvements",
+    "version": "1.0",
+    "description": "Enable direct payment from the ticket screen in POS",
+    "author": "Ravij Parikh (snrav)",
+    "application": True,
+    "depends": ["point_of_sale"],
+    "license": "LGPL-3"
+}

--- a/pos_improvements/static/src/pos_ticket_screen/js/pos_ticket_screen.js
+++ b/pos_improvements/static/src/pos_ticket_screen/js/pos_ticket_screen.js
@@ -1,0 +1,9 @@
+import { TicketScreen } from '@point_of_sale/app/screens/ticket_screen/ticket_screen';
+import { patch } from '@web/core/utils/patch';
+
+patch(TicketScreen.prototype, {
+    async onPayClick() {
+        this.pos.setOrder(this.getSelectedOrder());
+        this.pos.pay();
+    },
+});

--- a/pos_improvements/static/src/pos_ticket_screen/xml/pos_ticket_screen.xml
+++ b/pos_improvements/static/src/pos_ticket_screen/xml/pos_ticket_screen.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="point_of_sale.TicketScreen" t-inherit-mode="extension">
+        <xpath expr="//div[@t-if='ui.isSmall']//button[hasclass('load-order-button')]" position="after">
+            <button class="button btn-primary pay-order-button btn btn-lg w-50" t-on-click="onPayClick">Payment</button>
+        </xpath>
+        <xpath expr="//div[@t-else='']//button[hasclass('load-order-button')]" position="after">
+            <button class="button btn-primary pay-order-button btn btn-lg w-100" t-on-click="onPayClick">Payment</button>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Before:
Cashiers were required to:
1. Use "Load Order" to open a ticket
2. Then press "Payment" to navigate to the PaymentScreen
This resulted in an extra step during checkout.

After:
- Added a new "Payment" button next to "Load Order" on the TicketScreen
- Clicking it loads the selected ticket and opens the PaymentScreen immediately

Impact:
Speeds up the cashier checkout process by reducing the number of actions needed to reach payment.

Task: [5476673]
