### PR TITLE
POS: second UoM

### DIFF
--- a/second_uom/__init__.py
+++ b/second_uom/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/second_uom/__manifest__.py
+++ b/second_uom/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': 'second_uom',
+    'description': "Add Button for second uom",
+    'author': "meet kavathiya",
+    'website': 'https://www.odoo.com/',
+    'category': '',
+    'version': '0.1',
+    'application': True,
+    'installable': True,
+    'depends': ['point_of_sale'],
+    'data': ['views/product_views.xml'],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'second_uom/static/src/app/**/*.js',
+            'second_uom/static/src/app/**/*.xml',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/second_uom/models/__init__.py
+++ b/second_uom/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_template
+from . import product_product

--- a/second_uom/models/product_product.py
+++ b/second_uom/models/product_product.py
@@ -1,0 +1,11 @@
+from odoo import api, models
+
+
+class InheritedProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.model
+    def _load_pos_data_fields(self, config):
+        params = super()._load_pos_data_fields(config)
+        params.append('pos_second_uom_id')
+        return params

--- a/second_uom/models/product_template.py
+++ b/second_uom/models/product_template.py
@@ -1,0 +1,30 @@
+from odoo import api, fields, models
+
+
+class InheritedProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    pos_second_uom_id = fields.Many2one(
+        'uom.uom',
+        string="POS Second UoM",
+        help="Secondary unit of measure for quick quantity conversion in the POS popup.",
+    )
+    uom_root_id = fields.Many2one(
+        'uom.uom', string="UoM Root", compute='_compute_uom_root_id'
+    )
+
+    @api.depends('uom_id')
+    def _compute_uom_root_id(self):
+        for record in self:
+            if record.uom_id and record.uom_id.parent_path:
+                root_id = int(record.uom_id.parent_path.split('/')[0])
+                record.uom_root_id = root_id
+            else:
+                record.uom_root_id = False
+
+    @api.onchange('uom_id')
+    def _onchange_uom_id_clear_second(self):
+        if self.pos_second_uom_id and not self.uom_id._has_common_reference(
+            self.pos_second_uom_id
+        ):
+            self.pos_second_uom_id = False

--- a/second_uom/static/src/app/components/uom_popup/second_uom_popup.js
+++ b/second_uom/static/src/app/components/uom_popup/second_uom_popup.js
@@ -1,0 +1,14 @@
+import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
+
+export class SecondUomPopup extends NumberPopup {
+    static template = "second_uom.SecondUomPopup";
+    static props = {
+        ...NumberPopup.props,
+        uomName: { type: String },
+    };
+
+    confirm() {
+    this.props.getPayload(this.state.buffer);
+    this.props.close();
+    }
+}

--- a/second_uom/static/src/app/components/uom_popup/second_uom_popup.xml
+++ b/second_uom/static/src/app/components/uom_popup/second_uom_popup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="second_uom.SecondUomPopup" t-inherit="point_of_sale.NumberPopup" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('input-symbol')]" position="before">
+            <div class="text-center mb-2 fw-bold text-primary">
+                Unit: <t t-esc="props.uomName"/>
+            </div>
+        </xpath>
+        <xpath expr="//div[hasclass('popup-input')]" position="inside">
+            <span class="ms-1 text-muted" style="font-size: 0.8em;">
+                (<t t-esc="props.uomName"/>)
+            </span>
+        </xpath>
+    </t>
+</templates>

--- a/second_uom/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/second_uom/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,0 +1,32 @@
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+import { SecondUomPopup } from "@second_uom/app/components/uom_popup/second_uom_popup";
+import { patch } from "@web/core/utils/patch";
+import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
+
+patch(ControlButtons.prototype, {
+    displaySecondUomBtn() {
+        const selectedLine = this.currentOrder?.getSelectedOrderline();
+        return selectedLine && selectedLine.product_id.pos_second_uom_id;
+    },
+
+    async clickSecondUom() {
+        const selectedLine = this.currentOrder.getSelectedOrderline();
+        if (!selectedLine) return;
+
+        const secondUom = selectedLine.product_id.pos_second_uom_id;
+        const mainUom = selectedLine.product_id.uom_id;
+
+        const result = await makeAwaitable(this.dialog, SecondUomPopup, {
+            title: "Secondary Unit Entry",
+            uomName: secondUom.name,
+            startingValue: 0,
+        });
+
+        if (result !== null && result !== undefined) {
+            const enteredQty = parseFloat(result);
+            if (isNaN(enteredQty)) return;
+            const newMainQty = (enteredQty * secondUom.factor) / mainUom.factor;
+            selectedLine.setQuantity(newMainQty);
+        }
+    }
+});

--- a/second_uom/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/second_uom/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('more-btn')]" position="before">
+            <button t-if="displaySecondUomBtn()" 
+                    class="btn btn-secondary btn-lg flex-shrink-0" 
+                    t-on-click="clickSecondUom">
+                <t t-esc="currentOrder.getSelectedOrderline().product_id.pos_second_uom_id.name"/>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/second_uom/views/product_views.xml
+++ b/second_uom/views/product_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_view_inherit_pos_second_uom" model="ir.ui.view">
+        <field name="name">product.template.form.inherit.second.uom</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='uom_id']" position="after">
+                <field name="pos_second_uom_id" domain="[('id', 'child_of', uom_root_id)]" options="{'no_create': True, 'no_open': True}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR introduces a new feature allowing POS users to enter product quantities using a secondary Unit of Measure (UoM). This is particularly useful for products sold in bulk (e.g., a "Pack of 6") where the cashier needs to quickly input a count of individual items (e.g., "12 units") and have the POS automatically convert it to the main unit ("2 Packs").