### PR TITLE
[ADD] purchase_order_discount: Add global discount wizard for purchase orders - juson

### DIFF
--- a/purchase_order_discount/__init__.py
+++ b/purchase_order_discount/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/purchase_order_discount/__manifest__.py
+++ b/purchase_order_discount/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "Purchase Order Discount",
+    "version": "1.0",
+    "category": "Purchase",
+    "description": "Purchase order global discount wizard.",
+    "author": "juson-odoo",
+    "depends": ["base", "purchase"],
+    "installable": True,
+    "license": "LGPL-3",
+    "data": [
+        "security/ir.model.access.csv",
+        "views/purchase_order_views.xml",
+        "wizard/purchase_order_discount.xml",
+    ],
+}

--- a/purchase_order_discount/models/__init__.py
+++ b/purchase_order_discount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/purchase_order_discount/models/purchase_order.py
+++ b/purchase_order_discount/models/purchase_order.py
@@ -1,0 +1,18 @@
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def action_open_discount_wizard(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Apply Discount",
+            "res_model": "purchase.order.discount",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_purchase_order_id": self.id,
+            },
+        }

--- a/purchase_order_discount/security/ir.model.access.csv
+++ b/purchase_order_discount/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_order_discount,access_purchase_order_discount,model_purchase_order_discount,base.group_user,1,1,1,1

--- a/purchase_order_discount/views/purchase_order_views.xml
+++ b/purchase_order_discount/views/purchase_order_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_purchase_order_form_discount_inherit" model="ir.ui.view">
+        <field name="name">purchase.order.form.discount.inherit</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='products']//field[@name='order_line']" position="after">
+                <div class="my-2 d-flex">
+                    <button name="action_open_discount_wizard"
+                            type="object"
+                            string="Apply Discount"
+                            class="btn btn-primary ms-auto"
+                            icon="fa-percent"/>
+                </div>
+            </xpath>
+            
+            <xpath expr="//page[@name='products']//field[@name='order_line']/list/field[@name='tax_ids']" position="after">
+                <field name="discount"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/purchase_order_discount/wizard/__init__.py
+++ b/purchase_order_discount/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order_discount

--- a/purchase_order_discount/wizard/purchase_order_discount.py
+++ b/purchase_order_discount/wizard/purchase_order_discount.py
@@ -1,0 +1,55 @@
+from odoo import api, fields, models
+
+
+class PurchaseOrderDiscount(models.TransientModel):
+    _name = "purchase.order.discount"
+    _description = "Purchase Discount Wizard"
+
+    purchase_order_id = fields.Many2one(
+        "purchase.order",
+        default=lambda self: self.env.context.get("default_purchase_order_id"),
+        required=True,
+    )
+    company_id = fields.Many2one(related="purchase_order_id.company_id")
+    currency_id = fields.Many2one(related="purchase_order_id.currency_id")
+    discount_amount = fields.Monetary(string="Amount")
+    discount_percentage = fields.Float(string="Percentage")
+    discount_type = fields.Selection(
+        string="Discount Type",
+        selection=[
+            ("percentage", "Percentage"),
+            ("amount", "Fixed Amount"),
+        ],
+        default="percentage",
+        required=True,
+    )
+    discount_amount_percentage = fields.Float(
+        string="Amount %", compute="_compute_discount_amount_percentage", store=True
+    )
+
+    @api.depends("discount_amount")
+    def _compute_discount_amount_percentage(self):
+        for record in self:
+            order = record.purchase_order_id
+            total = sum(line.price_unit * line.product_qty for line in order.order_line)
+            if total:
+                record.discount_amount_percentage = record.discount_amount / total
+            else:
+                record.discount_amount_percentage = 0.0
+
+    def action_apply_discount(self):
+        self.ensure_one()
+        order = self.purchase_order_id
+
+        if self.discount_type == "percentage":
+            for line in order.order_line:
+                line.discount = self.discount_percentage * 100
+        elif self.discount_type == "amount":
+            self._apply_fixed_amount_discount()
+
+    def _apply_fixed_amount_discount(self):
+        order = self.purchase_order_id
+        for line in order.order_line:
+            line.discount = 0.0
+            if self.discount_amount_percentage:
+                line.discount = self.discount_amount_percentage * 100

--- a/purchase_order_discount/wizard/purchase_order_discount.xml
+++ b/purchase_order_discount/wizard/purchase_order_discount.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="purchase_order_discount_wizard_form" model="ir.ui.view">
+        <field name="name">purchase.order.discount.form</field>
+        <field name="model">purchase.order.discount</field>
+        <field name="arch" type="xml">
+            <form string="Apply Discount">
+                <sheet>
+                    <field name="purchase_order_id" invisible="1"/>
+                    <field name="company_id" invisible="1"/>
+                    <field name="currency_id" invisible="1"/>
+                    <group>
+                        <field name="discount_type"/>
+                        <field name="discount_percentage"
+                               widget="percentage"
+                               invisible="discount_type != 'percentage'"/>
+                        <field name="discount_amount"
+                               invisible="discount_type != 'amount'"/>
+                        <field name="discount_amount_percentage"
+                               widget="percentage"
+                               decoration-muted="1"
+                               invisible="discount_type != 'amount'"/>
+                    </group>
+                    <div class="alert alert-info mt-3">
+                        <div>
+                            Discount will be applied to all lines.
+                        </div>
+                        <div invisible="discount_type != 'amount'">
+                            Rounding error may occur when applying a discount amount.
+                        </div>
+                    </div>
+                </sheet>
+                <footer>
+                    <button name="action_apply_discount"
+                            type="object"
+                            string="Apply"
+                            class="btn btn-primary"/>
+                    <button string="Cancel"
+                            special="cancel"
+                            class="btn btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Reason For PR (Why):
- Streamline bulk discount application on purchase orders
- Reduce manual discount entry for each line item
- Support flexible discount strategies (percentage or fixed amount)
- Improve purchase order management efficiency

What Changed In PR:
- Add purchase order discount wizard to apply percentage or fixed amount discounts
- Add "Apply Discount" button in purchase order form view
- Add discount field to purchase order line items
- Implement discount calculation with percentage and fixed amount modes
- Calculate discount percentage automatically for fixed amount discounts

Task-6074535