### PR TITLE
[ADD] sale_mrp_modular_type: add modular types to scale BOM quantities from sales order

### DIFF
--- a/sale_mrp_modular_type/__init__.py
+++ b/sale_mrp_modular_type/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_mrp_modular_type/__manifest__.py
+++ b/sale_mrp_modular_type/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Modular Type',
+    'description': """This module adds modular type to Manufacturing orders""",
+    'author': 'aykhu',
+    'license': 'LGPL-3',
+    'depends': ['sale_management', 'sale_mrp'],
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/modular_type_wizard_views.xml',
+        'views/modular_type_views.xml',
+        'views/product_template_views.xml',
+        'views/mrp_bom_views.xml',
+        'views/sale_order_views.xml',
+    ],
+}

--- a/sale_mrp_modular_type/models/__init__.py
+++ b/sale_mrp_modular_type/models/__init__.py
@@ -1,0 +1,6 @@
+from . import modular_type
+from . import product_template
+from . import mrp_bom
+from . import stock_move
+from . import sale_order_line
+from . import sale_order_line_modular_value

--- a/sale_mrp_modular_type/models/modular_type.py
+++ b/sale_mrp_modular_type/models/modular_type.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ModularType(models.Model):
+    _name = 'modular.type'
+    _description = 'Modular Types'
+
+    name = fields.Char()

--- a/sale_mrp_modular_type/models/mrp_bom.py
+++ b/sale_mrp_modular_type/models/mrp_bom.py
@@ -1,0 +1,17 @@
+from odoo import api, fields, models
+
+
+class MrpBomLine(models.Model):
+    _inherit = 'mrp.bom.line'
+
+    modular_type_id = fields.Many2one(
+        'modular.type', domain="[('id', 'in', available_modular_type_ids)]"
+    )
+    available_modular_type_ids = fields.Many2many(
+        'modular.type', compute='_compute_available_modular_type_ids'
+    )
+
+    @api.depends('product_id')
+    def _compute_available_modular_type_ids(self):
+        for line in self:
+            line.available_modular_type_ids = line.parent_product_tmpl_id.modular_type_ids

--- a/sale_mrp_modular_type/models/product_template.py
+++ b/sale_mrp_modular_type/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    modular_type_ids = fields.Many2many('modular.type')

--- a/sale_mrp_modular_type/models/sale_order_line.py
+++ b/sale_mrp_modular_type/models/sale_order_line.py
@@ -1,0 +1,33 @@
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    has_modular_type = fields.Boolean(
+        compute='_compute_has_modular_type', store=True
+    )
+    modular_value_ids = fields.One2many(
+        'sale.order.line.modular.value', 'order_line_id'
+    )
+
+    @api.depends('product_template_id', 'product_template_id.modular_type_ids')
+    def _compute_has_modular_type(self):
+        for line in self:
+            line.has_modular_type = bool(
+                line.product_template_id.modular_type_ids
+            )
+
+    def _set_default_modular_values(self):
+        vals_list = []
+        for line in self:
+            existing_types = line.modular_value_ids.mapped('modular_type_id')
+            missing_types = line.product_template_id.modular_type_ids - existing_types
+            for modular_type in missing_types:
+                vals_list.append({
+                    'order_line_id': line.id,
+                    'modular_type_id': modular_type.id,
+                    'value': 0.0,
+                })
+        if vals_list:
+            self.env['sale.order.line.modular.value'].create(vals_list)

--- a/sale_mrp_modular_type/models/sale_order_line_modular_value.py
+++ b/sale_mrp_modular_type/models/sale_order_line_modular_value.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class SaleOrderLineModularValue(models.Model):
+    _name = 'sale.order.line.modular.value'
+    _description = 'Sale Order Line Modular Value'
+
+    order_line_id = fields.Many2one(
+        'sale.order.line', required=True, ondelete='cascade'
+    )
+    modular_type_id = fields.Many2one('modular.type', required=True)
+    value = fields.Float(help="Quantity multiplier")

--- a/sale_mrp_modular_type/models/stock_move.py
+++ b/sale_mrp_modular_type/models/stock_move.py
@@ -1,0 +1,37 @@
+from odoo import api, fields, models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    modular_type_id = fields.Many2one(
+        'modular.type', compute="_compute_modular_type", store=True
+    )
+    sale_order_line_modular_value_id = fields.Many2one('sale.order.line.modular.value')
+    base_bom_qty = fields.Float()
+
+    @api.depends('production_id.bom_id.bom_line_ids')
+    def _compute_modular_type(self):
+        for move in self:
+            mo = move.raw_material_production_id
+            move.modular_type_id = mo.bom_id.bom_line_ids.filtered(
+                lambda line: line.product_id == move.product_id).modular_type_id
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        moves = super().create(vals_list)
+        for move in moves:
+            mo = move.raw_material_production_id
+            so_line = mo.sale_line_id
+            if so_line:
+                so_line._set_default_modular_values()
+            bom_line = mo.bom_id.bom_line_ids.filtered(
+                lambda line: line.product_id == move.product_id
+            )[:1]
+            move.base_bom_qty = bom_line.product_qty * mo.product_qty
+            modular_value = so_line.modular_value_ids.filtered(
+                lambda mv: mv.modular_type_id == bom_line.modular_type_id
+            )
+            if bom_line.modular_type_id and modular_value:
+                move.product_uom_qty = move.base_bom_qty * modular_value.value
+        return moves

--- a/sale_mrp_modular_type/security/ir.model.access.csv
+++ b/sale_mrp_modular_type/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_modular_types,access_modular_types,model_modular_type,base.group_user,1,1,1,1
+access_modular_type_wizard,access_modular_type_wizard,model_modular_type_wizard,base.group_user,1,1,1,1
+access_modular_type_wizard_line,access_modular_type_wizard_line,model_modular_type_wizard_line,base.group_user,1,1,1,1
+access_sale_order_line_modular_value,access_sale_order_line_modular_value,model_sale_order_line_modular_value,base.group_user,1,1,1,1

--- a/sale_mrp_modular_type/views/modular_type_views.xml
+++ b/sale_mrp_modular_type/views/modular_type_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="modular_type_view_form" model="ir.ui.view">
+        <field name="name">modular.type.view.form</field>
+        <field name="model">modular.type</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="name"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="mrp_modular_type_action" model="ir.actions.act_window">
+        <field name="name">Modular Type</field>
+        <field name="res_model">modular.type</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_mrp_modular_type"
+        name="Modular Types"
+        parent="mrp.menu_mrp_bom"
+        action="mrp_modular_type_action"
+        sequence="30"/>
+
+</odoo>

--- a/sale_mrp_modular_type/views/mrp_bom_views.xml
+++ b/sale_mrp_modular_type/views/mrp_bom_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="mrp_bom_form_view_inherit_modular_type" model="ir.ui.view">
+        <field name="name">mrp.bom.form.modular.type</field>
+        <field name="model">mrp.bom</field>
+        <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='bom_line_ids']//list//field[@name='product_qty']" position="before">
+                <field name="modular_type_id" string="Modular Types"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_mrp_modular_type/views/product_template_views.xml
+++ b/sale_mrp_modular_type/views/product_template_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_template_form_view_inherit_modular_types" model="ir.ui.view">
+        <field name="name">product.template.form.modular.types</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_general']" position="inside">
+                <field name="modular_type_ids" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_mrp_modular_type/views/sale_order_views.xml
+++ b/sale_mrp_modular_type/views/sale_order_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="action_modular_type_wizard" model="ir.actions.act_window">
+        <field name="name">Modular Type Value</field>
+        <field name="res_model">modular.type.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <record id="sale_order_form_view_inherit_modular_types" model="ir.ui.view">
+        <field name="name">sale.order.form.modular.types</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_template_id']" position="after">
+                <button
+                    name="%(action_modular_type_wizard)d"
+                    type="action"
+                    icon="fa-flask"
+                    context="{'active_order_line_id': id}"
+                    invisible="not has_modular_type"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_mrp_modular_type/wizard/__init__.py
+++ b/sale_mrp_modular_type/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import modular_type_wizard

--- a/sale_mrp_modular_type/wizard/modular_type_wizard.py
+++ b/sale_mrp_modular_type/wizard/modular_type_wizard.py
@@ -1,0 +1,51 @@
+from odoo import api, fields, models
+
+
+class ModularTypeWizard(models.TransientModel):
+    _name = 'modular.type.wizard'
+    _description = 'Modular Type Wizard'
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        order_line = self.env['sale.order.line'].browse(
+            self.env.context.get('active_order_line_id')
+        )
+        product = order_line.product_template_id
+        res.update({
+            'product_id': product.id,
+            'wizard_line_ids': [
+                (0, 0, {'modular_type_id': mt.id, 'value': 0})
+                for mt in product.modular_type_ids
+            ]
+        })
+        return res
+
+    product_id = fields.Many2one('product.template', readonly=True)
+    wizard_line_ids = fields.One2many('modular.type.wizard.line', 'wizard_id')
+
+    def add_modular_value(self):
+        active_order_line_id = self.env.context.get('active_order_line_id')
+        for line in self.wizard_line_ids:
+            existing = self.env['sale.order.line.modular.value'].search([
+                ('order_line_id', '=', active_order_line_id),
+                ('modular_type_id', '=', line.modular_type_id.id),
+            ], limit=1)
+            if existing:
+                existing.value = line.value
+            else:
+                self.env['sale.order.line.modular.value'].create({
+                    'order_line_id': active_order_line_id,
+                    'modular_type_id': line.modular_type_id.id,
+                    'value': line.value,
+                })
+        return
+
+
+class ModularTypeWizardLine(models.TransientModel):
+    _name = 'modular.type.wizard.line'
+    _description = 'Modular Type Wizard Line'
+
+    wizard_id = fields.Many2one('modular.type.wizard')
+    modular_type_id = fields.Many2one('modular.type')
+    value = fields.Float(default=0)

--- a/sale_mrp_modular_type/wizard/modular_type_wizard_views.xml
+++ b/sale_mrp_modular_type/wizard/modular_type_wizard_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="modular_type_wizard_view_form" model="ir.ui.view">
+        <field name="name">modular.type.wizard.view.form</field>
+        <field name="model">modular.type.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="wizard_line_ids" nolabel="1">
+                    <list editable="bottom" create="false" delete="false">
+                        <field name="modular_type_id"/>
+                        <field name="value"/>
+                    </list>
+                </field>
+                <footer>
+                    <button string="Add" type="object" name="add_modular_value" class="btn-primary"/>
+                    <button string="Cancel" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
In some manufacturing scenarios, the quantity of components depends on values defined at the time of sale (e.g., number of sections, length, area). However, BOMs in Odoo are static, which makes it difficult to handle such cases cleanly.

Today, users either duplicate BOMs for each variation or manually adjust quantities after order confirmation. Both approaches are error-prone and hard to maintain.

This PR introduces modular types to address this limitation in a structured way.

**Key Changes**

- Introduce a modular type model (e.g., sections, meters, etc.)
- Allow configuring modular types on products
- Link BOM lines to a modular type, making their quantity act as a base value
- Add support to input modular values on the sales order line
- Compute final component quantities during manufacturing order creation

**Result**

- Flexible manufacturing based on sales input
- No BOM duplication
- Reduced manual work and fewer errors
- Better traceability between sales and production.

Task: Modular Types
Task ID: [6221655](https://www.odoo.com/odoo/project/18468/tasks/6221655)