### PR TITLE
[ADD] sale_rental_deposit: introduce deposit mechanism for rental products

### DIFF
--- a/awesome_dashboard/__manifest__.py
+++ b/awesome_dashboard/__manifest__.py
@@ -25,6 +25,9 @@
         'web.assets_backend': [
             'awesome_dashboard/static/src/**/*',
         ],
+        'awesome_dashboard.dashboard': [
+            'awesome_dashboard/static/src/dashboard/**/*'
+        ]
     },
-    'license': 'AGPL-3'
+    'license': 'AGPL-3',
 }

--- a/awesome_dashboard/static/src/dashboard.js
+++ b/awesome_dashboard/static/src/dashboard.js
@@ -1,8 +1,0 @@
-import { Component } from "@odoo/owl";
-import { registry } from "@web/core/registry";
-
-class AwesomeDashboard extends Component {
-    static template = "awesome_dashboard.AwesomeDashboard";
-}
-
-registry.category("actions").add("awesome_dashboard.dashboard", AwesomeDashboard);

--- a/awesome_dashboard/static/src/dashboard.xml
+++ b/awesome_dashboard/static/src/dashboard.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<templates xml:space="preserve">
-
-    <t t-name="awesome_dashboard.AwesomeDashboard">
-        hello dashboard
-    </t>
-
-</templates>

--- a/awesome_dashboard/static/src/dashboard/dashboard.js
+++ b/awesome_dashboard/static/src/dashboard/dashboard.js
@@ -1,0 +1,88 @@
+import { _t } from "@web/core/l10n/translation";
+import { Component, useState } from "@odoo/owl";
+import { Layout } from "@web/search/layout";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { DashboardItem } from "./item/dashboard_item";
+import { Dialog } from "@web/core/dialog/dialog";
+import { CheckBox } from "@web/core/checkbox/checkbox";
+import { browser } from "@web/core/browser/browser";
+
+
+class AwesomeDashboard extends Component {
+    static template = "awesome_dashboard.AwesomeDashboard";
+    static components = { Layout, DashboardItem};
+    setup(){
+        this.action = useService("action");
+        this.statistics = useService("awesome_dashboard.statistics");
+        this.dialog = useService("dialog");
+        this.results = useState(this.statistics.stats);
+        this.items = registry.category("awesome_dashboard").getAll();
+        this.state = useState({
+            disabledItems: browser.localStorage.getItem("disabledDashboardItems")?.split(",") || []
+        });
+    }
+
+    openConfiguration() {
+        this.dialog.add(ConfigurationDialog, {
+            items: this.items,
+            disabledItems: this.state.disabledItems,
+            onUpdateConfiguration: this.updateConfiguration.bind(this),
+        })
+    }
+    updateConfiguration(newDisabledItems) {
+        this.state.disabledItems = newDisabledItems;
+    }
+    openCustomers() {
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "res.partner",
+            name: _t("Customers"),
+            views: [
+                [false, "kanban"],
+            ],
+        });
+    }
+    openLeads() {
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "crm.lead",
+            name: _t("Leads"),
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+        });
+    }
+}
+
+class ConfigurationDialog extends Component {
+    static template = "awesome_dashboard.ConfigurationDialog";
+    static components = { Dialog, CheckBox };
+    static props = ["close", "items", "disabledItems", "onUpdateConfiguration"];
+
+    setup() {
+        this.items = useState(this.props.items.map((item) => {
+            return {
+                ...item,
+                enabled: !this.props.disabledItems.includes(item.id),
+            }
+        }));
+    }
+    done() {
+        this.props.close();
+    }
+    onChange(checked, changedItem) {
+        changedItem.enabled = checked;
+        const newDisabledItems = Object.values(this.items).filter(
+            (item) => !item.enabled
+        ).map((item) => item.id)
+        browser.localStorage.setItem(
+            "disabledDashboardItems",
+            newDisabledItems,
+        );
+        this.props.onUpdateConfiguration(newDisabledItems);
+    }
+}
+
+registry.category("lazy_components").add("awesome_dashboard.dashboard", AwesomeDashboard);

--- a/awesome_dashboard/static/src/dashboard/dashboard.scss
+++ b/awesome_dashboard/static/src/dashboard/dashboard.scss
@@ -1,0 +1,3 @@
+.o_dashboard {
+    background-color: grey;
+}

--- a/awesome_dashboard/static/src/dashboard/dashboard.xml
+++ b/awesome_dashboard/static/src/dashboard/dashboard.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="awesome_dashboard.AwesomeDashboard">
+        <Layout display="{ controlPanel: {} }" className="'o_dashboard h-100'">
+            <t t-set-slot="layout-buttons">
+                <button class="btn btn-primary" t-on-click="openCustomers">Customers</button>
+                <button class="btn btn-primary" t-on-click="openLeads">Leads</button>
+            </t>
+            <t t-set-slot="control-panel-additional-actions">
+                <button t-on-click="openConfiguration" class="btn p-0 ms-1 border-0">
+                    <i class="fa fa-cog"></i>
+                </button>
+            </t>
+            <div class="d-flex flex-wrap p-3">
+                <t t-foreach="items" t-as="item" t-key="item.id">
+                    <DashboardItem t-if="!state.disabledItems.includes(item.id)" size="item.size || 1">                        <t t-set="itemProp" t-value="item.props ? item.props(results) : {'data': results}"/>
+                        <t t-component="item.Component" t-props="itemProp" />
+                    </DashboardItem>
+                </t>
+            </div>
+        </Layout>
+    </t>
+    <t t-name="awesome_dashboard.ConfigurationDialog">
+        <Dialog title="'Dashboard items configuration'">
+            Which cards do you whish to see ?
+            <t t-foreach="items" t-as="item" t-key="item.id">
+                <CheckBox value="item.enabled" onChange="(ev) => this.onChange(ev, item)">
+                    <t t-esc="item.description"/>
+                </CheckBox>
+            </t>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="done">
+                    Done
+                </button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/awesome_dashboard/static/src/dashboard/dashboard_items.js
+++ b/awesome_dashboard/static/src/dashboard/dashboard_items.js
@@ -1,0 +1,67 @@
+import { NumberCard } from "./number_card/number_card";
+import { PieChartCard } from "./piechart_card/piechart_card";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+
+
+const items = [
+    {
+        id: "average_quantity",
+        description: "Average amount of t-shirt",
+        Component: NumberCard,
+        props: (data) => ({
+            title: _t("Average amount of t-shirt by order this month"),
+            value: data.average_quantity,
+        })
+    },
+    {
+        id: "average_time",
+        description: "Average time for an order",
+        Component: NumberCard,
+        props: (data) => ({
+            title: _t("Average time for an order to go from 'new' to 'sent' or 'cancelled'"),
+            value: data.average_time,
+        })
+    },
+    {
+        id: "number_new_orders",
+        description: "New orders this month",
+        Component: NumberCard,
+        props: (data) => ({
+            title: _t("Number of new orders this month"),
+            value: data.nb_new_orders,
+        })
+    },
+    {
+        id: "cancelled_orders",
+        description: "Cancelled orders this month",
+        Component: NumberCard,
+        props: (data) => ({
+            title: _t("Number of cancelled orders this month"),
+            value: data.nb_cancelled_orders,
+        })
+    },
+    {
+        id: "amount_new_orders",
+        description: "amount orders this month",
+        Component: NumberCard,
+        props: (data) => ({
+            title: _t("Total amount of new orders this month"),
+            value: data.total_amount,
+        })
+    },
+    {
+        id: "pie_chart",
+        description: "Shirt orders by size",
+        Component: PieChartCard,
+        size: 2,
+        props: (data) => ({
+            title: _t("Shirt orders by size"),
+            data: data.orders_by_size,
+        })
+    }
+]
+
+items.forEach(item => {
+    registry.category("awesome_dashboard").add(item.id, item);
+});

--- a/awesome_dashboard/static/src/dashboard/item/dashboard_item.js
+++ b/awesome_dashboard/static/src/dashboard/item/dashboard_item.js
@@ -1,0 +1,15 @@
+import { Component } from "@odoo/owl";
+
+
+export class DashboardItem extends Component{
+    static template="awesome_dashboard.DashboardItem"
+
+    static props = {
+        size: { type: Number, optional: true },
+        slots: { type: Object, optional: true },
+    };
+    get width() {
+        const size = this.props.size || 1;
+        return `width: ${18 * size}rem;`;
+    }
+}

--- a/awesome_dashboard/static/src/dashboard/item/dashboard_item.xml
+++ b/awesome_dashboard/static/src/dashboard/item/dashboard_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="awesome_dashboard.DashboardItem">
+        <div class="o_dashboard_item card m-2 p-3" t-att-style="width">
+            <t t-slot="default"/>
+        </div>
+    </t>
+</templates>

--- a/awesome_dashboard/static/src/dashboard/number_card/number_card.js
+++ b/awesome_dashboard/static/src/dashboard/number_card/number_card.js
@@ -1,0 +1,10 @@
+import { Component } from "@odoo/owl";
+
+
+export class NumberCard extends Component {
+    static template = "awesome_dashboard.NumberCard";
+    static props = {
+        title: { type: String },
+        value: { type: Number },
+    };
+}

--- a/awesome_dashboard/static/src/dashboard/number_card/number_card.xml
+++ b/awesome_dashboard/static/src/dashboard/number_card/number_card.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve" owl="1">
+    <t t-name="awesome_dashboard.NumberCard">
+        <div>
+            <div t-esc="props.title" />
+            <h1 t-esc="props.value" />
+        </div>
+    </t>
+</templates>

--- a/awesome_dashboard/static/src/dashboard/piechart/piechart.js
+++ b/awesome_dashboard/static/src/dashboard/piechart/piechart.js
@@ -1,0 +1,37 @@
+import { Component, onWillStart, onMounted, useRef } from "@odoo/owl";
+import { loadJS } from "@web/core/assets";
+
+
+export class PieChart extends Component {
+    static template = "awesome_dashboard.PieChart";
+
+    setup() {
+        this.canvasRef = useRef("canvas");
+        onWillStart(async () => {
+            await loadJS("/web/static/lib/Chart/Chart.js");
+        });
+        onMounted(() => {
+            this.renderChart();
+        });
+    }
+
+    renderChart() {
+        const ctx = this.canvasRef.el.getContext("2d");
+        const data = this.props.data || {};
+        new Chart(ctx, {
+            type: "pie",
+            data: {
+                labels: ["S", "M", "XL"],
+                datasets: [
+                    {
+                        data: [
+                            data.s || 0,
+                            data.m || 0,
+                            data.xl || 0,
+                        ],
+                    },
+                ],
+            },
+        });
+    }
+}

--- a/awesome_dashboard/static/src/dashboard/piechart/piechart.xml
+++ b/awesome_dashboard/static/src/dashboard/piechart/piechart.xml
@@ -1,0 +1,3 @@
+<t t-name="awesome_dashboard.PieChart">
+    <canvas t-ref="canvas"/>
+</t>

--- a/awesome_dashboard/static/src/dashboard/piechart_card/piechart_card.js
+++ b/awesome_dashboard/static/src/dashboard/piechart_card/piechart_card.js
@@ -1,0 +1,14 @@
+import { Component } from "@odoo/owl";
+import { PieChart } from "../piechart/piechart";
+
+
+export class PieChartCard extends Component {
+    static components = { PieChart };
+    static template = "awesome_dashboard.PieChartCard";
+
+    static components = { PieChart };
+    static props = {
+    title: { type: String },
+    values: { type: Object },
+    };
+}

--- a/awesome_dashboard/static/src/dashboard/piechart_card/piechart_card.xml
+++ b/awesome_dashboard/static/src/dashboard/piechart_card/piechart_card.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve" owl="1">
+    <t t-name="awesome_dashboard.PieChartCard">
+        <div class="o_card">
+            <h5><t t-esc="props.title"/></h5>
+            <div class="pie-container">
+                <PieChart data="props.data || {}"/>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/awesome_dashboard/static/src/dashboard/statistics_service.js
+++ b/awesome_dashboard/static/src/dashboard/statistics_service.js
@@ -1,0 +1,21 @@
+import { registry } from "@web/core/registry";
+import { rpc } from "@web/core/network/rpc";
+import { reactive } from "@odoo/owl";
+
+
+const statisticsService = {
+    start() {
+        const stats = reactive({});
+        async function loadStatistics() {
+            const result = await rpc("/awesome_dashboard/statistics");
+            Object.assign(stats, result);
+        }
+        loadStatistics();
+        setInterval(loadStatistics, 600000);
+        return {
+            stats,
+        };
+    },
+};
+
+registry.category("services").add("awesome_dashboard.statistics", statisticsService);

--- a/awesome_dashboard/static/src/dashboard_action.js
+++ b/awesome_dashboard/static/src/dashboard_action.js
@@ -1,0 +1,22 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { LazyComponent } from "@web/core/assets";
+import { Component, xml } from "@odoo/owl";
+
+
+class AwesomeDashboardAction extends Component {
+    static components = { LazyComponent };
+
+    static template = xml`
+        <LazyComponent
+            bundle="'awesome_dashboard.dashboard'"
+            Component="'awesome_dashboard.dashboard'"
+        />
+    `;
+}
+
+registry.category("actions").add(
+    "awesome_dashboard.dashboard",
+    AwesomeDashboardAction
+);

--- a/awesome_owl/static/src/card/card.js
+++ b/awesome_owl/static/src/card/card.js
@@ -1,0 +1,20 @@
+import { Component, useState } from "@odoo/owl";
+
+export class Card extends Component {
+    static template = "awesome_owl.Card";
+
+    setup(){
+        this.state = useState({
+            isOpen: true,
+        });
+    }
+
+    toggle() {
+        this.state.isOpen = !this.state.isOpen;
+    }
+
+    static props = {
+        title : String,
+        slots: Object,
+    }
+}

--- a/awesome_owl/static/src/card/card.xml
+++ b/awesome_owl/static/src/card/card.xml
@@ -1,0 +1,18 @@
+<templates xml:space="preserve">
+    <t t-name="awesome_owl.Card">
+        <div class="card m-3 d-inline-block shadow-sm">
+            <div class="card-header">
+                <t t-esc="props.title"/>
+                <button class="btn btn-secondary" t-on-click="toggle">
+                    <t t-if="state.isOpen">Hide</t>
+                    <t t-else="">Show</t>
+                </button>
+            </div>
+            <t t-if="state.isOpen">
+                <div class="card-body">
+                    <t t-slot="default"/>
+                </div>
+            </t>
+        </div>  
+    </t>
+</templates>

--- a/awesome_owl/static/src/counter/counter.js
+++ b/awesome_owl/static/src/counter/counter.js
@@ -1,0 +1,16 @@
+import { Component, useState } from "@odoo/owl";
+
+export class Counter extends Component {
+    static template = "awesome_owl.Counter";
+
+    setup() {
+        this.state = useState({ value: 0 });
+    }
+
+    increment() {
+        this.state.value++;
+        if (this.props.onincrement) {
+        this.props.onincrement();
+        }
+    }
+}

--- a/awesome_owl/static/src/counter/counter.xml
+++ b/awesome_owl/static/src/counter/counter.xml
@@ -1,0 +1,10 @@
+<templates xml:space="preserve">
+    <t t-name="awesome_owl.Counter">
+        <div class="p-3">
+            Counter: <t t-esc="state.value"/>
+            <button class="btn ms-3 bg-primary" t-on-click="increment">
+                Increment
+            </button>
+        </div>
+    </t>
+</templates>

--- a/awesome_owl/static/src/playground.js
+++ b/awesome_owl/static/src/playground.js
@@ -1,5 +1,17 @@
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
+import { Counter } from "./counter/counter";
+import { Card } from "./card/card";
+import { TodoList } from "./todo/todo_list";
 
 export class Playground extends Component {
     static template = "awesome_owl.playground";
+    static components = { Counter, Card, TodoList };
+
+    setup() {
+        this.sum = useState({ value: 0 });
+    }
+
+    incrementSum() {
+        this.sum.value++;
+    }
 }

--- a/awesome_owl/static/src/playground.xml
+++ b/awesome_owl/static/src/playground.xml
@@ -1,10 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-
     <t t-name="awesome_owl.playground">
+        <Card title="'Counter Card'">
+            <Counter onincrement.bind="incrementSum"/>
+        </Card>
         <div class="p-3">
-            hello world
+            <Counter onincrement.bind="incrementSum"/>
+            <Counter onincrement.bind="incrementSum"/>
+            "The sum is :" <t t-esc="sum.value"/>
+        </div>
+        <div>
+            <TodoList/>
         </div>
     </t>
-
 </templates>

--- a/awesome_owl/static/src/todo/todoList.xml
+++ b/awesome_owl/static/src/todo/todoList.xml
@@ -1,0 +1,14 @@
+<t t-name="awesome_owl.TodoList">
+    Todo Input: <input type="text" name="desc" t-on-keyup="addTodo" t-model="inputValue.text" t-ref="InputValue"/>
+    <div>
+        <t t-foreach="todos" t-as="todo" t-key="todo.id">
+            <TodoItem
+                id="todo.id"
+                description="todo.description"
+                isCompleted="todo.isCompleted"
+                toggleTodo = "toggleTodo"
+                removeTodo = "removeTodo"
+            />
+        </t>
+    </div>
+</t>

--- a/awesome_owl/static/src/todo/todo_item.js
+++ b/awesome_owl/static/src/todo/todo_item.js
@@ -1,0 +1,21 @@
+import { Component } from "@odoo/owl";
+
+export class TodoItem extends Component {
+    static template = "awesome_owl.TodoItem";
+
+    static props = {
+        id: Number,
+        description: String,
+        isCompleted: Boolean,
+        toggleTodo: Function,
+        removeTodo: Function,
+    };
+
+    onToggle() {
+        this.props.toggleTodo(this.props.id);
+    }
+
+    onRemove(){
+        this.props.removeTodo(this.props.id);
+    }
+}

--- a/awesome_owl/static/src/todo/todo_list.js
+++ b/awesome_owl/static/src/todo/todo_list.js
@@ -1,0 +1,41 @@
+import { Component, useState} from "@odoo/owl";
+import { TodoItem } from "./todo_item";
+import { useAutofocus } from "../utils";
+
+export class TodoList extends Component {
+    static template = "awesome_owl.TodoList";
+    static components = { TodoItem };
+
+    setup(){
+        this.inputRef = useAutofocus("InputValue")
+        this.todos = useState([]);
+        this.nextId = 1
+        this.inputValue = useState({ text: "" });
+        this.removeTodo = this.removeTodo.bind(this);
+    }
+
+    addTodo(ev)
+    {
+        if (ev.keyCode != 13) return
+        this.todos.push({
+            id : this.nextId++,
+            description : this.inputValue.text,
+            isCompleted : false
+        })
+        this.inputValue.text = ""
+    }
+
+    toggleTodo = (id) => {
+        const todo = this.todos.find(t => t.id == id);
+        if (todo) {
+            todo.isCompleted = !todo.isCompleted;
+        }
+    }
+
+    removeTodo(id) {
+        const index = this.todos.findIndex(todo => todo.id === id);
+        if (index !== -1) {
+            this.todos.splice(index, 1);
+        }
+    }
+}

--- a/awesome_owl/static/src/todo/todoitem.xml
+++ b/awesome_owl/static/src/todo/todoitem.xml
@@ -1,0 +1,14 @@
+<t t-name="awesome_owl.TodoItem">
+    <div class="ms-3" t-att-class="{
+        'text-muted': props.isCompleted,
+        'text-decoration-line-through': props.isCompleted
+    }">
+        <input type="checkbox" t-att-checked="props.isCompleted" t-on-change="onToggle"/>
+        <span>
+            id: <t t-esc="props.id"/> -
+            description: <t t-esc="props.description"/> -
+            iscompleted: <t t-esc="props.isCompleted"/>
+        </span>
+        <span role="button" class="fa fa-remove" t-on-click="onRemove" />
+    </div>
+</t>

--- a/awesome_owl/static/src/utils.js
+++ b/awesome_owl/static/src/utils.js
@@ -1,0 +1,11 @@
+import { useRef, onMounted } from "@odoo/owl";
+
+export function useAutofocus(refName) {
+    const ref = useRef(refName);
+
+    onMounted(() => {
+            ref.el.focus();
+    });
+
+    return ref;
+}

--- a/estate/__init__.py
+++ b/estate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -15,9 +15,9 @@
     'data': [
         'security/ir.model.access.csv',
         'views/estate_property_views.xml',
+        'views/estate_property_offer_views.xml',
         'views/estate_property_type_views.xml',
         'views/estate_property_tag_views.xml',
-        'views/estate_property_offer_views.xml',
         'views/estate_menus.xml',
     ],
 }

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': "Estate",
+    'version': '0.1',
+    'summary': "Real Estate Advertisement",
+    'description': """
+        This module allows you to manage real estate advertisements, including
+        properties, agents, and customer inquiries.
+    """,
+    'author': "aykhu",
+    'license': 'LGPL-3',
+    'website': "https://www.odoo.com/app/estate",
+    'category': 'Tutorials',
+    'application': True,
+    'depends': ['base'],
+}

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -15,6 +15,9 @@
     'data': [
         'security/ir.model.access.csv',
         'views/estate_property_views.xml',
+        'views/estate_property_type_views.xml',
+        'views/estate_property_tag_views.xml',
+        'views/estate_property_offer_views.xml',
         'views/estate_menus.xml',
     ],
 }

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -11,14 +11,16 @@
     'website': "https://www.odoo.com/app/estate",
     'category': 'Tutorials',
     'application': True,
-    'depends': ['base'],
+    'depends': ['base', 'calendar'],
     'data': [
         'security/ir.model.access.csv',
+        'views/estate_property_issue_views.xml',
+        'views/estate_property_visit_views.xml',
         'views/estate_property_views.xml',
         'views/estate_property_offer_views.xml',
         'views/estate_property_type_views.xml',
         'views/estate_property_tag_views.xml',
         'views/estate_menus.xml',
-        'views/res_users_views.xml'
+        'views/res_users_views.xml',
     ],
 }

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -12,4 +12,7 @@
     'category': 'Tutorials',
     'application': True,
     'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+    ],
 }

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -14,5 +14,7 @@
     'depends': ['base'],
     'data': [
         'security/ir.model.access.csv',
+        'views/estate_property_views.xml',
+        'views/estate_menus.xml',
     ],
 }

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -11,7 +11,7 @@
     'website': "https://www.odoo.com/app/estate",
     'category': 'Tutorials',
     'application': True,
-    'depends': ['base', 'calendar'],
+    'depends': ['base', 'calendar', 'mail'],
     'data': [
         'security/ir.model.access.csv',
         'views/estate_property_issue_views.xml',

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -19,5 +19,6 @@
         'views/estate_property_type_views.xml',
         'views/estate_property_tag_views.xml',
         'views/estate_menus.xml',
+        'views/res_users_views.xml'
     ],
 }

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,0 +1,1 @@
+from . import estate_property

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,1 +1,4 @@
 from . import estate_property
+from . import estate_property_type
+from . import estate_property_tag
+from . import estate_property_offer

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -2,3 +2,4 @@ from . import estate_property
 from . import estate_property_type
 from . import estate_property_tag
 from . import estate_property_offer
+from . import res_users

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -3,3 +3,5 @@ from . import estate_property_type
 from . import estate_property_tag
 from . import estate_property_offer
 from . import res_users
+from . import estate_property_visit
+from . import estate_property_issues

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,6 +1,7 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 
 class EstateProperty(models.Model):
@@ -80,3 +81,17 @@ class EstateProperty(models.Model):
         else:
             self.garden_area = None
             self.garden_orientation = None
+
+    def action_property_sold(self):
+        for record in self:
+            if record.state == "cancelled":
+                raise UserError("Cancelled property cannot be set as sold.")
+            else:
+                record.state = "sold"
+
+    def action_property_cancelled(self):
+        for record in self:
+            if record.state == "sold":
+                raise UserError("Sold property cannot be set as cancelled")
+            else:
+                record.state = "cancelled"

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -66,9 +66,6 @@ class EstateProperty(models.Model):
     _check_expected_price = models.Constraint(
         'CHECK(expected_price > 0)', 'Price must be strictly positive'
     )
-    _check_selling_price = models.Constraint(
-        'CHECK (selling_price > 0)', "Selling price must be strictly positive"
-    )
 
     @api.depends("living_area", "garden_area")
     def _compute_total_area(self):
@@ -121,4 +118,12 @@ class EstateProperty(models.Model):
                 raise UserError("Sold property cannot be set as cancelled")
             else:
                 record.state = "cancelled"
+        return True
+
+    @api.ondelete(at_uninstall=False)
+    def delete_state_check(self):
+        for record in self:
+            if record.state not in ('new', 'cancelled'):
+                raise UserError("Only New or Cancelled properties can be deleted")
+
         return True

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,6 +1,6 @@
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.float_utils import float_compare, float_is_zero
 
@@ -9,6 +9,7 @@ class EstateProperty(models.Model):
     _name = 'estate.property'
     _description = 'Estate Property'
     _order = "id desc"
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     name = fields.Char(string='Title', required=True, default='Unknown')
     description = fields.Text(string='Description')
@@ -85,8 +86,15 @@ class EstateProperty(models.Model):
 
     @api.depends('visit_ids')
     def _compute_issue_count(self):
+        data = dict(self.env['estate.property.issue']._read_group(
+            [('property_id', 'in', self.ids)],
+            groupby=['property_id'],
+            aggregates=['__count']
+        ))
+
         for record in self:
-            record.issue_count = len(record.issue_ids)
+            record.issue_count = data.get(record, 0)
+            # record.issue_count = len(record.issue_ids)
 
     @api.onchange('has_garden')
     def _onchange_garden(self):
@@ -108,32 +116,47 @@ class EstateProperty(models.Model):
                 min_price,
                 precision_digits=2
             ) < 0:
-                raise ValidationError(
+                raise ValidationError(_(
                     "The selling price cannot be lower than 90% of the expected price."
-                )
+                ))
 
     def action_property_sold(self):
-        for record in self:
-            if record.state == "cancelled":
-                raise UserError("Cancelled property cannot be set as sold.")
-            elif record.issue_ids.priority == '3' and record.issue_ids.state != "resolved":
-                raise UserError("High priority issue is still not resolved")
-            else:
-                record.state = "sold"
+        if self.state == "cancelled":
+            raise UserError(_("Cancelled property cannot be set as sold."))
+        elif self.issue_ids.priority == '3' and self.issue_ids.state != "resolved":
+            raise UserError(_("High priority issue is still not resolved"))
+        else:
+            self.state = "sold"
         return True
 
+    def action_set_sold_rainbow_man(self):
+        self.action_property_sold()
+
+        return {
+            'effect': {
+                'fadeout': 'slow',
+                'img_url': '/web/static/img/smile.svg',
+                'type': 'rainbow_man',
+            }
+        }
+
     def action_property_cancelled(self):
-        for record in self:
-            if record.state == "sold":
-                raise UserError("Sold property cannot be set as cancelled")
-            else:
-                record.state = "cancelled"
+        if self.state == "sold":
+            raise UserError(_("Sold property cannot be set as cancelled"))
+        else:
+            self.state = "cancelled"
+        return True
+
+    def action_accept_best_offer(self):
+        best_offer = self.offer_ids.filtered_domain(
+            [('price', '=', self.best_price)])
+        best_offer.action_offer_accepted()
         return True
 
     @api.ondelete(at_uninstall=False)
     def delete_state_check(self):
         for record in self:
             if record.state not in ('new', 'cancelled'):
-                raise UserError("Only New or Cancelled properties can be deleted")
-
+                raise UserError(
+                    _("Only New or Cancelled properties can be deleted"))
         return True

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,5 +1,6 @@
-from odoo import fields, models
 from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models
 
 
 class EstateProperty(models.Model):
@@ -26,17 +27,31 @@ class EstateProperty(models.Model):
     active = fields.Boolean(string="Is Active ?", default=True)
     garden_orientation = fields.Selection(
         string="Garden Orientation",
-        selection=[('north', 'North'),
-                   ('south', 'South'),
-                   ('east', 'East'),
-                   ('west', 'West')],
+        selection=[
+            ('north', 'North'),
+            ('south', 'South'),
+            ('east', 'East'),
+            ('west', 'West')
+        ],
     )
     state = fields.Selection(
         string="Status",
-        selection=[("New", "New"),
-                   ("Offer Received", "Offer Received"),
-                   ("Offer Accepted", "Offer Accepted"),
-                   ("Sold", "Sold"),
-                   ("Cancelled", "Cancelled")],
-        required=True, default="New", copy=False
+        selection=[
+            ("new", "New"),
+            ("offer_received", "Offer Received"),
+            ("offer_accepted", "Offer Accepted"),
+            ("sold", "Sold"),
+            ("cancelled", "Cancelled")
+        ],
+        required=True, default="new", copy=False
     )
+    property_type_id = fields.Many2one(
+        "estate.property.type", ondelete='Cascade', string="Property Type"
+    )
+    salesperson_id = fields.Many2one(
+        "res.users", string="Sales Person", default=lambda self: self.env.user
+    )
+    buyer_id = fields.Many2one("res.partner", string="Buyer", copy=False)
+    property_tags_ids = fields.Many2many(
+        "estate.property.tag", string="Property Tags")
+    offer_ids = fields.One2many("estate.property.offer", "property_id")

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -8,18 +8,19 @@ from odoo.tools.float_utils import float_compare, float_is_zero
 class EstateProperty(models.Model):
     _name = 'estate.property'
     _description = 'Estate Property'
+    _order = "id desc"
 
     name = fields.Char(string='Title', required=True, default='Unknown')
     description = fields.Text(string='Description')
     postcode = fields.Char(string='Postal Code')
     date_availability = fields.Date(
-        string='Available From', copy=False, default=fields.Date.today() + relativedelta(months=+3)
+        string='Available From', copy=False, default=lambda self: fields.Date.today() + relativedelta(months=3)
     )
     expected_price = fields.Float(string='Expected Price', required=True)
     selling_price = fields.Float(
         string='Selling Price', readonly=True, copy=False
     )
-    living_area = fields.Float(string='Living Area (sq m)')
+    living_area = fields.Integer(string='Living Area (sq m)')
     bedrooms = fields.Integer(string='Bedrooms', default=2)
     facades = fields.Integer(string='Facades')
     has_garage = fields.Boolean(string="Has Garage ?")
@@ -47,7 +48,7 @@ class EstateProperty(models.Model):
         required=True, default="new", copy=False
     )
     property_type_id = fields.Many2one(
-        "estate.property.type", ondelete='Cascade', string="Property Type"
+        "estate.property.type", ondelete='cascade', string="Property Type"
     )
     salesperson_id = fields.Many2one(
         "res.users", string="Sales Person", default=lambda self: self.env.user
@@ -76,10 +77,11 @@ class EstateProperty(models.Model):
 
     @api.depends("offer_ids.price")
     def _compute_best_price(self):
-        if self.offer_ids:
-            self.best_price = max(self.offer_ids.mapped("price"))
-        else:
-            self.best_price = 0.0
+        for record in self:
+            if record.offer_ids:
+                record.best_price = max(record.offer_ids.mapped("price"))
+            else:
+                record.best_price = 0.0
 
     @api.onchange('has_garden')
     def _onchange_garden(self):
@@ -89,6 +91,21 @@ class EstateProperty(models.Model):
         else:
             self.garden_area = None
             self.garden_orientation = None
+
+    @api.constrains('selling_price', 'expected_price')
+    def _check_selling_price(self):
+        for record in self:
+            if float_is_zero(record.selling_price, precision_digits=2):
+                continue
+            min_price = record.expected_price * 0.9
+            if float_compare(
+                record.selling_price,
+                min_price,
+                precision_digits=2
+            ) < 0:
+                raise ValidationError(
+                    "The selling price cannot be lower than 90% of the expected price."
+                )
 
     def action_property_sold(self):
         for record in self:
@@ -105,18 +122,3 @@ class EstateProperty(models.Model):
             else:
                 record.state = "cancelled"
         return True
-
-    @api.constrains('selling_price', 'expected_price')
-    def _check_selling_price(self):
-        for record in self:
-            if float_is_zero(record.selling_price, precision_digits=2):
-                continue
-            min_price = record.expected_price * 0.9
-            if float_compare(
-                record.selling_price,
-                min_price,
-                precision_digits=2
-            ) < 0:
-                raise ValidationError(
-                    "The selling price cannot be lower than 90% of the expected price."
-                )

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -61,6 +61,13 @@ class EstateProperty(models.Model):
         string="Best Offer", compute="_compute_best_price"
     )
 
+    _check_expected_price = models.Constraint(
+        'CHECK(expected_price > 0)', 'Price must be strictly positive'
+    )
+    _check_selling_price = models.Constraint(
+        'CHECK (selling_price > 0)', "Selling price must be strictly positive"
+    )
+
     @api.depends("living_area", "garden_area")
     def _compute_total_area(self):
         for record in self:

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -60,7 +60,7 @@ class EstateProperty(models.Model):
     offer_ids = fields.One2many("estate.property.offer", "property_id")
     total_area = fields.Float(compute="_compute_total_area")
     best_price = fields.Float(
-        string="Best Offer", compute="_compute_best_price"
+        string="Best Offer", compute="_compute_best_price", store=True
     )
 
     _check_expected_price = models.Constraint(

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,0 +1,26 @@
+from odoo import fields, models
+
+
+class EstateProperty(models.Model):
+    _name = 'estate.property'
+    _description = 'Estate Property'
+
+    name = fields.Char(string='Title', required=True)
+    description = fields.Text(string='Description')
+    postcode = fields.Char(string='Postal Code')
+    date_availability = fields.Date(string='Available From')
+    expected_price = fields.Float(string='Expected Price', required=True)
+    selling_price = fields.Float(string='Price')
+    living_area = fields.Float(string='Area (sq m)')
+    bedrooms = fields.Integer(string='Bedrooms')
+    facades = fields.Integer(string='Facades')
+    has_garage = fields.Boolean(string="Has Garage ?")
+    has_garden = fields.Boolean(string="Has Garden ?")
+    garden_area = fields.Integer(string="Garden Area (sq m)")
+    garden_orientation = fields.Selection(
+        string="Garden Orientation",
+        selection=[('north', 'North'),
+                   ('south', 'South'),
+                   ('east', 'East'),
+                   ('west', 'West')],
+    )

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,7 +1,8 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class EstateProperty(models.Model):
@@ -104,3 +105,18 @@ class EstateProperty(models.Model):
             else:
                 record.state = "cancelled"
         return True
+
+    @api.constrains('selling_price', 'expected_price')
+    def _check_selling_price(self):
+        for record in self:
+            if float_is_zero(record.selling_price, precision_digits=2):
+                continue
+            min_price = record.expected_price * 0.9
+            if float_compare(
+                record.selling_price,
+                min_price,
+                precision_digits=2
+            ) < 0:
+                raise ValidationError(
+                    "The selling price cannot be lower than 90% of the expected price."
+                )

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -88,6 +88,7 @@ class EstateProperty(models.Model):
                 raise UserError("Cancelled property cannot be set as sold.")
             else:
                 record.state = "sold"
+        return True
 
     def action_property_cancelled(self):
         for record in self:
@@ -95,3 +96,4 @@ class EstateProperty(models.Model):
                 raise UserError("Sold property cannot be set as cancelled")
             else:
                 record.state = "cancelled"
+        return True

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,6 +1,6 @@
 from dateutil.relativedelta import relativedelta
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class EstateProperty(models.Model):
@@ -18,7 +18,7 @@ class EstateProperty(models.Model):
     expected_price = fields.Float(string='Expected Price', required=True)
     selling_price = fields.Float(
         string='Selling Price', readonly=True, copy=False)
-    living_area = fields.Float(string='Area (sq m)')
+    living_area = fields.Float(string='Living Area (sq m)')
     bedrooms = fields.Integer(string='Bedrooms', default=2)
     facades = fields.Integer(string='Facades')
     has_garage = fields.Boolean(string="Has Garage ?")
@@ -55,3 +55,20 @@ class EstateProperty(models.Model):
     property_tags_ids = fields.Many2many(
         "estate.property.tag", string="Property Tags")
     offer_ids = fields.One2many("estate.property.offer", "property_id")
+    total_area = fields.Float(compute="_compute_area")
+    best_price = fields.Float(
+        string="Best Offer", compute="_compute_best_price"
+    )
+
+    @api.depends("living_area", "garden_area")
+    def _compute_area(self):
+        for rec in self:
+            rec.total_area = rec.living_area + rec.garden_area
+
+    @api.depends("offer_ids.price")
+    def _compute_best_price(self):
+        for rec in self:
+            if rec.offer_ids:
+                rec.best_price = max(rec.offer_ids.mapped("price"))
+            else:
+                rec.best_price = 0.0

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -10,14 +10,13 @@ class EstateProperty(models.Model):
     name = fields.Char(string='Title', required=True, default='Unknown')
     description = fields.Text(string='Description')
     postcode = fields.Char(string='Postal Code')
-    last_seen = fields.Datetime(
-        string="Last Seen", default=fields.Datetime.now)
     date_availability = fields.Date(
         string='Available From', copy=False, default=fields.Date.today() + relativedelta(months=+3)
     )
     expected_price = fields.Float(string='Expected Price', required=True)
     selling_price = fields.Float(
-        string='Selling Price', readonly=True, copy=False)
+        string='Selling Price', readonly=True, copy=False
+    )
     living_area = fields.Float(string='Living Area (sq m)')
     bedrooms = fields.Integer(string='Bedrooms', default=2)
     facades = fields.Integer(string='Facades')
@@ -53,22 +52,31 @@ class EstateProperty(models.Model):
     )
     buyer_id = fields.Many2one("res.partner", string="Buyer", copy=False)
     property_tags_ids = fields.Many2many(
-        "estate.property.tag", string="Property Tags")
+        "estate.property.tag", string="Property Tags"
+    )
     offer_ids = fields.One2many("estate.property.offer", "property_id")
-    total_area = fields.Float(compute="_compute_area")
+    total_area = fields.Float(compute="_compute_total_area")
     best_price = fields.Float(
         string="Best Offer", compute="_compute_best_price"
     )
 
     @api.depends("living_area", "garden_area")
-    def _compute_area(self):
-        for rec in self:
-            rec.total_area = rec.living_area + rec.garden_area
+    def _compute_total_area(self):
+        for record in self:
+            record.total_area = record.living_area + record.garden_area
 
     @api.depends("offer_ids.price")
     def _compute_best_price(self):
-        for rec in self:
-            if rec.offer_ids:
-                rec.best_price = max(rec.offer_ids.mapped("price"))
-            else:
-                rec.best_price = 0.0
+        if self.offer_ids:
+            self.best_price = max(self.offer_ids.mapped("price"))
+        else:
+            self.best_price = 0.0
+
+    @api.onchange('has_garden')
+    def _onchange_garden(self):
+        if self.has_garden:
+            self.garden_area = 10
+            self.garden_orientation = 'north'
+        else:
+            self.garden_area = None
+            self.garden_orientation = None

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -62,6 +62,9 @@ class EstateProperty(models.Model):
     best_price = fields.Float(
         string="Best Offer", compute="_compute_best_price", store=True
     )
+    visit_ids = fields.One2many('estate.property.visit', 'property_id')
+    issue_ids = fields.One2many('estate.property.issue', 'property_id')
+    issue_count = fields.Integer(compute='_compute_issue_count')
 
     _check_expected_price = models.Constraint(
         'CHECK(expected_price > 0)', 'Price must be strictly positive'
@@ -79,6 +82,11 @@ class EstateProperty(models.Model):
                 record.best_price = max(record.offer_ids.mapped("price"))
             else:
                 record.best_price = 0.0
+
+    @api.depends('visit_ids')
+    def _compute_issue_count(self):
+        for record in self:
+            record.issue_count = len(record.issue_ids)
 
     @api.onchange('has_garden')
     def _onchange_garden(self):
@@ -108,6 +116,8 @@ class EstateProperty(models.Model):
         for record in self:
             if record.state == "cancelled":
                 raise UserError("Cancelled property cannot be set as sold.")
+            elif record.issue_ids.priority == '3' and record.issue_ids.state != "resolved":
+                raise UserError("High priority issue is still not resolved")
             else:
                 record.state = "sold"
         return True

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,26 +1,42 @@
 from odoo import fields, models
+from dateutil.relativedelta import relativedelta
 
 
 class EstateProperty(models.Model):
     _name = 'estate.property'
     _description = 'Estate Property'
 
-    name = fields.Char(string='Title', required=True)
+    name = fields.Char(string='Title', required=True, default='Unknown')
     description = fields.Text(string='Description')
     postcode = fields.Char(string='Postal Code')
-    date_availability = fields.Date(string='Available From')
+    last_seen = fields.Datetime(
+        string="Last Seen", default=fields.Datetime.now)
+    date_availability = fields.Date(
+        string='Available From', copy=False, default=fields.Date.today() + relativedelta(months=+3)
+    )
     expected_price = fields.Float(string='Expected Price', required=True)
-    selling_price = fields.Float(string='Price')
+    selling_price = fields.Float(
+        string='Selling Price', readonly=True, copy=False)
     living_area = fields.Float(string='Area (sq m)')
-    bedrooms = fields.Integer(string='Bedrooms')
+    bedrooms = fields.Integer(string='Bedrooms', default=2)
     facades = fields.Integer(string='Facades')
     has_garage = fields.Boolean(string="Has Garage ?")
     has_garden = fields.Boolean(string="Has Garden ?")
     garden_area = fields.Integer(string="Garden Area (sq m)")
+    active = fields.Boolean(string="Is Active ?", default=True)
     garden_orientation = fields.Selection(
         string="Garden Orientation",
         selection=[('north', 'North'),
                    ('south', 'South'),
                    ('east', 'East'),
                    ('west', 'West')],
+    )
+    state = fields.Selection(
+        string="Status",
+        selection=[("New", "New"),
+                   ("Offer Received", "Offer Received"),
+                   ("Offer Accepted", "Offer Accepted"),
+                   ("Sold", "Sold"),
+                   ("Cancelled", "Cancelled")],
+        required=True, default="New", copy=False
     )

--- a/estate/models/estate_property_issues.py
+++ b/estate/models/estate_property_issues.py
@@ -1,0 +1,88 @@
+from datetime import timedelta
+
+from odoo import api, fields, models
+
+AVAILABLE_PRIORITIES = [
+    ('1', 'Low'),
+    ('2', 'Medium'),
+    ('3', 'High'),
+]
+
+
+class EstatePropertyIssues(models.Model):
+    _name = 'estate.property.issue'
+    _description = "Raise and Manage issues in properties"
+
+    name = fields.Char(required=True)
+    property_id = fields.Many2one('estate.property', required=True)
+    reported_by = fields.Many2one('res.partner')
+    assigned_to = fields.Many2one('res.users')
+    issue_type = fields.Selection(
+        selection=[
+            ('plumbing', 'Plumbing'),
+            ('electrical', 'Electrical'),
+            ('structural', 'Structural'),
+            ('other', 'other'),
+        ],
+        required=True
+    )
+    state = fields.Selection(
+        string="Status",
+        selection=[
+            ("new", "New"),
+            ("in_progress", "In progress"),
+            ("resolved", "Resolved"),
+            ("cancelled", "Cancelled")
+        ],
+        default="new",
+    )
+    priority = fields.Selection(
+        AVAILABLE_PRIORITIES, compute="_compute_priority"
+    )
+    resolved_date = fields.Date()
+    description = fields.Text()
+    is_overdue = fields.Boolean(compute="_compute_is_overdue", default=False)
+
+    @api.depends('issue_type')
+    def _compute_priority(self):
+        for record in self:
+            if record.issue_type not in ('electrical', 'structural'):
+                record.priority = '1'
+            if record.issue_type == 'electrical':
+                record.priority = '2'
+            if record.issue_type == 'structural':
+                record.priority = '3'
+
+    @api.depends('create_date', 'priority', 'resolved_date')
+    def _compute_is_overdue(self):
+        priority_days = {
+            '3': 2,
+            '2': 5,
+            '1': 10,
+        }
+
+        for record in self:
+            start_date = record.create_date.date() if record.create_date else fields.Date.today()
+            resolve_date = record.resolved_date or fields.Date.today()
+            limit_days = priority_days.get(record.priority)
+
+            if (resolve_date - start_date) > timedelta(days=limit_days):
+                record.is_overdue = True
+            else:
+                record.is_overdue = False
+
+    @api.onchange('assigned_to')
+    def _check_state(self):
+        for record in self:
+            if record.assigned_to and record.state == "new":
+                record.state = "in_progress"
+
+    def action_set_resolved(self):
+        for record in self:
+            record.state = 'resolved'
+            if not record.resolved_date:
+                record.resolved_date = fields.Date.today()
+
+    def action_set_cancelled(self):
+        for record in self:
+            record.state = 'cancelled'

--- a/estate/models/estate_property_issues.py
+++ b/estate/models/estate_property_issues.py
@@ -78,11 +78,11 @@ class EstatePropertyIssues(models.Model):
                 record.state = "in_progress"
 
     def action_set_resolved(self):
-        for record in self:
-            record.state = 'resolved'
-            if not record.resolved_date:
-                record.resolved_date = fields.Date.today()
+        self.state = 'resolved'
+        if not self.resolved_date:
+            self.resolved_date = fields.Date.today()
+        return True
 
     def action_set_cancelled(self):
-        for record in self:
-            record.state = 'cancelled'
+        self.state = 'cancelled'
+        return True

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -7,8 +7,9 @@ from odoo.exceptions import UserError
 class EstatePropertyOffer(models.Model):
     _name = "estate.property.offer"
     _description = "Estate Property Offer"
+    _order = "price desc"
 
-    price = fields.Float(string="Offer Price")
+    price = fields.Float(string="Offer Price", required=True)
     status = fields.Selection(
         selection=[
             ("accepted", "Accepted"),
@@ -23,6 +24,7 @@ class EstatePropertyOffer(models.Model):
     date_deadline = fields.Date(
         string="Deadline", compute='_compute_date_deadline', inverse="_inverse_deadline",
     )
+    property_type_id = fields.Many2one(related="property_id.property_type_id", store=True)
 
     _check_offer_price = models.Constraint(
         'CHECK (price > 0)', 'Offer price must be strictly positive'
@@ -42,6 +44,15 @@ class EstatePropertyOffer(models.Model):
                 record.create_date.date() if record.create_date else fields.Date.today()
             )
             record.validity = (record.date_deadline - start_date).days
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        offers = super().create(vals_list)
+        for offer in offers:
+            if offer.property_id.state == 'new':
+                offer.property_id.state = 'offer_received'
+
+        return offers
 
     def action_accepted(self):
         for record in self:

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,6 +1,7 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 
 class EstatePropertyOffer(models.Model):
@@ -37,3 +38,20 @@ class EstatePropertyOffer(models.Model):
                 record.create_date.date() if record.create_date else fields.Date.today()
             )
             record.validity = (record.date_deadline - start_date).days
+
+    def action_accepted(self):
+        for record in self:
+            for offer in record.property_id.offer_ids:
+                if offer.status == "accepted":
+                    raise UserError(
+                        "Only 1 offer can be accepted for each property")
+            record.status = "accepted"
+            record.property_id.selling_price = record.price
+            record.property_id.buyer_id = record.partner_id
+            record.property_id.state = "offer_accepted"
+        return True
+
+    def action_refused(self):
+        for record in self:
+            record.status = "refused"
+        return True

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,6 +1,6 @@
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -52,7 +52,7 @@ class EstatePropertyOffer(models.Model):
             property_id = self.env['estate.property'].browse(vals['property_id'])
             for offer in property_id.offer_ids:
                 if current_price < offer.price:
-                    raise UserError("Offer Price cannot be less than previous offer prices")
+                    raise UserError(_("Offer Price cannot be less than previous offer prices"))
 
         offers = super().create(vals_list)
 
@@ -62,19 +62,18 @@ class EstatePropertyOffer(models.Model):
 
         return offers
 
-    def action_accepted(self):
-        for record in self:
-            for offer in record.property_id.offer_ids:
-                if offer.status == "accepted":
-                    raise UserError(
-                        "Only 1 offer can be accepted for each property")
-            record.status = "accepted"
-            record.property_id.selling_price = record.price
-            record.property_id.buyer_id = record.partner_id
-            record.property_id.state = "offer_accepted"
+    def action_offer_accepted(self):
+        if self.price < self.property_id.best_price:
+            raise UserError(_("Another higher price offer exists"))
+        self.status = "accepted"
+        self.property_id.selling_price = self.price
+        self.property_id.buyer_id = self.partner_id
+        self.property_id.state = "offer_accepted"
+
+        offers = self.property_id.offer_ids.filtered(lambda x: x.status != "accepted")
+        offers.write({'status': 'refused'})
         return True
 
-    def action_refused(self):
-        for record in self:
-            record.status = "refused"
+    def action_offer_refused(self):
+        self.status = "refused"
         return True

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class EstatePropertyOffer(models.Model):
+    _name = "estate.property.offer"
+    _description = "Estate Property Offer"
+
+    price = fields.Float(string="Offer Price")
+    status = fields.Selection(
+        selection=[
+            ("accepted", "Accepted"),
+            ("refused", "Refused"),
+        ],
+        string="Status",
+        copy=False,
+    )
+    partner_id = fields.Many2one("res.partner", required=True)
+    property_id = fields.Many2one("estate.property", required=True)

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,4 +1,6 @@
-from odoo import fields, models
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models
 
 
 class EstatePropertyOffer(models.Model):
@@ -16,3 +18,22 @@ class EstatePropertyOffer(models.Model):
     )
     partner_id = fields.Many2one("res.partner", required=True)
     property_id = fields.Many2one("estate.property", required=True)
+    validity = fields.Integer(string="Validity (days)", default=7)
+    date_deadline = fields.Date(
+        string="Deadline", compute='_compute_date_deadline', inverse="_inverse_deadline",
+    )
+
+    @api.depends('create_date', 'validity')
+    def _compute_date_deadline(self):
+        for record in self:
+            start_date = (
+                record.create_date.date() if record.create_date else fields.Date.today()
+            )
+            record.date_deadline = start_date + relativedelta(days=record.validity)
+
+    def _inverse_deadline(self):
+        for record in self:
+            start_date = (
+                record.create_date.date() if record.create_date else fields.Date.today()
+            )
+            record.validity = (record.date_deadline - start_date).days

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -24,6 +24,10 @@ class EstatePropertyOffer(models.Model):
         string="Deadline", compute='_compute_date_deadline', inverse="_inverse_deadline",
     )
 
+    _check_offer_price = models.Constraint(
+        'CHECK (price > 0)', 'Offer price must be strictly positive'
+    )
+
     @api.depends('create_date', 'validity')
     def _compute_date_deadline(self):
         for record in self:

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -47,7 +47,15 @@ class EstatePropertyOffer(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for vals in vals_list:
+            current_price = vals.get('price')
+            property_id = self.env['estate.property'].browse(vals['property_id'])
+            for offer in property_id.offer_ids:
+                if current_price < offer.price:
+                    raise UserError("Offer Price cannot be less than previous offer prices")
+
         offers = super().create(vals_list)
+
         for offer in offers:
             if offer.property_id.state == 'new':
                 offer.property_id.state = 'offer_received'

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class EstatePropertyTags(models.Model):
+    _name = "estate.property.tag"
+    _description = "Estate Property Tag"
+
+    name = fields.Char(string="Name", required=True)

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -6,3 +6,5 @@ class EstatePropertyTags(models.Model):
     _description = "Estate Property Tag"
 
     name = fields.Char(string="Name", required=True)
+
+    _unique_tag_name = models.Constraint('UNIQUE (name)', "Tag name must be unique")

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -4,7 +4,9 @@ from odoo import fields, models
 class EstatePropertyTags(models.Model):
     _name = "estate.property.tag"
     _description = "Estate Property Tag"
+    _order = "name"
 
     name = fields.Char(string="Name", required=True)
+    color = fields.Integer()
 
     _unique_tag_name = models.Constraint('UNIQUE (name)', "Tag name must be unique")

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class EstatePropertyType(models.Model):
+    _name = "estate.property.type"
+    _description = "Estate Property Type"
+
+    name = fields.Char(string="Name", required=True)

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,10 +1,20 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class EstatePropertyType(models.Model):
     _name = "estate.property.type"
     _description = "Estate Property Type"
+    _order = "name"
 
     name = fields.Char(string="Name", required=True)
+    property_ids = fields.One2many("estate.property", "property_type_id")
+    sequence = fields.Integer()
+    offer_ids = fields.One2many("estate.property.offer", "property_type_id")
+    offer_count = fields.Integer(compute='_compute_offer_count')
 
     _unique_type_name = models.Constraint('UNIQUE(name)', "Type name must be unique")
+
+    @api.depends('offer_count')
+    def _compute_offer_count(self):
+        for record in self:
+            record.offer_count = len(record.offer_ids)

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -6,3 +6,5 @@ class EstatePropertyType(models.Model):
     _description = "Estate Property Type"
 
     name = fields.Char(string="Name", required=True)
+
+    _unique_type_name = models.Constraint('UNIQUE(name)', "Type name must be unique")

--- a/estate/models/estate_property_visit.py
+++ b/estate/models/estate_property_visit.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -35,4 +35,4 @@ class EstatePropertyVisit(models.Model):
                 if record.id == visit.id or record.visit_date.date() != visit.visit_date.date():
                     continue
                 if record.visit_date - visit.visit_date < timedelta(hours=1):
-                    raise UserError("2 visits cannot have same time")
+                    raise UserError(_("2 visits cannot have same time"))

--- a/estate/models/estate_property_visit.py
+++ b/estate/models/estate_property_visit.py
@@ -1,0 +1,38 @@
+from datetime import timedelta
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class EstatePropertyVisit(models.Model):
+    _name = "estate.property.visit"
+    _description = "Schedule for properties"
+
+    salesperson_id = fields.Many2one(related="property_id.salesperson_id")
+    customer_name = fields.Many2one('res.partner')
+    visit_date = fields.Datetime(default=fields.Datetime.now())
+    property_id = fields.Many2one('estate.property', required=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+
+        visits = super().create(vals_list)
+
+        for visit in visits:
+            stop_time = visit.visit_date + timedelta(hours=+1)
+            self.env['calendar.event'].create({
+                'name': 'Property Visit',
+                'start': visit.visit_date,
+                'stop': stop_time,
+            })
+
+        return visits
+
+    @api.constrains('visit_date', 'property_id')
+    def _check_visit_time(self):
+        for record in self:
+            for visit in record.property_id.visit_ids:
+                if record.id == visit.id or record.visit_date.date() != visit.visit_date.date():
+                    continue
+                if record.visit_date - visit.visit_date < timedelta(hours=1):
+                    raise UserError("2 visits cannot have same time")

--- a/estate/models/res_users.py
+++ b/estate/models/res_users.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _name = 'res.users'
+    _inherit = ['res.users']
+
+    property_ids = fields.One2many(
+        'estate.property', 'salesperson_id', domain=[('state', 'not in', ('sold', 'cancelled'))]
+    )

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+estate.access_estate_property,access_estate_property,estate.model_estate_property,base.group_user,1,0,0,0

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,2 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 estate.access_estate_property,access_estate_property,estate.model_estate_property,base.group_user,1,1,1,1
+estate.access_estate_property_type,access_estate_property_type,estate.model_estate_property_type,base.group_user,1,1,1,1
+estate.access_estate_property_tag,access_estate_property_tag,estate.model_estate_property_tag,base.group_user,1,1,1,1
+estate.access_estate_property_offer,access_estate_property_offer,estate.model_estate_property_offer,base.group_user,1,1,1,1

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-estate.access_estate_property,access_estate_property,estate.model_estate_property,base.group_user,1,0,0,0
+estate.access_estate_property,access_estate_property,estate.model_estate_property,base.group_user,1,1,1,1

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -3,3 +3,5 @@ estate.access_estate_property,access_estate_property,estate.model_estate_propert
 estate.access_estate_property_type,access_estate_property_type,estate.model_estate_property_type,base.group_user,1,1,1,1
 estate.access_estate_property_tag,access_estate_property_tag,estate.model_estate_property_tag,base.group_user,1,1,1,1
 estate.access_estate_property_offer,access_estate_property_offer,estate.model_estate_property_offer,base.group_user,1,1,1,1
+estate.access_estate_visit,access_estate_property_visit,estate.model_estate_property_visit,base.group_user,1,1,1,1
+estate.access_estate_issue,access_estate_property_issue,estate.model_estate_property_issue,base.group_user,1,1,1,1

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+<menuitem id = "estate_menu_root" name = "Real Estate">
+    <menuitem id = "estate_menu_advertisements" name = "Advertisements">
+        <menuitem id = "estate_menu_advertisements_properties" name = "Properties" action="estate_property_action"/>
+    </menuitem>
+</menuitem>          
+</odoo>

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-<menuitem id = "estate_menu_root" name = "Real Estate">
-    <menuitem id = "estate_menu_advertisements" name = "Advertisements">
-        <menuitem id = "estate_menu_advertisements_properties" name = "Properties" action="estate_property_action"/>
+    <menuitem id = "estate_menu_root" name = "Real Estate">
+        <menuitem id = "estate_menu_advertisements" name = "Advertisements">
+            <menuitem id = "estate_menu_advertisements_properties" name = "Properties" action="estate_property_action"/>
+        </menuitem>
+        <menuitem id = "estate_menu_settings" name="Settings">
+            <menuitem id = "estate_menu_settings_type" name = "Property Types" action="estate.estate_property_type_action"/>
+            <menuitem id = "estate_menu_settings_tag" name="Property Tags" action="estate_property_tag_action"/>
+        </menuitem>
     </menuitem>
-</menuitem>          
 </odoo>

--- a/estate/views/estate_property_issue_views.xml
+++ b/estate/views/estate_property_issue_views.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="estate_property_issue_action" model="ir.actions.act_window">
+        <field name="name">Estate Property Issue</field>
+        <field name="res_model">estate.property.issue</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('property_id', '=', active_id)]</field>
+    </record>
+
+    <record id="estate_property_issue_view_form" model="ir.ui.view">
+        <field name="name">estate.property.issue.form</field>
+        <field name="model">estate.property.issue</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <field name="state" widget="statusbar"/>
+                    <button name="action_set_resolved" type="object" string="Mark as Resolved"/>
+                    <button name="action_set_cancelled" type="object" string="Mark as Cancelled"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="property_id"/>
+                            <field name="reported_by"/>
+                            <field name="assigned_to"/>
+                            <field name="issue_type"/>
+                        </group>
+                        <group>
+                            <field name="priority" widget="priority"/>
+                            <field name="create_date" string="Reported Date"/>
+                            <field name="resolved_date"/>
+                            <field name="is_overdue"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Other Info">
+                            <group>
+                                <field name="description"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_issue_view_list" model="ir.ui.view">
+        <field name="name">estate.property.issue.list</field>
+        <field name="model">estate.property.issue</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+                <field name="property_id"/>
+                <field name="priority" widget="priority"/>
+                <field name="state"/>
+                <field name="issue_type"/>
+                <field name="assigned_to"/>
+            </list>
+        </field>
+    </record>
+
+</odoo>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="estate_property_offer_action" model="ir.actions.act_window">
+        <field name="name">Offers</field>
+        <field name="res_model">estate.property.offer</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('property_type_id', '=', active_id)]</field>
+    </record>
+
     <record id="estate_property_offer_view_list" model="ir.ui.view">
         <field name="name">estate.property.offer.list</field>
         <field name="model">estate.property.offer</field>
         <field name="arch" type="xml">
-            <list>
+            <list editable="bottom" decoration-danger="status=='refused'" decoration-success="status=='accepted'">
                 <field name="price"/>
                 <field name="partner_id"/>
+                <field name="property_type_id"/>
                 <field name="validity" width="100"/>
                 <field name="date_deadline"/>
-                <button name="action_accepted" type="object" string="Accept" icon="fa-check"/>
-                <button name="action_refused" type="object" string="Refuse" icon="fa-times"/>
-                <field name="status"/>
+                <button name="action_accepted" type="object" string="Accept" icon="fa-check" invisible="status != False"/>
+                <button name="action_refused" type="object" string="Refuse" icon="fa-times" invisible="status != False"/>
             </list>
         </field>
     </record>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -17,8 +17,8 @@
                 <field name="property_type_id"/>
                 <field name="validity" width="100"/>
                 <field name="date_deadline"/>
-                <button name="action_accepted" type="object" string="Accept" icon="fa-check" invisible="status != False"/>
-                <button name="action_refused" type="object" string="Refuse" icon="fa-times" invisible="status != False"/>
+                <button name="action_offer_accepted" type="object" string="Accept" icon="fa-check" invisible="status != False"/>
+                <button name="action_offer_refused" type="object" string="Refuse" icon="fa-times" invisible="status != False"/>
             </list>
         </field>
     </record>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- List View-->
     <record id="estate_property_offer_view_list" model="ir.ui.view">
         <field name="name">estate.property.offer.list</field>
         <field name="model">estate.property.offer</field>
@@ -8,12 +7,13 @@
             <list>
                 <field name="price"/>
                 <field name="partner_id"/>
+                <field name="validity" width="100"/>
+                <field name="date_deadline"/>
                 <field name="status"/>
             </list>
         </field>
     </record>
 
-    <!-- Form View -->
     <record id="estate_property_offer_view_form" model="ir.ui.view">
         <field name="name">estate.property.offer.form</field>
         <field name="model">estate.property.offer</field>
@@ -22,7 +22,9 @@
                 <group>
                     <field name="price"/>
                     <field name="partner_id"/>
+                    <field name="validity"/>
                     <field name="status"/>
+                    <field name="date_deadline"/>
                 </group>
             </form>
         </field>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -9,6 +9,8 @@
                 <field name="partner_id"/>
                 <field name="validity" width="100"/>
                 <field name="date_deadline"/>
+                <button name="action_accepted" type="object" string="Accept" icon="fa-check"/>
+                <button name="action_refused" type="object" string="Refuse" icon="fa-times"/>
                 <field name="status"/>
             </list>
         </field>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- List View-->
+    <record id="estate_property_offer_view_list" model="ir.ui.view">
+        <field name="name">estate.property.offer.list</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="price"/>
+                <field name="partner_id"/>
+                <field name="status"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="estate_property_offer_view_form" model="ir.ui.view">
+        <field name="name">estate.property.offer.form</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="price"/>
+                    <field name="partner_id"/>
+                    <field name="status"/>
+                </group>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -5,4 +5,15 @@
         <field name="res_model">estate.property.tag</field>
         <field name="view_mode">list,form</field>
     </record>
+
+    <record id="estate_property_tag_view_list" model="ir.ui.view">
+        <field name="name">estate.property.tag.list</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="name"/>
+                <field name="color" widget="color_picker"/>
+            </list>
+        </field>
+    </record>
 </odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="estate_property_tag_action" model="ir.actions.act_window">
+        <field name="name">Estate Property Tag</field>
+        <field name="res_model">estate.property.tag</field>
+        <field name="view_mode">list,form</field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="estate_property_type_action" model="ir.actions.act_window">
+        <field name="name">Estate Property Types</field>
+        <field name="res_model">estate.property.type</field>
+        <field name="view_mode">list,form</field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -5,4 +5,44 @@
         <field name="res_model">estate.property.type</field>
         <field name="view_mode">list,form</field>
     </record>
+
+    <record id="estate_property_type_view_form" model="ir.ui.view">
+        <field name="name">estate.property.type.form</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="%(estate.estate_property_offer_action)d" type="action" class="oe_stat_button" icon="fa-money" string="Offers">
+                            <field name="offer_count" widget="statinfo" string="Offers"/>
+                        </button>
+                    </div>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                    <group>
+                        <field name="property_ids">
+                            <list>
+                                <field name="name"/>
+                                <field name="expected_price"/>
+                                <field name="state"/>
+                            </list>
+                        </field>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_type_view_list" model="ir.ui.view">
+        <field name="name">estate.property.type.list</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="offer_count"/>
+            </list>
+        </field>
+    </record>
 </odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <record id="estate_property_action" model="ir.actions.act_window">
+        <field name="name">Test action</field>
+        <field name="res_model">estate.property</field>
+        <field name="view_mode">list,form</field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -55,6 +55,11 @@
                     <field name="state" widget="statusbar" statusbar_visible="new,offer_received,offer_accepted,sold"/>
                 </header>
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="%(estate_property_issue_action)d" type="action" class="oe_stat_button" icon="fa-edit" string="Issues">
+                            <field name="issue_count" widget="statinfo" string="Issues"/>
+                        </button>
+                    </div>
                     <h1>
                         <field name="name"/>
                     </h1>
@@ -95,6 +100,9 @@
                                 <field name="salesperson_id"/>
                                 <field name="buyer_id"/>
                             </group>
+                        </page>
+                        <page string="Visits">
+                            <field name="visit_ids"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="estate_property_action" model="ir.actions.act_window">
-        <field name="name">Test action</field>
+        <field name="name">Estate Property</field>
         <field name="res_model">estate.property</field>
         <field name="view_mode">list,form</field>
     </record>
 
-    <!-- List View -->
     <record id="estate_property_view_list" model="ir.ui.view">
         <field name="name">estate.property.list</field>
         <field name="model">estate.property</field>
@@ -25,7 +24,6 @@
         </field>
     </record>
 
-    <!-- Search View-->
     <record id="estate_property_view_search" model="ir.ui.view">
         <field name="name">estate.property.search</field>
         <field name="model">estate.property</field>
@@ -38,13 +36,12 @@
                 <field name="living_area"/>
                 <field name="facades"/>
                 <field name="property_type_id"/>
-                <filter name="state" string="Status" domain="['|', ('state', '=', 'New'), ('state', '=', 'Offer Received')]"/>
+                <filter name="state" string="Status" domain="[('state', 'in', ('new', 'offer_received'))]"/>
                 <filter name="groupby_postcode" string="Postcode" context="{'group_by': 'postcode'}"/>
             </search>
         </field>
     </record>
 
-    <!-- Form View -->
     <record id="estate_property_view_form" model="ir.ui.view">
         <field name="name">estate.property.form</field>
         <field name="model">estate.property</field>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -67,8 +67,6 @@
                             <field name="expected_price"/>
                             <field name="best_price"/>
                             <field name="selling_price"/>
-                            <field name="buyer_id"/>
-                            <field name="salesperson_id"/>
                         </group>
                     </group>
                     <notebook>
@@ -89,6 +87,12 @@
                         </page>
                         <page string="Offers">
                             <field name="offer_ids"/>
+                        </page>
+                        <page string="Other Info">
+                            <group>
+                                <field name="salesperson_id"/>
+                                <field name="buyer_id"/>
+                            </group>
                         </page>
                     </notebook>
                 </sheet>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="estate_property_action" model="ir.actions.act_window">
         <field name="name">Test action</field>
@@ -5,13 +6,16 @@
         <field name="view_mode">list,form</field>
     </record>
 
-    <record id="estate_property_list_view" model="ir.ui.view">
-        <field name="name">estate_property.list</field>
+    <!-- List View -->
+    <record id="estate_property_view_list" model="ir.ui.view">
+        <field name="name">estate.property.list</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <list>
                 <field name="name" width="200"/>
                 <field name="postcode" width="80"/>
+                <field name="property_type_id"/>
+                <field name="property_tags_ids" widget="many2many_tags" width="300"/>
                 <field name="bedrooms"/>
                 <field name="living_area"/>
                 <field name="expected_price"/>
@@ -21,24 +25,47 @@
         </field>
     </record>
 
+    <!-- Search View-->
+    <record id="estate_property_view_search" model="ir.ui.view">
+        <field name="name">estate.property.search</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <field name="postcode"/>
+                <field name="expected_price"/>
+                <field name="bedrooms"/>
+                <field name="living_area"/>
+                <field name="facades"/>
+                <field name="property_type_id"/>
+                <filter name="state" string="Status" domain="['|', ('state', '=', 'New'), ('state', '=', 'Offer Received')]"/>
+                <filter name="groupby_postcode" string="Postcode" context="{'group_by': 'postcode'}"/>
+            </search>
+        </field>
+    </record>
 
-    <record id="estate_property_form_view" model="ir.ui.view">
-        <field name="name">estate_property.form</field>
+    <!-- Form View -->
+    <record id="estate_property_view_form" model="ir.ui.view">
+        <field name="name">estate.property.form</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <form>
                 <sheet>
                     <h1>
-                            <field name="name"/>
+                        <field name="name"/>
                     </h1>
                     <group>
                         <group>
+                            <field name="property_tags_ids" widget="many2many_tags"/>
                             <field name="postcode"/>
                             <field name="date_availability"/>
+                            <field name="property_type_id"/>
                         </group>
                         <group>
                             <field name="expected_price"/>
                             <field name="selling_price"/>
+                            <field name="buyer_id"/>
+                            <field name="salesperson_id"/>
                         </group>
                     </group>
                     <notebook>
@@ -55,6 +82,9 @@
                                 <field name="garden_area" invisible="not has_garden"/>
                                 <field name="garden_orientation" invisible="not has_garden"/>
                             </group>
+                        </page>
+                        <page string="Offers">
+                            <field name="offer_ids"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -3,7 +3,7 @@
     <record id="estate_property_action" model="ir.actions.act_window">
         <field name="name">Estate Property</field>
         <field name="res_model">estate.property</field>
-        <field name="view_mode">list,form</field>
+        <field name="view_mode">list,form,kanban</field>
         <field name="context">{'search_default_available_properties':1}</field>
     </record>
 
@@ -101,4 +101,34 @@
             </form>
         </field>
     </record>
+
+    <record id="estate_property_view_kanban" model="ir.ui.view">
+        <field name="name">estate.property.kanban</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="property_type_id">
+                <field name="state"/>
+                <templates>
+                    <t t-name="card">
+                        <main>
+                            <div>
+                                <field name="name"/>
+                                <div>
+                                    Expected Price : <field name="expected_price"/>
+                                </div>
+                                <div t-if="'offer_ids'">
+                                    Best Price : <field name="best_price"/>
+                                </div>
+                                <div t-if="record.state.raw_value == 'offer_accepted'">
+                                    Selling Price : <field name="selling_price"/>
+                                </div>
+                                <field name="property_tags_ids"/>
+                            </div>
+                        </main>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
 </odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -47,6 +47,10 @@
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                    <button name="action_property_sold" string="Sold" type="object"/>
+                    <button name="action_property_cancelled" string="Cancel" type="object"/>
+                </header>
                 <sheet>
                     <h1>
                         <field name="name"/>
@@ -57,6 +61,7 @@
                             <field name="postcode"/>
                             <field name="date_availability"/>
                             <field name="property_type_id"/>
+                            <field name="state"/>
                         </group>
                         <group>
                             <field name="expected_price"/>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -63,6 +63,7 @@
                         </group>
                         <group>
                             <field name="expected_price"/>
+                            <field name="best_price"/>
                             <field name="selling_price"/>
                             <field name="buyer_id"/>
                             <field name="salesperson_id"/>
@@ -81,6 +82,7 @@
                                 <field name="has_garden"/>
                                 <field name="garden_area" invisible="not has_garden"/>
                                 <field name="garden_orientation" invisible="not has_garden"/>
+                                <field name="total_area"/>
                             </group>
                         </page>
                         <page string="Offers">

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -4,13 +4,14 @@
         <field name="name">Estate Property</field>
         <field name="res_model">estate.property</field>
         <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_available_properties':1}</field>
     </record>
 
     <record id="estate_property_view_list" model="ir.ui.view">
         <field name="name">estate.property.list</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
-            <list>
+            <list decoration-muted="state == 'sold'" decoration-success="state != 'sold' and (offer_ids or state == 'offer_accepted')" decoration-bf="state == 'offer_accepted'">
                 <field name="name" width="200"/>
                 <field name="postcode" width="80"/>
                 <field name="property_type_id"/>
@@ -19,7 +20,7 @@
                 <field name="living_area"/>
                 <field name="expected_price"/>
                 <field name="selling_price"/>
-                <field name="date_availability"/>
+                <field name="date_availability" optional="hide"/>
             </list>
         </field>
     </record>
@@ -33,11 +34,12 @@
                 <field name="postcode"/>
                 <field name="expected_price"/>
                 <field name="bedrooms"/>
-                <field name="living_area"/>
+                <field name="living_area" filter_domain="[('living_area', '>=', self)]"/>
                 <field name="facades"/>
                 <field name="property_type_id"/>
                 <filter name="state" string="Status" domain="[('state', 'in', ('new', 'offer_received'))]"/>
                 <filter name="groupby_postcode" string="Postcode" context="{'group_by': 'postcode'}"/>
+                <filter name="available_properties" string="Available" domain="[('state', 'not in', ('cancelled', 'sold'))]"/>
             </search>
         </field>
     </record>
@@ -48,8 +50,9 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <button name="action_property_sold" string="Sold" type="object"/>
-                    <button name="action_property_cancelled" string="Cancel" type="object"/>
+                    <button name="action_property_sold" string="Sold" type="object" invisible="state in ('sold', 'cancelled')"/>
+                    <button name="action_property_cancelled" string="Cancel" type="object" invisible="state in ('sold', 'cancelled')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="new,offer_received,offer_accepted,sold"/>
                 </header>
                 <sheet>
                     <h1>
@@ -57,11 +60,10 @@
                     </h1>
                     <group>
                         <group>
-                            <field name="property_tags_ids" widget="many2many_tags"/>
+                            <field name="property_tags_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field name="postcode"/>
                             <field name="date_availability"/>
-                            <field name="property_type_id"/>
-                            <field name="state"/>
+                            <field name="property_type_id" options="{'no_create': True}"/>
                         </group>
                         <group>
                             <field name="expected_price"/>
@@ -86,7 +88,7 @@
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids"/>
+                            <field name="offer_ids" readonly="state in ('sold','cancelled','offer_accepted')"/>
                         </page>
                         <page string="Other Info">
                             <group>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -14,10 +14,10 @@
             <list decoration-muted="state == 'sold'" decoration-success="state != 'sold' and (offer_ids or state == 'offer_accepted')" decoration-bf="state == 'offer_accepted'">
                 <field name="name" width="200"/>
                 <field name="postcode" width="80"/>
-                <field name="property_type_id"/>
+                <field name="property_type_id" optional="hide"/>
                 <field name="property_tags_ids" widget="many2many_tags" options="{'color_field': 'color'}" width="300"/>
-                <field name="bedrooms"/>
-                <field name="living_area"/>
+                <field name="bedrooms" optional="hide"/>
+                <field name="living_area" optional="hide"/>
                 <field name="expected_price"/>
                 <field name="selling_price"/>
                 <field name="date_availability" optional="hide"/>
@@ -50,8 +50,9 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <button name="action_property_sold" string="Sold" type="object" invisible="state in ('sold', 'cancelled')"/>
+                    <button name="action_set_sold_rainbow_man" string="Sold" class="btn-primary" type="object" invisible="state != 'offer_accepted'"/>
                     <button name="action_property_cancelled" string="Cancel" type="object" invisible="state in ('sold', 'cancelled')"/>
+                    <button name="action_accept_best_offer" string="Accept Best Offer" type="object" class="btn-primary" invisible="offer_ids.length &lt; 1"/>
                     <field name="state" widget="statusbar" statusbar_visible="new,offer_received,offer_accepted,sold"/>
                 </header>
                 <sheet>
@@ -63,6 +64,7 @@
                     <h1>
                         <field name="name"/>
                     </h1>
+                    <widget name="web_ribbon" title="Sold" invisible="state != 'sold'"/>
                     <group>
                         <group>
                             <field name="property_tags_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
@@ -106,6 +108,7 @@
                         </page>
                     </notebook>
                 </sheet>
+                <chatter/>
             </form>
         </field>
     </record>
@@ -114,11 +117,12 @@
         <field name="name">estate.property.kanban</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="property_type_id">
+            <kanban default_group_by="state" records_draggable="false">
                 <field name="state"/>
                 <templates>
                     <t t-name="card">
                         <main>
+                        <widget name="web_ribbon" title="Sold" invisible="state != 'sold'"/>
                             <div>
                                 <field name="name"/>
                                 <div>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -15,7 +15,7 @@
                 <field name="name" width="200"/>
                 <field name="postcode" width="80"/>
                 <field name="property_type_id"/>
-                <field name="property_tags_ids" widget="many2many_tags" width="300"/>
+                <field name="property_tags_ids" widget="many2many_tags" options="{'color_field': 'color'}" width="300"/>
                 <field name="bedrooms"/>
                 <field name="living_area"/>
                 <field name="expected_price"/>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -4,4 +4,61 @@
         <field name="res_model">estate.property</field>
         <field name="view_mode">list,form</field>
     </record>
+
+    <record id="estate_property_list_view" model="ir.ui.view">
+        <field name="name">estate_property.list</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name" width="200"/>
+                <field name="postcode" width="80"/>
+                <field name="bedrooms"/>
+                <field name="living_area"/>
+                <field name="expected_price"/>
+                <field name="selling_price"/>
+                <field name="date_availability"/>
+            </list>
+        </field>
+    </record>
+
+
+    <record id="estate_property_form_view" model="ir.ui.view">
+        <field name="name">estate_property.form</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <h1>
+                            <field name="name"/>
+                    </h1>
+                    <group>
+                        <group>
+                            <field name="postcode"/>
+                            <field name="date_availability"/>
+                        </group>
+                        <group>
+                            <field name="expected_price"/>
+                            <field name="selling_price"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description">
+                            <group>
+                                <field name="description"/>
+                                <field name="bedrooms"/>
+                                <field name="living_area"/>
+                                <field name="facades"/>
+                                <field name="has_garage"/>
+                            </group>
+                            <group>
+                                <field name="has_garden"/>
+                                <field name="garden_area" invisible="not has_garden"/>
+                                <field name="garden_orientation" invisible="not has_garden"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
 </odoo>

--- a/estate/views/estate_property_visit_views.xml
+++ b/estate/views/estate_property_visit_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="estate_property_visit_action" model="ir.actions.act_window">
+        <field name="name">Estate Property Visit</field>
+        <field name="res_model">estate.property.visit</field>
+        <field name="view_mode">list,form,calendar</field>
+        <field name="domain">[('property_id', '=', active_id)]</field>
+    </record>
+
+    <record id="estate_property_visit_view_list" model="ir.ui.view">
+        <field name="name">estate.property.visit.list</field>
+        <field name="model">estate.property.visit</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="customer_name"/>
+                <field name="visit_date"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_visit_view_form" model="ir.ui.view">
+        <field name="name">estate.property.visit.form</field>
+        <field name="model">estate.property.visit</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="customer_name"/>
+                <field name="visit_date"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_visit_view_calendar" model="ir.ui.view">
+        <field name="name">estate.property.visit.calendar</field>
+        <field name="model">estate.property.visit</field>
+        <field name="arch" type="xml">
+            <calendar string="Visit Views" mode="month" date_start="visit_date">
+                <field name="customer_name"/>
+                <field name="visit_date"/>
+            </calendar>
+        </field>
+    </record>
+
+</odoo>

--- a/estate/views/res_users_views.xml
+++ b/estate/views/res_users_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_users_form" model="ir.ui.view">
+        <field name="name">res.users.form.inherit.estate</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='preferences']" position="after">
+                <page string="Properties" name="properties">
+                    <field name="property_ids" />
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/estate_account/__init__.py
+++ b/estate_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate_account/__manifest__.py
+++ b/estate_account/__manifest__.py
@@ -1,0 +1,6 @@
+{
+    'name': 'Estate Account',
+    'author': "Ayush Khubchandani (aykhu)",
+    'license': 'LGPL-3',
+    'depends': ['estate', 'account']
+}

--- a/estate_account/models/__init__.py
+++ b/estate_account/models/__init__.py
@@ -1,0 +1,1 @@
+from . import estate_account

--- a/estate_account/models/estate_account.py
+++ b/estate_account/models/estate_account.py
@@ -1,0 +1,26 @@
+from odoo import Command, models
+
+
+class EstateAccount(models.Model):
+    _inherit = 'estate.property'
+
+    def action_property_sold(self):
+
+        super().action_property_sold()
+
+        self.env['account.move'].create([{
+            'partner_id': self.salesperson_id.id,
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [
+                Command.create({
+                'name': '6% commision',
+                'price_unit': self.selling_price * 0.06,
+                'quantity': 1,
+                }),
+                Command.create({
+                'name': 'Administrative fees',
+                'price_unit': 100,
+                'quantity': 1,
+                })
+            ]
+        }])

--- a/sale_renting_deposit/__init__.py
+++ b/sale_renting_deposit/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_renting_deposit/__manifest__.py
+++ b/sale_renting_deposit/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': 'Renting Deposit',
+    'author': "Ayush Khubchandani (aykhu)",
+    'license': 'LGPL-3',
+    'depends': ['sale_renting', 'website_sale'],
+    'data': [
+        'views/product_template_views.xml',
+        'views/res_config_settings_views.xml',
+        'views/website_sale_view.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'sale_renting_deposit/static/src/js/deposit_rental.js',
+        ],
+    },
+}

--- a/sale_renting_deposit/models/__init__.py
+++ b/sale_renting_deposit/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import res_config_settings
+from . import sale_order_lines

--- a/sale_renting_deposit/models/product_template.py
+++ b/sale_renting_deposit/models/product_template.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    deposit_required = fields.Boolean(help="Enable if this product requires deposit.")
+    deposit_amount = fields.Float(help="This specifies deposit for 1 unit of this product.")

--- a/sale_renting_deposit/models/res_config_settings.py
+++ b/sale_renting_deposit/models/res_config_settings.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    deposit_product_id = fields.Many2one(
+        "product.product",
+        string="Deposit Product",
+        config_parameter="sale_renting.deposit_product_id"
+    )

--- a/sale_renting_deposit/models/sale_order_lines.py
+++ b/sale_renting_deposit/models/sale_order_lines.py
@@ -1,0 +1,54 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    is_deposit_line = fields.Boolean(default=False)
+    deposit_origin_line_id = fields.Many2one('sale.order.line', ondelete='cascade')
+
+    def _get_line_header(self):
+        if self.is_deposit_line and self.name:
+            return self.name
+        return super()._get_line_header()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        order_lines = super().create(vals_list)
+        for line in order_lines:
+            if (line.product_id.deposit_required and not line.is_deposit_line):
+                deposit_product_param = self.env["ir.config_parameter"].sudo().get_param(
+                    "sale_renting.deposit_product_id"
+                )
+                deposit_product_id = int(deposit_product_param)
+                deposit_amount = line.product_id.deposit_amount
+                self.create({
+                    'order_id': line.order_id.id,
+                    'product_id': deposit_product_id,
+                    'product_uom_qty': line.product_uom_qty,
+                    'price_unit': deposit_amount,
+                    'name': f"Deposit for {line.product_id.name}",
+                    'is_deposit_line': True,
+                    'deposit_origin_line_id': line.id,
+                })
+        return order_lines
+
+    def write(self, vals):
+        res = super().write(vals)
+        deposit_lines = self.env['sale.order.line'].search(
+            [('deposit_origin_line_id', 'in', self.ids)]
+        )
+        for line in self:
+            if line.is_deposit_line:
+                continue
+            deposit_line = deposit_lines.filtered(
+                lambda l: l.deposit_origin_line_id == line
+            )
+            if not deposit_line:
+                continue
+            deposit_line.write({
+                'product_uom_qty': line.product_uom_qty,
+                'price_unit': line.product_id.deposit_amount,
+                'name': f"Deposit for {line.product_id.name}",
+            })
+        return res

--- a/sale_renting_deposit/static/src/js/deposit_rental.js
+++ b/sale_renting_deposit/static/src/js/deposit_rental.js
@@ -1,0 +1,18 @@
+document.addEventListener('change', function (ev) {
+    const input = ev.target;
+    if (!input.matches('.js_main_product input[name="add_qty"]')) {
+        return;
+    }
+    const productEl = input.closest('.js_product');
+    const depositEl = productEl?.querySelector('.o_deposit_wrapper');
+    if (!depositEl) {
+        return;
+    }
+    const depositUnit = parseFloat(depositEl.dataset.depositUnit) || 0;
+    const quantity = parseFloat(input.value) || 0;
+    const total = (depositUnit * quantity).toFixed(2);
+    const target = depositEl.querySelector('.o_deposit_amount_value');
+    if (target) {
+        target.textContent = total;
+    }
+});

--- a/sale_renting_deposit/views/product_template_views.xml
+++ b/sale_renting_deposit/views/product_template_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="product_template_inherit_view_form_stock_rental_deposit" model="ir.ui.view">
+        <field name="name">product.template.inherit.stock.rental</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="sale_renting.product_template_form_view_rental"/>
+        <field name="arch" type="xml">
+            <group name="extra_rental" position="inside">
+                <field name="deposit_required"/>
+                <field name="deposit_amount" invisible="not deposit_required"/>
+            </group>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_renting_deposit/views/res_config_settings_views.xml
+++ b/sale_renting_deposit/views/res_config_settings_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.rental</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="10"/>
+        <field name="inherit_id" ref="sale_renting.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@name='rental_delay_costs']" position="inside">
+                <div class="row mt8">
+                    <label for="deposit_product_id" class="col-lg-3 o_light_label"/>
+                    <field name="deposit_product_id" class="col-lg-2"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_renting_deposit/views/website_sale_view.xml
+++ b/sale_renting_deposit/views/website_sale_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <template id="product_template_inherit" inherit_id="website_sale.cta_wrapper">
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
+            <t t-if="product.deposit_required">
+                <div class="mt-3 p-2 o_deposit_wrapper" t-att-data-deposit-unit="product.deposit_amount" t-att-data-currency-symbol="product.currency_id.symbol">
+                    <div class="text-danger fw-semibold fs-6 mb-1">
+                        <strong class="fw-bold text-dark">Deposit per unit:</strong>
+                        <span class="o_deposit_amount_unit">
+                            <span t-esc="product.currency_id.symbol"/>
+                            <span t-esc="product.deposit_amount"/>
+                        </span>
+                    </div>
+                    <div class="text-danger fw-semibold fs-6">
+                        <strong class="fw-bold text-dark">Total deposit:</strong>
+                        <span class="o_deposit_amount_total">
+                            <span t-esc="product.currency_id.symbol"/>
+                            <span class="o_deposit_amount_value" t-esc="product.deposit_amount"/>
+                        </span>
+                    </div>
+                </div>
+            </t>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Rental workflows currently lack a proper way to manage security deposits, which are a common requirement for renting high-value or damage-sensitive products.

In the absence of a standard mechanism, users rely on manual workarounds such as adding extra order lines or handling deposits outside the system. This leads to inconsistent processes, higher risk of errors, and no clear link between the rented product and its associated deposit. It also impacts the website experience, as customers have no visibility of required deposits before placing an order.

This PR introduces a structured and configurable deposit mechanism to handle this scenario in a consistent and automated way across both backend and frontend flows.

**Key Changes**

- Add a global deposit product configuration in settings
- Allow defining deposit requirement and per-unit amount on products
- Automatically create and manage deposit lines on sale/rental orders
- Ensure deposit amounts stay in sync with product quantities
- Extend the behavior to the website, displaying deposit details to customers

**Result**

- Deposits are always applied when required
- No manual adjustments needed
- Clear traceability between rental items and deposits
- Improved user and customer experience

Task: Deposit in Rental App
Task ID: [6213214](https://www.odoo.com/odoo/project/18468/tasks/6213214)