### PR TITLE
[ADD] sale_zero_stock_approval: add zero stock approval control on sale orders

### DIFF
--- a/sale_zero_stock_approval/__init__.py
+++ b/sale_zero_stock_approval/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_zero_stock_approval/__manifest__.py
+++ b/sale_zero_stock_approval/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    'name': 'Sale Zero Stock Approval',
+    'description': 'Allow sale users to confirm approved zero stock sale orders',
+    'depends': ['sale_management', 'sale_stock'],
+    'author': 'aykhu',
+    'license': 'LGPL-3',
+    'data': [
+        'views/sale_order_views.xml',
+    ]
+}

--- a/sale_zero_stock_approval/models/__init__.py
+++ b/sale_zero_stock_approval/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_zero_stock_approval/models/sale_order.py
+++ b/sale_zero_stock_approval/models/sale_order.py
@@ -1,0 +1,23 @@
+from odoo import fields, models
+from odoo.exceptions import AccessError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(string="Approval", default=False)
+
+    def action_confirm(self):
+        for record in self:
+            for line in record.order_line:
+                if (
+                    not record.zero_stock_approval
+                    and not self.env.user.has_group("sales_team.group_sale_manager")
+                    and line.product_id.type == "consu"
+                    and line.product_id.is_storable
+                    and line.product_id.qty_available < line.product_uom_qty
+                ):
+                    raise AccessError(
+                        "Access denied: You are not authorized to confirm this sales order."
+                    )
+        return super().action_confirm()

--- a/sale_zero_stock_approval/views/sale_order_views.xml
+++ b/sale_zero_stock_approval/views/sale_order_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form_inherit_sale_zero_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.sale.zero.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <field name="payment_term_id" position="after">
+                <field name="zero_stock_approval" readonly="1" groups="!sales_team.group_sale_manager" />
+                <field name="zero_stock_approval" groups="sales_team.group_sale_manager" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
By default, sales users can confirm orders even when there is not enough available stock. While this provides flexibility, it can also lead to unintended commitments, stock inconsistencies, and reliance on manual validation.

This PR introduces a Zero Stock Approval mechanism to bring better control and accountability to such scenarios.

⚙️ Key Changes
Add a boolean field (zero_stock_approval) on sale orders
Restrict sales users from confirming orders with insufficient stock unless approval is granted
Allow sales managers to bypass this restriction
Make the field read-only for regular users and manageable by administrators
Extend confirmation logic to validate stock availability per order line

✅ Result
Controlled confirmation of zero-stock orders
Reduced risk of stock-related issues
Clear approval flow aligned with business rules
Improved reliability and traceability in sales operations


Task : DEV - ZERO STOCK BLOCKAGE
Task ID: [6226931](https://www.odoo.com/odoo/project/18468/tasks/6226931)