### PR TITLE
[ADD] po_global_discount: add module to apply global discounts on purchase order

### DIFF
--- a/po_global_discount/__init__.py
+++ b/po_global_discount/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/po_global_discount/__manifest__.py
+++ b/po_global_discount/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Purchase global discount',
+    'version': '0.1.0',
+    'description': 'Add a global discount to the all purchase order lines',
+    'depends': [
+        'purchase'
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/purchase_order_view.xml',
+        'wizard/purchase_global_discount_view.xml',
+    ],
+    'installable': True,
+    'application': True,
+    'author': 'Ishwar',
+    'license': 'LGPL-3'
+}

--- a/po_global_discount/models/__init__.py
+++ b/po_global_discount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/po_global_discount/models/purchase_order.py
+++ b/po_global_discount/models/purchase_order.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    def action_purchase_global_discount(self):
+        return {
+            'name': 'Global Discount',
+            'view_mode': 'form',
+            'res_model': 'purchase.global.discount',
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'context': {'default_order_id': self.id},
+        }

--- a/po_global_discount/security/ir.model.access.csv
+++ b/po_global_discount/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_global_discount,purchase.global.discount,model_purchase_global_discount,base.group_user,1,1,1,1

--- a/po_global_discount/views/purchase_order_view.xml
+++ b/po_global_discount/views/purchase_order_view.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.view.form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//field[@name='order_line']" position="after">
+                <div class="d-flex justify-content-end">
+                    <button class="btn btn-secondary" name="action_purchase_global_discount"
+                        type="object" string="Discount">
+                    </button>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/po_global_discount/wizard/__init__.py
+++ b/po_global_discount/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_global_discount

--- a/po_global_discount/wizard/purchase_global_discount.py
+++ b/po_global_discount/wizard/purchase_global_discount.py
@@ -1,0 +1,36 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class PurchaseGlobalDiscount(models.TransientModel):
+    _name = 'purchase.global.discount'
+
+    order_id = fields.Many2one('purchase.order', required=True)
+    discount_value = fields.Float()
+    discount_type = fields.Selection(
+        [
+            ("percentage", "%"),
+            ("amount", "$"),
+        ],
+        default="percentage"
+    )
+    discount_percentage = fields.Float(compute="_compute_discount_percentage", string="Preview Percentage")
+
+    @api.depends('discount_value', 'discount_type', 'order_id')
+    def _compute_discount_percentage(self):
+        for wizard in self:
+            wizard.discount_percentage = 0.0
+            if wizard.discount_type == 'percentage':
+                wizard.discount_percentage = wizard.discount_value
+            elif wizard.discount_type == 'amount' and wizard.order_id:
+                total_amount = sum(line.price_unit * line.product_qty for line in wizard.order_id.order_line)
+                if total_amount > 0:
+                    wizard.discount_percentage = (wizard.discount_value / total_amount) * 100
+
+    def action_apply_discount(self):
+        self.ensure_one()
+        if self.discount_percentage > 100:
+            raise UserError("Discount Must be less then 100% ")
+        for line in self.order_id.order_line:
+            line.discount = self.discount_percentage
+        return {'type': 'ir.actions.act_window_close'}

--- a/po_global_discount/wizard/purchase_global_discount_view.xml
+++ b/po_global_discount/wizard/purchase_global_discount_view.xml
@@ -1,0 +1,36 @@
+<odoo>
+    <record id="purchase_global_discount_view_form" model="ir.ui.view">
+        <field name="name">purchase.global.discount.form</field>
+        <field name="model">purchase.global.discount</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <label for="discount_value" string="Discount" />
+
+                            <div class="o_row">
+                                <field name="discount_value" class="oe_inline" />
+                                <field name="discount_type" widget="radio"
+                                    options="{'horizontal': true}" />
+                            </div>
+
+                            <field name="discount_percentage"
+                                class="text-muted"
+                                invisible="discount_type != 'amount'"
+                                readonly="1" />
+                        </group>
+                    </group>
+                    <div class="alert alert-info" role="alert" invisible="discount_type != 'amount'">
+                        Rounding error may occur when applying a fixed amount discount.
+                    </div>
+                </sheet>
+                <footer>
+                    <button string="Apply" name="action_apply_discount" type="object"
+                        class="btn-primary" />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Apply Global Discount On Purchase Order
Key Features:
- Global Discount Wizard: Allows users to input a discount as either a fixed amount or a percentage.
- Dual Calculation Logic:
  - Percentage: Directly applies the value to the 'discount' field on lines.
  - Fixed Amount: Calculates the equivalent percentage based on the total order value and distributes it across lines.
- Validation: Displays a warning about potential rounding errors when using fixed amount mode.

Technical Details:
- Model: Created `purchase.global.discount (TransientModel).
- Views: Extended `purchase.order` form and created wizard form view.