### PR TITLE
[ADD] mrp_bom_custom: merge availability into status, remove availability column, and improve BOM status UI

### DIFF
--- a/mrp_bom_custom/__init__.py
+++ b/mrp_bom_custom/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mrp_bom_custom/__manifest__.py
+++ b/mrp_bom_custom/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "MRP BOM Customization",
+    "author": "Dharmil Goyani",
+    "license": "LGPL-3",
+    "version": "1.0",
+    "summary": "Customize BOM report logic",
+    "depends": ["mrp"],
+    "assets": {
+        "web.assets_backend": [
+            "mrp_bom_custom/static/src/**/*",
+        ],
+    },
+    "installable": True,
+    "application": False,
+}

--- a/mrp_bom_custom/models/__init__.py
+++ b/mrp_bom_custom/models/__init__.py
@@ -1,0 +1,1 @@
+from . import report_bom_structure

--- a/mrp_bom_custom/models/report_bom_structure.py
+++ b/mrp_bom_custom/models/report_bom_structure.py
@@ -1,0 +1,17 @@
+from odoo import _, models
+
+
+class ReportMrpReportBomStructure(models.AbstractModel):
+    _inherit = "report.mrp.report_bom_structure"
+
+    def _get_bom_data(self, *args, **kwargs):
+        result = super()._get_bom_data(*args, **kwargs)
+
+        if result.get("level") == 0:
+            qty = int(result.get("producible_qty") or 0)
+            if qty > 0:
+                result["status"] = _("%(qty)s Ready To Produce", qty=qty)
+            else:
+                result["status"] = _("No Ready To Produce")
+
+        return result

--- a/mrp_bom_custom/static/src/bom_overview_line.js
+++ b/mrp_bom_custom/static/src/bom_overview_line.js
@@ -1,0 +1,17 @@
+import { patch } from "@web/core/utils/patch";
+import { BomOverviewLine } from "@mrp/components/bom_overview_line/mrp_bom_overview_line";
+
+patch(BomOverviewLine.prototype, {
+    get statusBackgroundColor() {
+        console.log(this.data)
+        if (this.data.level !== 0 && this.data.availability_state == 'estimated') {
+            return "text-bg-warning";
+        }
+        switch (this.data.availability_state) {
+            case "available": return "text-bg-success";
+            case "expected": return "text-bg-warning";
+            case "unavailable": return "text-bg-danger";
+            default: return "text-bg-dark";
+        }
+    }
+});

--- a/mrp_bom_custom/static/src/bom_overview_line.xml
+++ b/mrp_bom_custom/static/src/bom_overview_line.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-inherit="mrp.BomOverviewLine" t-inherit-mode="extension">
+        <xpath expr="//td[t[@t-if=&quot;data.hasOwnProperty('availability_state')&quot;]]"
+            position="replace"/>
+        <xpath expr="//td//div[hasclass('o_field_badge')]" position="replace">
+            <div class="o_field_badge">
+                <t t-if="data.type == 'operation'">
+                    <span href="#" role="button" t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundColor}}" 
+                   t-esc="data.availability_display"/>
+                </t>
+                <t t-elif="data.level != 0">
+                    <span href="#" role="button" t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundColor}}" 
+                    t-on-click.prevent="goToForecast" t-esc="data.availability_display"/>
+                </t>
+                <t t-else="">
+                    <t t-if="data.status == 'No Ready To Produce'">
+                        <span href="#" role="button" t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundColor}}" 
+                        t-on-click.prevent="goToForecast" t-esc="data.availability_display"/>
+                    </t>
+                    <t t-else="">
+                        <span href="#" role="button" t-attf-class="badge rounded-pill o_mrp_overview_badge text-bg-success" 
+                        t-on-click.prevent="goToForecast" t-esc="data.status"/>
+                    </t>
+                </t>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/mrp_bom_custom/static/src/mrp_bom_overview_table.xml
+++ b/mrp_bom_custom/static/src/mrp_bom_overview_table.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="mrp.change_forecast_view" t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension">
+        <xpath expr="//a[@t-on-click.prevent='goToProduct']/ancestor::div[2]" position="replace"/>
+        <xpath expr="//th[text()='Availability']" position="replace"/>
+    </t>
+</templates>


### PR DESCRIPTION
-Improve BoM Overview by integrating availability into the status column and removing the availability column.

-Enhance status badges with better colors, click behavior, and forecast navigation (excluding operations).
