### PR TITLE
[ADD] pricelist_price: add book price field based on pricelist

### DIFF
--- a/pricelist_price/__init__.py
+++ b/pricelist_price/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pricelist_price/__manifest__.py
+++ b/pricelist_price/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'pricelist_price',
+    'author': 'soham',
+    'version': "1.0",
+    'description': 'Added pricelist price',
+    'depends': ['sale_management'],
+    'license': 'LGPL-3',
+    'data': [
+        'views/account_move_line_view.xml',
+        'views/sale_order_line_view.xml'
+    ],
+    'application': True,
+    'installable': True,
+    'auto-install': True,
+}

--- a/pricelist_price/models/__init__.py
+++ b/pricelist_price/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_line
+from . import account_move_line

--- a/pricelist_price/models/account_move_line.py
+++ b/pricelist_price/models/account_move_line.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    book_price = fields.Float(
+        string="Book Price",
+        compute="_compute_book_price",
+        readonly=True
+    )
+
+    @api.depends("sale_line_ids.book_price")
+    def _compute_book_price(self):
+        for line in self:
+            if line.sale_line_ids:
+                line.book_price = line.sale_line_ids[0].book_price
+            else:
+                line.book_price = 0.0

--- a/pricelist_price/models/sale_order_line.py
+++ b/pricelist_price/models/sale_order_line.py
@@ -1,0 +1,17 @@
+from odoo import models, fields, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    book_price = fields.Float(compute="_compute_pricelist", readonly=True)
+
+    @api.depends("product_id", "product_uom_qty", "order_id.pricelist_id", "product_template_id.list_price")
+    def _compute_pricelist(self):
+        for record in self:
+            if not record.product_id:
+                record.book_price = 0.0
+            elif not record.order_id.pricelist_id:
+                record.book_price = record.product_template_id.list_price
+            else:
+                record.book_price = record.order_id.pricelist_id._get_product_price(record.product_id, record.product_uom_qty)

--- a/pricelist_price/views/account_move_line_view.xml
+++ b/pricelist_price/views/account_move_line_view.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.view.form.inherit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='quantity']" position="before">
+                <field name="book_price" invisible="move_type != 'out_invoice'"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/pricelist_price/views/sale_order_line_view.xml
+++ b/pricelist_price/views/sale_order_line_view.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="sale_order_from_pricelist" model="ir.ui.view">
+        <field name="name">sale.order.view.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list//field[@name='product_uom_qty']" position="before">
+                <field name="book_price"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Business Context
This task adds a Book Price field on Sales Order Lines and Customer Invoice Lines. The Book Price shows the original price calculated from the selected pricelist, product, and quantity, so users can compare it with the manually adjusted Unit Price.

Changes Done
Added computed Book Price field on sale.order.line.
Computed Book Price using the selected pricelist, product, and quantity.
Added Book Price field on account.move.line.
Synced invoice line Book Price from the related sale order line.
Added Book Price column in Sales Order line tree view.
Added Book Price column in Customer Invoice line tree view.

Result
Users can now see the original pricelist price on both Sales Orders and Customer Invoices, making it easier to compare the Book Price with the final Unit Price.

Task ID-6225662