### PR TITLE
[ADD] project_recognition_sync

### DIFF
--- a/project_recognition_sync/__init__.py
+++ b/project_recognition_sync/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/project_recognition_sync/__manifest__.py
+++ b/project_recognition_sync/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "Linking project date",
+    "version": "1.0",
+    "author": "japat",
+    "depends": [
+        "project",
+        "account",
+        "sale_management",
+    ],
+    "data": [
+        "views/project_project_view.xml",
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/project_recognition_sync/models/__init__.py
+++ b/project_recognition_sync/models/__init__.py
@@ -1,0 +1,2 @@
+from . import project_project
+from . import account_move_line

--- a/project_recognition_sync/models/account_move_line.py
+++ b/project_recognition_sync/models/account_move_line.py
@@ -1,0 +1,25 @@
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    recognition_date = fields.Date(
+        string="Recognition Date",
+        help="Reloaded date from Planned date of corresponding project of sale order",
+    )
+
+    def action_automatic_entry(self, default_action=None):
+        result = super().action_automatic_entry(default_action)
+
+        ctx = dict(result.get("context", {}))
+
+        project = self.move_id.line_ids.mapped(
+            "sale_line_ids.order_id.project_id"
+        ).filtered(lambda p: p.date_start)
+
+        if project:
+            ctx["default_date"] = project[0].date_start
+
+        result["context"] = ctx
+        return result

--- a/project_recognition_sync/models/project_project.py
+++ b/project_recognition_sync/models/project_project.py
@@ -1,0 +1,56 @@
+from odoo import api, fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    is_recognition_required = fields.Boolean(compute="_compute_is_recognition_required")
+
+    @api.depends("date_start", "sale_order_id.invoice_ids.line_ids.recognition_date")
+    def _compute_is_recognition_required(self):
+        for project in self:
+            project.is_recognition_required = False
+
+            if not project.sale_order_id or not project.date_start:
+                continue
+
+            journal_items = self.env["account.move.line"].search(
+                [
+                    ("move_id", "in", project.sale_order_id.invoice_ids.ids),
+                    ("account_id.internal_group", "in", ["income", "expense"]),
+                    ("parent_state", "=", "posted"),
+                    ("recognition_date", "!=", project.date_start),
+                ],
+                limit=1,
+            )
+
+            project.is_recognition_required = bool(journal_items)
+
+    def open_cut_off_wizard(self):
+        self.ensure_one()
+
+        journal_items = self.env["account.move.line"].search(
+            [
+                ("move_id", "in", self.sale_order_id.invoice_ids.ids),
+                ("account_id.internal_group", "in", ["income", "expense"]),
+                ("parent_state", "=", "posted"),
+                ("recognition_date", "!=", self.date_start),
+            ]
+        )
+
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account.account_automatic_entry_wizard_action"
+        )
+
+        ctx = dict(self.env.context or {})
+        ctx.update(
+            {
+                "active_ids": journal_items.ids,
+                "active_model": "account.move.line",
+                "default_action": "change_period",
+                "default_date": self.date_start,
+            }
+        )
+
+        action["context"] = ctx
+        return action

--- a/project_recognition_sync/views/project_project_view.xml
+++ b/project_recognition_sync/views/project_project_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="edit_project_inherited" model="ir.ui.view">
+        <field name="name">project.project.form.inherit.recognition</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project" />
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='date_start']" position="after">
+                <button name="open_cut_off_wizard"
+                    type="object"
+                    string="Recognise the invoices"
+                    icon="fa-refresh"
+                    invisible="not is_recognition_required" />
+            </xpath>
+
+            <xpath expr="//form/header" position="inside">
+                <div class="alert alert-warning"
+                    role="alert"
+                    invisible="not is_recognition_required"> You still have journal items to be
+                    recognised from <b>
+                        <field name="date_start" readonly="1" />
+                    </b>
+
+                </div>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/project_recognition_sync/wizard/__init__.py
+++ b/project_recognition_sync/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import automatic_entry_wizard

--- a/project_recognition_sync/wizard/automatic_entry_wizard.py
+++ b/project_recognition_sync/wizard/automatic_entry_wizard.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class AutomaticEntryWizard(models.TransientModel):
+    _inherit = "account.automatic.entry.wizard"
+
+    def do_action(self):
+        active_ids = self.env.context.get("active_ids", [])
+        journal_lines = self.env["account.move.line"].browse(active_ids)
+
+        journal_lines.write({"recognition_date": self.date})
+
+        return super().do_action()


### PR DESCRIPTION
This PR adds a recognition check on projects based on invoice journal items.

1. Adds recognition_date field on account.move.line
2. Computes is_recognition_required on project
3. Displays warning message if recognition is pending
4. Adds button to open automatic entry wizard with project planned date

This ensures invoice recognition matches the project planned start date.