### PR TITLE
[IMP] mrp_bom_overview: clean forecast view with consolidated status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+/vanilla_js
+/health
+/library
+/hr_loan

--- a/mrp_bom_overview_forecast/__init__.py
+++ b/mrp_bom_overview_forecast/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mrp_bom_overview_forecast/__manifest__.py
+++ b/mrp_bom_overview_forecast/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "bom_overview",
+    "version": "1.0",
+    "depends": ["mrp", "purchase"],
+    "author": "times",
+    "category": "Tutorials",
+    "license": "LGPL-3",
+    'installable': True,
+    "assets": {
+        "web.assets_backend": [
+            "mrp_bom_overview_forecast/static/src/**/*",
+        ],
+    },
+}

--- a/mrp_bom_overview_forecast/__manifest__.py
+++ b/mrp_bom_overview_forecast/__manifest__.py
@@ -1,11 +1,12 @@
 {
-    "name": "bom_overview",
+    "name": "mrp_bom_overview_forecast",
     "version": "1.0",
     "depends": ["mrp", "purchase"],
     "author": "times",
     "category": "Tutorials",
     "license": "LGPL-3",
     'installable': True,
+    'auto_install': True,
     "assets": {
         "web.assets_backend": [
             "mrp_bom_overview_forecast/static/src/**/*",

--- a/mrp_bom_overview_forecast/models/__init__.py
+++ b/mrp_bom_overview_forecast/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mrp_report_bom_structure

--- a/mrp_bom_overview_forecast/models/mrp_report_bom_structure.py
+++ b/mrp_bom_overview_forecast/models/mrp_report_bom_structure.py
@@ -1,0 +1,15 @@
+from odoo import _, models
+
+
+class ReportMrpReport_Bom_Structure(models.AbstractModel):
+    _inherit = 'report.mrp.report_bom_structure'
+
+    def _get_bom_data(self, *args, **kwargs):
+        result = super()._get_bom_data(*args, **kwargs)
+        if result.get('level') == 0:
+            qty = int(result.get('producible_qty') or 0)
+            if qty > 0:
+                result["status"] = _("%(qty)s Ready To Produce", qty=qty)
+            else:
+                result["status"] = _("No Ready To Produce")
+        return result

--- a/mrp_bom_overview_forecast/static/src/bom_overview.xml
+++ b/mrp_bom_overview_forecast/static/src/bom_overview.xml
@@ -9,27 +9,27 @@
     </t>
 
     <t t-name="mrp.BomOverviewLine" t-inherit="mrp.BomOverviewLine" t-inherit-mode="extension">
-        <xpath expr="//td[@class='text-center' and .//div[hasclass('o_field_badge')]]" position="replace">
+        <xpath expr="//td[.//div[@t-if=&quot;data.hasOwnProperty('status')&quot;]]" position="replace">
             <td t-if="forecastMode" class="text-center">
                 <div t-if="data.is_storable" class="o_field_badge" role="button" t-on-click.prevent="goToForecast">
                     <span t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundClass}}" t-out="statusData"/>
                 </div>
             </td>
         </xpath>
-        <xpath expr="//td[@class='text-center' and .//t[@t-if=&quot;data.hasOwnProperty('availability_state')&quot;]]" position="replace"/>
+        <xpath expr="//td[.//t[@t-if=&quot;data.hasOwnProperty('availability_state')&quot;]]" position="replace"/>
     </t>
 
     <t t-name="mrp.BomOverviewTable.headers" t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension">
-        <xpath expr="//th[@title='Reception time estimation.']" position="replace"/>
-        <xpath expr="//tfoot//tr[1]/td[@t-if='forecastMode'][3]" position="replace"/>
+        <xpath expr="//th[@name='th_mrp_bom_h']/following-sibling::th[@t-if='forecastMode'][3]" position="replace"/>
+        <xpath expr="//td[@name='td_mrp_bom_f']/following-sibling::td[@t-if='forecastMode'][3]" position="replace"/>
     </t>
 
     <t t-name="mrp.BomOverviewTable.byproducts_footer" t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension">
-        <xpath expr="//tfoot//t//tr/td[@t-if='forecastMode'][3]" position="replace"/>
+        <xpath expr="//td[@name='td_mrp_bom_b']/following-sibling::td[@t-if='forecastMode'][3]" position="replace"/>
     </t>
 
     <t t-name="mrp.BomOverviewSpecialLine" t-inherit="mrp.BomOverviewSpecialLine" t-inherit-mode="extension">
-        <xpath expr="//td[@t-if='forecastMode'][3]" position="replace"/>
+        <xpath expr="//td[@name='bom_cost']/preceding-sibling::td[@t-if='forecastMode'][last()]" position="replace"/>
     </t>
 
     <t t-name="mrp.BomOverviewComponentsBlock" t-inherit="mrp.BomOverviewComponentsBlock" t-inherit-mode="extension">

--- a/mrp_bom_overview_forecast/static/src/bom_overview.xml
+++ b/mrp_bom_overview_forecast/static/src/bom_overview.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mrp.BomOverviewTable" t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('d-flex','mb-5')]" position="replace"/>
+        <xpath expr="//div[hasclass('o_mrp_bom_report_page')]" position="attributes">
+            <attribute name="class">o_mrp_bom_report_page py-3 py-lg-2 px-0 overflow-auto border-bottom bg-view</attribute>
+        </xpath>
+    </t>
+
+    <t t-name="mrp.BomOverviewLine" t-inherit="mrp.BomOverviewLine" t-inherit-mode="extension">
+        <xpath expr="//td[@class='text-center' and .//div[hasclass('o_field_badge')]]" position="replace">
+            <td t-if="forecastMode" class="text-center">
+                <div t-if="data.is_storable" class="o_field_badge" role="button" t-on-click.prevent="goToForecast">
+                    <span t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundClass}}" t-out="statusData"/>
+                </div>
+            </td>
+        </xpath>
+        <xpath expr="//td[@class='text-center' and .//t[@t-if=&quot;data.hasOwnProperty('availability_state')&quot;]]" position="replace"/>
+    </t>
+
+    <t t-name="mrp.BomOverviewTable.headers" t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension">
+        <xpath expr="//th[@title='Reception time estimation.']" position="replace"/>
+        <xpath expr="//tfoot//tr[1]/td[@t-if='forecastMode'][3]" position="replace"/>
+    </t>
+
+    <t t-name="mrp.BomOverviewTable.byproducts_footer" t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension">
+        <xpath expr="//tfoot//t//tr/td[@t-if='forecastMode'][3]" position="replace"/>
+    </t>
+
+    <t t-name="mrp.BomOverviewSpecialLine" t-inherit="mrp.BomOverviewSpecialLine" t-inherit-mode="extension">
+        <xpath expr="//td[@t-if='forecastMode'][3]" position="replace"/>
+    </t>
+
+    <t t-name="mrp.BomOverviewComponentsBlock" t-inherit="mrp.BomOverviewComponentsBlock" t-inherit-mode="extension">
+        <xpath expr="//BomOverviewLine" position="attributes">
+            <attribute name="currentWarehouseId">props.currentWarehouseId</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/mrp_bom_overview_forecast/static/src/bom_overview_line.js
+++ b/mrp_bom_overview_forecast/static/src/bom_overview_line.js
@@ -1,0 +1,35 @@
+import { patch } from "@web/core/utils/patch";
+import { BomOverviewLine } from "@mrp/components/bom_overview_line/mrp_bom_overview_line";
+
+patch(BomOverviewLine.prototype, {
+
+    get statusData() {
+        if (this.data.hasOwnProperty('components_available') && this.data.status && this.data.status !== "No Ready To Produce") {
+            return this.data.status;
+        }
+        if (this.data.status === "No Ready To Produce" && this.data.availability_display) {
+            return this.data.availability_display;
+        }
+        if (this.data.availability_display) {
+            return this.data.availability_display;
+        }
+
+        return "Not Available";
+    },
+
+    get statusBackgroundClass() {
+        if (!this.statusData) {
+            return "text-bg-danger";
+        }
+        if (this.statusData === "Available" || this.statusData.includes("Ready To Produce")) {
+            return "text-bg-success";
+        }
+        if (this.statusData.includes("Expected")) {
+            return "text-bg-warning";
+        }
+        if (this.statusData.includes("Estimated")) {
+            return "text-bg-dark";
+        }
+        return "text-bg-danger";
+    },
+});

--- a/mrp_bom_overview_forecast/static/src/bom_overview_line.js
+++ b/mrp_bom_overview_forecast/static/src/bom_overview_line.js
@@ -4,11 +4,14 @@ import { BomOverviewLine } from "@mrp/components/bom_overview_line/mrp_bom_overv
 patch(BomOverviewLine.prototype, {
 
     get statusData() {
-        if (this.data.hasOwnProperty('components_available') && this.data.status && this.data.status !== "No Ready To Produce") {
-            return this.data.status;
-        }
-        if (this.data.status === "No Ready To Produce" && this.data.availability_display) {
-            return this.data.availability_display;
+        if (this.data.hasOwnProperty('components_available')) {
+            const qty = parseInt(this.data.producible_qty) || 0;
+            if (qty > 0) {
+                return this.data.status;
+            }
+            if (qty == 0 && this.data.availability_display) {
+                return this.data.availability_display;
+            }
         }
         if (this.data.availability_display) {
             return this.data.availability_display;
@@ -18,18 +21,23 @@ patch(BomOverviewLine.prototype, {
     },
 
     get statusBackgroundClass() {
-        if (!this.statusData) {
-            return "text-bg-danger";
+        if (this.data.hasOwnProperty('components_available')) {
+            const qty = parseInt(this.data.producible_qty) || 0;
+            if (qty > 0) {
+                return "text-bg-success";
+            }
         }
-        if (this.statusData === "Available" || this.statusData.includes("Ready To Produce")) {
-            return "text-bg-success";
+
+        const state = this.data.availability_state;
+        switch (state) {
+            case "available":
+                return "text-bg-success";
+            case "expected":
+                return "text-bg-warning";
+            case "estimated":
+                return "text-bg-dark";
+            default:
+                return "text-bg-danger";
         }
-        if (this.statusData.includes("Expected")) {
-            return "text-bg-warning";
-        }
-        if (this.statusData.includes("Estimated")) {
-            return "text-bg-dark";
-        }
-        return "text-bg-danger";
     },
 });


### PR DESCRIPTION
The BOM overview forecast view is simplified by removing visual redundancy and consolidating availability information into the Status column.

Changes introduced via patch on BomOverviewLine and inheritance of report.mrp.report_bom_structure:

- Remove the standalone BOM name header section as it duplicates the breadcrumb information already visible in the page header
- Remove the Availability column to reduce redundancy and consolidate all stock information into the Status column
- Display quantity as integer to avoid unnecessary decimal places on whole-number quantities
- Ensure 'Ready To Produce' tag is only shown when producible quantity is greater than zero
- Always render 'Ready To Produce' tag in green for visual consistency regardless of other conditions
- Each component now independently displays its availability state as a colored tag: green for available, dark for estimated, orange for expected, and red for not available
- When components are missing, top-level BOM line shows estimated production date instead of 'No Ready To Produce'
- All status tags are clickable and navigate to the respective product forecast report

task-6204743