### PR TITLE
[FIX] awesome_gallery: define gallery vew type view_info

### DIFF
--- a/awesome_gallery/models/ir_ui_view.py
+++ b/awesome_gallery/models/ir_ui_view.py
@@ -6,3 +6,6 @@ class View(models.Model):
     _inherit = 'ir.ui.view'
 
     type = fields.Selection(selection_add=[('gallery', "Awesome Gallery")])
+
+    def _get_view_info(self):
+        return {'gallery': {'icon': 'fa fa-picture-o'}} | super()._get_view_info()


### PR DESCRIPTION
This commit relates to the JS tutorial on view type creation: https://www.odoo.com/documentation/19.0/developer/tutorials/master_odoo_web_framework/02_create_gallery_view.html#make-a-hello-world-view

Currently, using the given files:
https://github.com/odoo/tutorials/tree/19.0/awesome_gallery And the most up to date solution I could find (dating back to 17.0): https://github.com/odoo/tutorials/commit/acce6085d8a53e44e3960b7e46cac1931d8ec03e

Results in an error being raised:
`Uncaught Promise > View types not defined gallery found in act_window action 143`

Tracing this error back to its root it appears that: `_executeActWindowAction()` raises the error, because `session.view_info` does not contain a key for 'gallery' (The type we cant to create).

Ctrl-F through the enterprise files reveals a couple of instances of the function `_get_view_info()` in 18.0 that did not exist in 17.0.

This is probably just due to the tutorial files being out of date, I have confirmed that adding this function to the View inheritance model fixes the issue, hence the fix proposed here.