### PR TITLE
[ADD] add_pricelist_price: add book price to sale and invoice lines

### DIFF
--- a/add_pricelist_price/__init__.py
+++ b/add_pricelist_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/add_pricelist_price/__manifest__.py
+++ b/add_pricelist_price/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Add pricelist price',
+    'version': '0.1.0',
+    'description': 'Add pricelist price field.',
+    'depends': [
+        'sale', 'account'
+    ],
+    'data': [
+        'views/sale_order_line_views.xml',
+        'views/account_move_views.xml'
+    ],
+    'author': 'Ishwar Goswami',
+    'license': 'LGPL-3',
+    'installable': True
+}

--- a/add_pricelist_price/models/__init__.py
+++ b/add_pricelist_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_line
+from . import account_move_line

--- a/add_pricelist_price/models/account_move_line.py
+++ b/add_pricelist_price/models/account_move_line.py
@@ -1,0 +1,31 @@
+from odoo import api, fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    book_price = fields.Monetary(
+        string="Book Price",
+        compute="_compute_book_price",
+        readonly=True,
+    )
+
+    @api.depends('product_id', 'quantity', 'move_id.partner_id')
+    def _compute_book_price(self):
+        for line in self:
+            if not line.product_id:
+                line.book_price = 0.0
+                continue
+
+            if line.sale_line_ids:
+                pricelist = line.sale_line_ids[0].order_id.pricelist_id
+            else:
+                pricelist = line.move_id.partner_id.property_product_pricelist
+
+            if pricelist:
+                line.book_price = pricelist._get_product_price(
+                    product=line.product_id,
+                    quantity=line.quantity,
+                )
+            else:
+                line.book_price = line.product_id.list_price

--- a/add_pricelist_price/models/sale_order_line.py
+++ b/add_pricelist_price/models/sale_order_line.py
@@ -1,0 +1,22 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = ["sale.order.line"]
+
+    book_price = fields.Monetary(compute="_compute_book_price", readonly=True)
+
+    @api.depends('order_id.pricelist_id', 'product_id', 'product_uom_qty')
+    def _compute_book_price(self):
+        for line in self:
+            if not line.product_id:
+                line.book_price = 0
+                continue
+            pricelist = line.order_id.pricelist_id
+            if line.product_id and pricelist:
+                line.book_price = pricelist._get_product_price(
+                    product=line.product_id,
+                    quantity=line.product_uom_qty,
+                )
+            else:
+                line.book_price = line.product_id.lst_price

--- a/add_pricelist_price/views/account_move_views.xml
+++ b/add_pricelist_price/views/account_move_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//list//field[@name='price_unit']" position="before">
+                <field name="book_price" column_invisible="parent.move_type != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/add_pricelist_price/views/sale_order_line_views.xml
+++ b/add_pricelist_price/views/sale_order_line_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="sale_order_line_view_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//list//field[@name='product_uom_qty']" position="after">
+                <field name="book_price" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Business Context

Client requires the ability to see the original pricelist price ("Book Price") on sales order lines and invoice lines. This will be used to compare between pricelist ("Book Price") and any manually adjusted price on the lines.

Proposed Solution:

Add a new computed field on Sales Order Lines and Account Move Lines that will output the relevant pricelist price based on the currently selected pricelist, product and quantity.

On the Invoice Lines tree view - add the new "Book Price" field (only on customer invoices)

On the Sales Order lines tree view - add the new "Book Price" field.