### PR TITLE
[ADD] mrp_bom: improve BoM overview forecast display

### DIFF
--- a/mrp_bom/__init__.py
+++ b/mrp_bom/__init__.py
@@ -1,0 +1,1 @@
+from . import report

--- a/mrp_bom/__manifest__.py
+++ b/mrp_bom/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Mrp Bom",
+    "author": "Ayush Chavda",
+    "depends": ["base", "mrp"],
+    "data": [],
+    "assets": {
+        "web.assets_backend": ["mrp_bom/static/src/**/*"],
+    },
+    "license": "LGPL-3",
+    "installable": True,
+    "application": True,
+}

--- a/mrp_bom/report/__init__.py
+++ b/mrp_bom/report/__init__.py
@@ -1,0 +1,1 @@
+from . import mrp_report_bom_structure

--- a/mrp_bom/report/mrp_report_bom_structure.py
+++ b/mrp_bom/report/mrp_report_bom_structure.py
@@ -1,0 +1,26 @@
+from odoo import _, models
+import math
+
+
+class MrpBom(models.AbstractModel):
+    _inherit = "report.mrp.report_bom_structure"
+
+    def _get_bom_data(self, *args, **kwargs):
+        result = super()._get_bom_data(*args, **kwargs)
+        self._modify_bom_result(result)
+        return result
+
+    def _modify_bom_result(self, data):
+        if data.get("producible_qty") is not None:
+            qty = math.floor(data["producible_qty"])
+            data["producible_qty"] = qty
+
+            if data.get("level") == 0 and qty > 0:
+                data["status"] = _("%(qty)s Ready To Produce", qty=qty)
+
+        for component in data.get("components", []):
+            if component.get("is_storable"):
+                component["status"] = component.get("availability_display")
+
+            if component.get("components"):
+                self._modify_bom_result(component)

--- a/mrp_bom/static/src/components/bom_overview_line/bom_heading_patch.xml
+++ b/mrp_bom/static/src/components/bom_overview_line/bom_heading_patch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension" >
+        <xpath expr="//th[@title='Reception time estimation.']" position="replace"/>
+    </t>
+
+</templates>

--- a/mrp_bom/static/src/components/bom_overview_line/bom_overview_line.js
+++ b/mrp_bom/static/src/components/bom_overview_line/bom_overview_line.js
@@ -1,0 +1,27 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { BomOverviewLine } from "@mrp/components/bom_overview_line/mrp_bom_overview_line";
+
+patch(BomOverviewLine.prototype, {
+  get statusBackgroundClass() {
+    if (this.data.level === 0 && this.data.producible_qty > 0) {
+      return "text-bg-success";
+    }
+
+    if (this.data.level === 0 && this.data.producible_qty <= 0) {
+      return "text-bg-dark";
+    }
+
+    switch (this.data.availability_state) {
+      case "available":
+        return "text-bg-success";
+      case "expected":
+        return "text-bg-warning";
+      case "estimated":
+        return "text-bg-secondary";
+      case "unavailable":
+        return "text-bg-danger";
+    }
+  },
+});

--- a/mrp_bom/static/src/components/bom_overview_line/bom_overview_line.xml
+++ b/mrp_bom/static/src/components/bom_overview_line/bom_overview_line.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-inherit="mrp.BomOverviewLine" t-inherit-mode="extension">
+        <xpath expr="//td[@t-if='forecastMode' and .//span[@t-out='data.status']]" position="replace">
+
+            <td t-if="forecastMode" class="text-center">
+                <t t-set="display_value" t-value="
+                        data.level === 0
+                        ? (data.producible_qty > 0
+                            ? data.status
+                            : data.availability_display)
+                        : (data.status || data.availability_display)
+                   "/>
+
+                <div t-if="display_value" class="o_field_badge">
+                    <t t-if="data.type !== 'operation'">
+                        <a href="#" t-on-click.prevent="goToForecast">
+                            <span t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundClass}}" t-out="display_value"/>
+                        </a>
+                    </t>
+                    <t t-else="">
+                        <span t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundClass}}" t-out="display_value"/>
+                    </t>
+                </div>
+
+            </td>
+        </xpath>
+
+        <xpath expr="//td[@t-if='forecastMode' and .//span[@t-esc='data.availability_display']]" position="replace">
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
- Show "Ready to Produce" only when quantity is available
- Display all availability information inside the status column
- Remove separate availability column for a cleaner view
- Make status badges clickable to open forecast report
- Disable click action for operations