### PR TITLE
[IMP] modular_types: add modular configuration from sale order

### DIFF
--- a/modular_types/__init__.py
+++ b/modular_types/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/modular_types/__init__.py
+++ b/modular_types/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/modular_types/__manifest__.py
+++ b/modular_types/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "Modular Types",
+    "version": "1.0",
+    "category": "Manufacturing",
+    "author": "Abhi Bhingradiya(abbhi)",
+    "description": """
+        This module allows adding modular types to products and BoM lines.
+        In Sales Orders, users can set values for these modular types, which
+        will then be used to multiply the quantities in the resulting Manufacturing Orders.
+    """,
+    "depends": ["sale_management", "mrp", "sale_mrp"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/modular_type_views.xml",
+        "views/product_views.xml",
+        "views/mrp_bom_views.xml",
+        "views/sale_order_views.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/modular_types/__manifest__.py
+++ b/modular_types/__manifest__.py
@@ -15,6 +15,8 @@
         "views/product_views.xml",
         "views/mrp_bom_views.xml",
         "views/sale_order_views.xml",
+        "wizard/set_modular_values_views.xml",
+        "views/mrp_production_views.xml"
     ],
     "license": "LGPL-3",
 }

--- a/modular_types/models/__init__.py
+++ b/modular_types/models/__init__.py
@@ -2,3 +2,6 @@ from . import modular_type
 from . import product
 from . import mrp_bom_line
 from . import sale_order_line
+from . import mrp_production
+from . import stock_move
+from . import sale_order_line_modular_values

--- a/modular_types/models/__init__.py
+++ b/modular_types/models/__init__.py
@@ -1,0 +1,4 @@
+from . import modular_type
+from . import product
+from . import mrp_bom_line
+from . import sale_order_line

--- a/modular_types/models/modular_type.py
+++ b/modular_types/models/modular_type.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import fields, models
 
 
 class ModularType(models.Model):

--- a/modular_types/models/modular_type.py
+++ b/modular_types/models/modular_type.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class ModularType(models.Model):
+    _name = "modular.type"
+    _description = "Modular Type"
+
+    name = fields.Char(string="Name", required=True)

--- a/modular_types/models/mrp_bom_line.py
+++ b/modular_types/models/mrp_bom_line.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class MrpBomLine(models.Model):
+    _inherit = "mrp.bom.line"
+
+    modular_type_id = fields.Many2one("modular.type", string="Module Type")

--- a/modular_types/models/mrp_production.py
+++ b/modular_types/models/mrp_production.py
@@ -1,0 +1,42 @@
+from odoo import models
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+
+    def _get_moves_raw_values(self):
+        res = super()._get_moves_raw_values()
+        for production in self:
+            if (
+                not production.sale_line_id
+                or not production.sale_line_id.modular_value_ids
+            ):
+                continue
+
+            factors = {
+                val.modular_type_id.id: val.value
+                for val in production.sale_line_id.modular_value_ids
+            }
+
+            for move_vals in res:
+                if move_vals.get("raw_material_production_id") == production.id:
+                    bom_line_id = move_vals.get("bom_line_id")
+                    if bom_line_id:
+                        bom_line = self.env["mrp.bom.line"].browse(bom_line_id)
+                        if (
+                            bom_line.modular_type_id
+                            and bom_line.modular_type_id.id in factors
+                        ):
+                            factor = factors[bom_line.modular_type_id.id]
+                            move_vals["product_uom_qty"] *= factor
+        return res
+
+    def _get_move_raw_values(
+        self, product, product_uom_qty, product_uom, operation_id=False, bom_line=False
+    ):
+        res = super()._get_move_raw_values(
+            product, product_uom_qty, product_uom, operation_id, bom_line
+        )
+        if bom_line and bom_line.modular_type_id:
+            res["modular_type_id"] = bom_line.modular_type_id.id
+        return res

--- a/modular_types/models/product.py
+++ b/modular_types/models/product.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import fields, models
 
 
 class ProductTemplate(models.Model):

--- a/modular_types/models/product.py
+++ b/modular_types/models/product.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    modular_type_ids = fields.Many2many("modular.type", string="Module Types")

--- a/modular_types/models/sale_order_line.py
+++ b/modular_types/models/sale_order_line.py
@@ -1,0 +1,33 @@
+from odoo import api, models, fields
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    has_modular_types = fields.Boolean(compute="_compute_has_modular_types", store=True)
+
+    @api.depends("product_id.modular_type_ids")
+    def _compute_has_modular_types(self):
+        for line in self:
+            line.has_modular_types = bool(line.product_id.modular_type_ids)
+
+    def action_open_modular_values_wizard(self):
+        self.ensure_one()
+        return {
+            "name": "set modular type values",
+            "type": "ir.actions.act_window",
+            "res_model": "set.modular.values.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_sale_line_id": self.id,
+                "default_line_ids": [
+                    (
+                        0,
+                        0,
+                        {"modular_type_id": m_type.id, "value": 1.0},
+                    )
+                    for m_type in self.product_id.modular_type_ids
+                ],
+            },
+        }

--- a/modular_types/models/sale_order_line.py
+++ b/modular_types/models/sale_order_line.py
@@ -1,12 +1,16 @@
-from odoo import api, models, fields
+from odoo import api, fields, models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    modular_value_ids = fields.One2many(
+        "sale.order.line.modular.value", "sale_line_id", string="Modular Values"
+    )
+
     has_modular_types = fields.Boolean(compute="_compute_has_modular_types", store=True)
 
-    @api.depends("product_id.modular_type_ids")
+    @api.depends("product_id", "product_id.modular_type_ids")
     def _compute_has_modular_types(self):
         for line in self:
             line.has_modular_types = bool(line.product_id.modular_type_ids)
@@ -14,7 +18,7 @@ class SaleOrderLine(models.Model):
     def action_open_modular_values_wizard(self):
         self.ensure_one()
         return {
-            "name": "set modular type values",
+            "name": "Set modular type values",
             "type": "ir.actions.act_window",
             "res_model": "set.modular.values.wizard",
             "view_mode": "form",
@@ -25,7 +29,13 @@ class SaleOrderLine(models.Model):
                     (
                         0,
                         0,
-                        {"modular_type_id": m_type.id, "value": 1.0},
+                        {
+                            "modular_type_id": m_type.id,
+                            "value": self.modular_value_ids.filtered(
+                                lambda v: v.modular_type_id == m_type
+                            )[:1].value
+                            or 1.0,
+                        },
                     )
                     for m_type in self.product_id.modular_type_ids
                 ],

--- a/modular_types/models/sale_order_line_modular_values.py
+++ b/modular_types/models/sale_order_line_modular_values.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class SaleOrderLineModularValue(models.Model):
+    _name = "sale.order.line.modular.value"
+    _description = "Sale Order Line Modular Value"
+
+    sale_line_id = fields.Many2one(
+        "sale.order.line", string="Sale Line", ondelete="cascade"
+    )
+    modular_type_id = fields.Many2one(
+        "modular.type", string="Modular Type", required=True
+    )
+    value = fields.Float(string="Value", default=1.0)

--- a/modular_types/models/stock_move.py
+++ b/modular_types/models/stock_move.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    modular_type_id = fields.Many2one("modular.type", string="Module Type")

--- a/modular_types/security/ir.model.access.csv
+++ b/modular_types/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_modular_type,modular_type,model_modular_type,base.group_user,1,1,1,1

--- a/modular_types/security/ir.model.access.csv
+++ b/modular_types/security/ir.model.access.csv
@@ -1,2 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_modular_type,modular_type,model_modular_type,base.group_user,1,1,1,1
+access_sale_order_line_modular_value,sale_order_line_modular_value,model_sale_order_line_modular_value,base.group_user,1,1,1,1
+access_set_modular_values_wizard,set_modular_values_wizard,model_set_modular_values_wizard,base.group_user,1,1,1,1
+access_set_modular_values_line_wizard,set_modular_values_line_wizard,model_set_modular_values_line_wizard,base.group_user,1,1,1,1

--- a/modular_types/views/modular_type_views.xml
+++ b/modular_types/views/modular_type_views.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <record id="view_modular_type_tree" model="ir.ui.view">
+        <field name="name">modular.type.list</field>
+        <field name="model">modular.type</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="action_modular_type" model="ir.actions.act_window">
+        <field name="name">Modular Types</field>
+        <field name="res_model">modular.type</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_modular_type" name="Modular Types" parent="mrp.menu_mrp_configuration" action="action_modular_type" sequence="100"/>
+</odoo>

--- a/modular_types/views/mrp_bom_views.xml
+++ b/modular_types/views/mrp_bom_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="mrp_bom_form_view_inherit" model="ir.ui.view">
+        <field name="name">mrp.bom.form.inherit</field>
+        <field name="model">mrp.bom</field>
+        <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='bom_line_ids']/list/field[@name='product_id']" position="after">
+                <field name="modular_type_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/modular_types/views/mrp_production_views.xml
+++ b/modular_types/views/mrp_production_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="mrp_production_form_view_inherit" model="ir.ui.view">
+        <field name="name">mrp.production.form.inherit.modular</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='move_raw_ids']/list/field[@name='product_id']" position="after">
+                <field name="modular_type_id" optional="show"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/modular_types/views/product_views.xml
+++ b/modular_types/views/product_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="product_template_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.template.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='categ_id']" position="after">
+                <field name="modular_type_ids" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/modular_types/views/sale_order_views.xml
+++ b/modular_types/views/sale_order_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_template_id']" position="after">
+                <button name="action_open_modular_values_wizard" type="object" icon="fa-flask" title="Set modular values" invisible="not has_modular_types"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/modular_types/wizard/__init__.py
+++ b/modular_types/wizard/__init__.py
@@ -1,0 +1,2 @@
+from . import set_modular_values_wizard
+from . import set_modular_values_line_wizard

--- a/modular_types/wizard/set_modular_values_line_wizard.py
+++ b/modular_types/wizard/set_modular_values_line_wizard.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class SetModularValuesLineWizard(models.TransientModel):
+    _name = "set.modular.values.line.wizard"
+    _description = "Set Modular Type Value Line"
+
+    wizard_id = fields.Many2one("set.modular.values.wizard", string="Wizard")
+    modular_type_id = fields.Many2one("modular.type", string="Modular Type")
+    value = fields.Float(string="Value", default=1.0)

--- a/modular_types/wizard/set_modular_values_views.xml
+++ b/modular_types/wizard/set_modular_values_views.xml
@@ -1,0 +1,20 @@
+<odoo>
+    <record id="view_set_modular_values_wizard_form" model="ir.ui.view">
+        <field name="name">set.modular.values.wizard.form</field>
+        <field name="model">set.modular.values.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Set modular type values">
+                <field name="line_ids">
+                    <list editable="bottom" create="false" delete="false">
+                        <field name="modular_type_id"/>
+                        <field name="value"/>
+                    </list>
+                </field>
+                <footer>
+                    <button name="action_confirm" string="Add" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/modular_types/wizard/set_modular_values_wizard.py
+++ b/modular_types/wizard/set_modular_values_wizard.py
@@ -1,0 +1,26 @@
+from odoo import fields, models
+
+
+class SetModularValuesWizard(models.TransientModel):
+    _name = "set.modular.values.wizard"
+    _description = "Set Modular Type Values"
+
+    sale_line_id = fields.Many2one("sale.order.line", string="Sale Line")
+    line_ids = fields.One2many(
+        "set.modular.values.line.wizard", "wizard_id", string="Values"
+    )
+
+    def action_confirm(self):
+        self.ensure_one()
+        self.sale_line_id.modular_value_ids.unlink()
+        vals = []
+        for line in self.line_ids:
+            vals.append(
+                (
+                    0,
+                    0,
+                    {"modular_type_id": line.modular_type_id.id, "value": line.value},
+                )
+            )
+        self.sale_line_id.write({"modular_value_ids": vals})
+        return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Before:
      Manufacturing component quantities were fixed based on the Bill of Materials (BoM).
      For configurable/modular products, users had to:
      manually edit quantities in the Manufacturing Order.
      This caused extra work and increased the risk of incorrect production quantities.

After:
      Added modular configuration on the Sale Order line.
      Users can enter modular parameters (e.g., Sections, Length, Panels) through a wizard
      When a Manufacturing Order is created from the sale order, raw material quantities are automatically recalculated based on the entered modular values
Component quantities are dynamically computed during stock move generation

Impact:
Reduces manual intervention in Manufacturing Orders and prevents quantity errors by automatically adjusting raw materials according to the sales configuration.

Task: [5930995]