### PR TITLE
[ADD] webshop_extended_description:  Added ecommerce extended description field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,11 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.eslintignore
+.eslintrc.json
+jsconfig.json
+package-lock.json
+package.json
+node_modules
+

--- a/webshop_extended_description/__init__.py
+++ b/webshop_extended_description/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/webshop_extended_description/__manifest__.py
+++ b/webshop_extended_description/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "webshop_extension",
+    "description": """
+    This module add an extended description field in the website ecommerce application.
+        - added multilingual HTML description field in product template
+        - displays this field in the frontend
+        - enable import/export of this field
+    """,
+    "summary": "Adds extended description field in the website ecommerce application",
+    "author": "haman",
+    "version": "1.0",
+    "category": "website",
+    "data": [
+        'views/product_views.xml',
+        'views/product_web_template.xml',
+    ],
+    "depends": ["website_sale"],
+    "installable": True,
+    "license": "LGPL-3"
+}

--- a/webshop_extended_description/models/__init__.py
+++ b/webshop_extended_description/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/webshop_extended_description/models/product_template.py
+++ b/webshop_extended_description/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    ecommerce_extended_description = fields.Html(string="Ecommerce Extended Description", translate=True, exportable=True)

--- a/webshop_extended_description/views/product_views.xml
+++ b/webshop_extended_description/views/product_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.view.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales']//group[@name='description']" position="after">
+                <group name="ecommerce_extended_description" string="Ecommerce Extended Description">
+                    <field name="ecommerce_extended_description"
+                           nolabel="1"
+                           colspan="2"
+                           placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."
+                    />
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/webshop_extended_description/views/product_web_template.xml
+++ b/webshop_extended_description/views/product_web_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="template_with_extended_description" inherit_id="website_sale.product">
+        <xpath expr="//section[@id='product_detail']" position="inside">
+            <div id="product_extended_description" class="oe_website_sale container">
+                <t t-if="product.ecommerce_extended_description">
+                    <h2 class="mt-4">Extended Description</h2>
+                    <div class="oe_structure">
+                        <t t-esc="product.ecommerce_extended_description"/>
+                    </div>
+                </t>
+            </div>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Add translatable HTML field for ecommerce extended description on products.
Display the field on product form (Sales tab) for easy backend editing.
Ensure field is available for import/export and translation per language

Task-5483814