### PR TITLE
[ADD] sale_management_discount: recalculate global discount

### DIFF
--- a/sale_management_discount/__init__.py
+++ b/sale_management_discount/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_management_discount/__manifest__.py
+++ b/sale_management_discount/__manifest__.py
@@ -1,0 +1,8 @@
+{
+    'name': "sale_management_discount",
+    'author': "pkhu",
+    'license': "LGPL-3",
+    'depends': ['sale_management'],
+    'data': [],
+    'auto_install': True,
+}

--- a/sale_management_discount/models/__init__.py
+++ b/sale_management_discount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/sale_management_discount/models/sale_order_line.py
+++ b/sale_management_discount/models/sale_order_line.py
@@ -1,0 +1,40 @@
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = ['sale.order.line']
+
+    @api.ondelete(at_uninstall=True)
+    def _onDelete_sale_order_line(self):
+        self._update_global_discount('delete')
+
+    def _get_global_discount_id(self):
+        return int(self.extra_tax_data.get(
+            "computation_key").split(",")[1])
+
+    def _update_global_discount(self, operation):
+        for record in self:
+            discount_order_line = record.order_id.order_line.filtered(
+                lambda o: o._is_global_discount())
+            if discount_order_line and record.id not in discount_order_line.ids:
+                for val in discount_order_line:
+                    DOL_id = val._get_global_discount_id()
+                    domain = [('order_id', 'in', record.order_id),
+                              ('id', 'not in', discount_order_line.ids)]
+                    if operation == 'delete':
+                        domain.append(('id', 'not in', record.ids))
+                    total_price = dict(record.env['sale.order.line']._read_group(
+                        domain=domain, aggregates=['price_subtotal:sum'], groupby=['order_id'])).get(record.order_id, 0.0)
+                    if total_price == 0:
+                        val.unlink()
+                        continue
+                    discount_per = record.env['sale.order.discount'].search(
+                        domain=[('sale_order_id', 'in', record.order_id), ('id', '=', DOL_id)]).discount_percentage
+                    new_price = -(total_price * discount_per)
+                    val.update({
+                        'price_unit': new_price})
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._update_global_discount('update')
+        return res


### PR DESCRIPTION
Task Description -
1. Add multiple products to a Sale Order.
2. Apply a single global discount.
3. When order lines are updated or removed, the discount should automatically recalculate based on the current order lines.
4. If no order lines remain, the global discount should be removed/reset.
5. Handle single global discount only.

- Created new module `global_discount_update` with required base files
- Inherited `sale.order.line` model to handle order line modifications
- Implemented `ondelete` logic to update/remove discount when lines are deleted
- Overridden `write` method to recalculate discount when order lines are updated
- Ensured discount is cleared when no order lines exist

Task - 5928684