### PR TITLE
[ADD] zero_stock_approval: create module and implement approval logic

### DIFF
--- a/sale_order_zero_stock_blockage/__init__.py
+++ b/sale_order_zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_order_zero_stock_blockage/__manifest__.py
+++ b/sale_order_zero_stock_blockage/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    'name': "sale_order_zero_stock_blockage",
+    'author': "pkhu",
+    'license': "LGPL-3",
+    'depends': ['sale_management', 'stock'],
+    'data': [
+        'views/sale_order_views.xml',
+    ],
+    'auto_install': True,
+}

--- a/sale_order_zero_stock_blockage/models/__init__.py
+++ b/sale_order_zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_order_zero_stock_blockage/models/sale_order.py
+++ b/sale_order_zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+from odoo.exceptions import AccessError
+
+
+class SaleOrder(models.Model):
+    _inherit = ['sale.order']
+
+    zero_stock_approval = fields.Boolean(default=False, string="Approval")
+
+    def action_confirm(self):
+        for record in self:
+            for line in record.order_line:
+                # if not record.zero_stock_approval and not self.env.user.has_group('sales_team.group_sale_manager'):
+                if not record.zero_stock_approval and not self.env.user.has_group('sales_team.group_sale_manager') and line.product_id.type == 'consu' and line.product_id.is_storable and line.product_id.qty_available < line.product_uom_qty:
+                    raise AccessError(
+                        "Access denied: You are not authorized to confirm this sales order.")
+        return super().action_confirm()

--- a/sale_order_zero_stock_blockage/views/sale_order_views.xml
+++ b/sale_order_zero_stock_blockage/views/sale_order_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form_inherit_sale_new" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.sale.new</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <field name="payment_term_id" position="after">
+                <field name="zero_stock_approval" readonly="1" groups="!sales_team.group_sale_manager"/>
+                <field name="zero_stock_approval" groups="sales_team.group_sale_manager"/>
+            </field>
+
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Task Description -
1. Add a new Boolean field zero_stock_approval in the Sales Order form view.
2. The field should be read-only for Sales Users and editable only by the Administrator (or Sales Manager).
3. If zero_stock_approval is enabled, the user should be allowed to confirm the quotation regardless of product stock availability.
4. If zero_stock_approval is disabled, the system should prevent confirmation of the quotation when the available quantity is less than the ordered quantity.

- Created new module `zero_stock_approval` with required base files
- Inherited `sale.order` model and added `zero_stock_approval` field
- Overridden `action_confirm` method to apply custom business logic
- Extended `view_order_form` to include the new approval field

Task-5929841