### PR TITLE
[ADD] pricelist: add book price in account invoicing and sales quotation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "xml.symbols.enabled": false,
+    "python.languageServer": "None"
+}

--- a/estate_pricelist_imp/__init__.py
+++ b/estate_pricelist_imp/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate_pricelist_imp/__manifest__.py
+++ b/estate_pricelist_imp/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "Sales Pricelist",
+    "version": "19.0.0",
+    "category": "Tutorials",
+    "depends": ["sale", "account"],
+    "author": "hemeh",
+    "application": True,
+    "summary": "Estate Account",
+    "description": """
+    Estate Pricelist Sales.
+    """,
+    "data": [
+        "views/estate_pricelist.xml",
+        "views/estate_account_pricelist.xml",
+    ],
+    "website": "https://odoo.com",
+    "license": "LGPL-3",
+    "installable": True,
+}

--- a/estate_pricelist_imp/models/__init__.py
+++ b/estate_pricelist_imp/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_line, sale_order_line

--- a/estate_pricelist_imp/models/account_move_line.py
+++ b/estate_pricelist_imp/models/account_move_line.py
@@ -1,0 +1,15 @@
+from odoo import api, fields, models
+
+
+class EstateAccountPrice(models.Model):
+    _inherit = 'account.move.line'
+    _description = "Invoicing Book Price"
+    book_price = fields.Monetary(compute="_compute_book_price", readonly=True)
+
+    @api.depends('sale_line_ids.book_price')
+    def _compute_book_price(self):
+        for rec in self:
+            if rec.sale_line_ids:
+                rec.book_price = rec.sale_line_ids[0].book_price
+            else:
+                rec.book_price = 0.0

--- a/estate_pricelist_imp/models/sale_order_line.py
+++ b/estate_pricelist_imp/models/sale_order_line.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    book_price = fields.Monetary(compute="_compute_book_price", readonly=True)
+
+    @api.depends('product_uom_qty', 'product_id', 'order_id.pricelist_id')
+    def _compute_book_price(self):
+        for line in self:
+            if not line.product_id:
+                line.book_price = 0.0
+                continue
+
+            pricelist = line.order_id.pricelist_id
+
+            if pricelist:
+                line.book_price = pricelist._get_product_price(
+                    product=line.product_id,
+                    quantity=line.product_uom_qty,
+                )
+            else:
+                line.book_price = line.product_id.list_price

--- a/estate_pricelist_imp/views/estate_account_pricelist.xml
+++ b/estate_pricelist_imp/views/estate_account_pricelist.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.line.form.inherit.book.price</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//list//field[@name='quantity']" position="before">
+                <field name="book_price" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/estate_pricelist_imp/views/estate_pricelist.xml
+++ b/estate_pricelist_imp/views/estate_pricelist.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="sale_order_line_view_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.book.price</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook//page//list//field[@name='product_uom_qty']" position="before">
+                <field name="book_price" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The book price is required to provide better pricing transparency during sales and invoicing processes.

By introducing this field, users can compare the original book price with the applied sale price directly in quotations and invoices, helping them in decision-making and ensuring pricing consistency.