### PR TITLE
[ADD] estate, estate_account: create Real Estate and Real Estate Account modules for managing real estate business.

### DIFF
--- a/estate/__init__.py
+++ b/estate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': 'Real Estate',
+    'application': True,
+    'depends': [
+        'base',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/estate_property_offer_views.xml',
+        'views/estate_property_tag_views.xml',
+        'views/estate_property_type_views.xml',
+        'views/estate_property_views.xml',
+        'views/estate_menus.xml',
+        'views/res_users_views.xml',
+    ],
+}

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,0 +1,5 @@
+from . import estate_property
+from . import estate_property_type
+from . import estate_property_tag
+from . import estate_property_offer
+from . import res_users

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,0 +1,147 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_compare, float_is_zero
+
+class EstateProperty(models.Model):
+    _name = "estate.property"
+    _description = "It's free real estate"
+
+    # Order attributes
+    _order = "id desc"
+    
+    name = fields.Char(required=True,)
+    description = fields.Text()
+    postcode = fields.Char()
+    date_availability = fields.Date(
+        default=lambda self: fields.Date.add(fields.Date.today(), months=3),
+        copy=False,)
+    expected_price = fields.Float(required=True,)
+    selling_price = fields.Float(readonly=True, copy=False,)
+    bedrooms = fields.Integer(default=2,)
+    living_area = fields.Integer()
+    facades = fields.Integer()
+    garage = fields.Boolean()
+    garden = fields.Boolean()
+    garden_area = fields.Integer()
+    garden_orientation = fields.Selection(
+        string='Garden Orientation',
+        selection=[('north', 'North'), ('south', 'South'), ('east', 'East'), ('west', 'West'),],
+        )
+    state = fields.Selection(
+            string='State',
+            selection=[
+                ('new', 'New'),
+                ('offer_received', 'Offer Received'),
+                ('offer_accepted', 'Offer Accepted'),
+                ('sold', 'Sold'),
+                ('canceled', 'Cancelled'),
+            ],
+            default='new',
+            required=True,
+            copy=False,
+        )
+
+    # Reserved fields
+    active = fields.Boolean(default=True, string='Active',)
+
+    # Relations
+    property_type_id = fields.Many2one("estate.property.type",)
+    property_tag_ids = fields.Many2many("estate.property.tag",)
+    salesperson_id = fields.Many2one('res.users', string='Salesman', default=lambda self: self.env.user,)
+    buyer_id = fields.Many2one('res.partner', copy=False,)
+    offer_ids = fields.One2many("estate.property.offer", "property_id", string="Offers",)
+
+    # -------------------------------------------------------------------------
+    # COMPUTED FIELDS
+    # -------------------------------------------------------------------------
+    total_area = fields.Integer(
+        string="Total Area (sqm)", 
+        compute="_compute_total_area",
+    )
+
+    best_price = fields.Float(
+        string="Best Offer", 
+        compute="_compute_best_price",
+    )
+
+    # -------------------------------------------------------------------------
+    # SQL Constraints
+    # -------------------------------------------------------------------------
+    _check_expected_price = models.Constraint(
+        'CHECK(expected_price > 0)', 
+        'A property expected price must be strictly positive.',
+    )
+    
+    _check_selling_price = models.Constraint(
+        'CHECK(selling_price >= 0)', 
+        'A property selling price must be positive.',
+    )
+
+    # -------------------------------------------------------------------------
+    # COMPUTE METHODS
+    # -------------------------------------------------------------------------
+    @api.depends("living_area", "garden_area",)
+    def _compute_total_area(self,):
+        for property in self:
+            property.total_area = property.living_area + property.garden_area
+
+    @api.depends("offer_ids.price",)
+    def _compute_best_price(self,):
+        for property in self:
+            if property.offer_ids:
+                property.best_price = max(property.offer_ids.mapped("price"), default=0.0)
+            else:
+                property.best_price = 0.0
+
+    # -------------------------------------------------------------------------
+    # CONSTRAINTs METHODS
+    # -------------------------------------------------------------------------
+    @api.constrains('expected_price', 'selling_price',)
+    def _check_selling_price(self,):
+        for property in self:
+            # Selling price = 0 => Do nothing
+            if float_is_zero(property.selling_price, precision_digits=2):
+                continue
+
+            minimum_price = property.expected_price * 0.90
+
+            if float_compare(property.selling_price, minimum_price, precision_digits=2) < 0:
+                raise UserError(self.env._("The selling price cannot be lower than 90% of the expected price."))
+
+    # -------------------------------------------------------------------------
+    # ONCHANGE METHODS
+    # -------------------------------------------------------------------------
+    @api.onchange("garden",)
+    def _onchange_garden(self,):
+        if self.garden:
+            self.garden_area = 10
+            self.garden_orientation = "north"
+        else:
+            self.garden_area = 0
+            self.garden_orientation = False
+
+    # -------------------------------------------------------------------------
+    # CRUD METHODS
+    # -------------------------------------------------------------------------
+    @api.ondelete(at_uninstall=False,)
+    def _unlink_except_new_or_canceled(self,):
+        for property in self:
+            if property.state not in ('new', 'canceled',):
+                raise UserError(self.env._("You can only delete properties that are New or Canceled."))
+
+    # -------------------------------------------------------------------------
+    # ACTIONS
+    # -------------------------------------------------------------------------
+    def action_sold(self,):
+        for property in self:
+            if property.state == 'canceled':
+                raise UserError(self.env._("You cannot sell a canceled property."))
+        self.state = 'sold'
+        return True
+
+    def action_cancel(self,):
+        for property in self:
+            if property.state == 'sold':
+                raise UserError(self.env._("You cannot cancel a sold property."))
+        self.state = 'canceled'
+        return True

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,0 +1,98 @@
+from datetime import timedelta
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+class EstatePropertyOffer(models.Model):
+    _name = "estate.property.offer"
+    _description = "Real Estate Property Offer"
+
+    # Order attributes
+    _order = "price desc"
+
+    price = fields.Float()
+    status = fields.Selection(
+        selection=[
+            ('accepted', 'Accepted'),
+            ('refused', 'Refused'),
+        ],
+        copy=False,
+    )
+    validity = fields.Integer(default=7,)
+    date_deadline = fields.Date(
+        compute="_compute_date_deadline",
+        inverse="_inverse_date_deadline",
+    )
+    partner_id = fields.Many2one("res.partner", required=True,)
+    property_id = fields.Many2one("estate.property", required=True,)
+    property_type_id = fields.Many2one(
+        "estate.property.type",
+        related="property_id.property_type_id",
+        string="Property Type",
+        store=True,
+    )
+
+    # -------------------------------------------------------------------------
+    # CONSTRAINTS
+    # -------------------------------------------------------------------------
+    _check_price = models.Constraint(
+        'CHECK(price > 0)', 
+        'An offer price must be strictly positive.',
+    )
+
+    @api.depends("create_date", "validity",)
+    def _compute_date_deadline(self,):
+        for offer in self:
+            base_date = (offer.create_date or fields.Datetime.now()).date()
+            offer.date_deadline = base_date + timedelta(days=offer.validity,)
+
+    def _inverse_date_deadline(self,):
+        for offer in self:
+            base_date = (offer.create_date or fields.Datetime.now()).date()
+            if offer.date_deadline:
+                offer.validity = (offer.date_deadline - base_date).days
+
+    # -------------------------------------------------------------------------
+    # CRUD methods
+    # -------------------------------------------------------------------------
+    @api.model_create_multi
+    def create(self, vals_list,):
+        for vals in vals_list:
+            property_record = self.env['estate.property'].browse(vals['property_id'])
+            
+            if property_record.offer_ids:
+                best_price = max(property_record.offer_ids.mapped('price'))
+                if vals.get('price', 0) < best_price:
+                    raise UserError(self.env._("You cannot create an offer with a price lower than the current best offer."))
+            
+            property_record.state = 'offer_received'
+            
+        return super().create(vals_list)
+
+    # -------------------------------------------------------------------------
+    # ACTIONS
+    # -------------------------------------------------------------------------
+    def action_accept(self,):
+        for offer in self:
+            if offer.property_id.state in ('sold', 'canceled',):
+                raise UserError(self.env._("You cannot accept an offer on a sold or canceled property."))
+            
+            if offer.property_id.offer_ids.filtered(lambda o: o.status == "accepted"):
+                raise UserError(self.env._("An offer has already been accepted for this property."))
+            
+            offer.status = 'accepted'
+            offer.property_id.selling_price = offer.price
+            offer.property_id.buyer_id = offer.partner_id
+            
+            other_offers = offer.property_id.offer_ids - offer
+            other_offers.status = 'refused'
+            
+        return True
+            
+    def action_refuse(self,):
+        for offer in self:
+            if offer.property_id.state in ('sold', 'canceled',):
+                raise UserError(self.env._("You cannot refuse an offer on a sold or canceled property."))
+                
+        self.status = 'refused'
+        
+        return True

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -1,0 +1,19 @@
+from odoo import fields, models
+
+class EstatePropertyTag(models.Model):
+    _name = "estate.property.tag"
+    _description = "Property's tag"
+     
+    # Order attributes
+    _order = "name"
+
+    name = fields.Char(required=True,)
+    color = fields.Integer(string="Color",)
+
+    # -------------------------------------------------------------------------
+    # CONSTRAINTS
+    # -------------------------------------------------------------------------
+    _unique_tag_name = models.Constraint(
+        'UNIQUE(name)', 
+        'A property tag name must be unique.',
+    )

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,0 +1,48 @@
+from odoo import api, fields, models
+
+class EstatePropertyType(models.Model):
+    _name = "estate.property.type"
+    _description = "Property's type"
+    
+    # Order attributes
+    _order = "sequence, name"
+
+    name = fields.Char(required=True,)
+
+    sequence = fields.Integer(string="Sequence", default=1, help="Used to order stages. Lower is better.",)
+
+    # Relations
+    property_ids = fields.One2many(
+        "estate.property", 
+        "property_type_id", 
+        string="Properties",
+    )
+
+    offer_ids = fields.One2many(
+        "estate.property.offer", 
+        "property_type_id", 
+        string="Offers",
+    )
+
+    # -------------------------------------------------------------------------
+    # COMPUTED FIELDS
+    # -------------------------------------------------------------------------
+    offer_count = fields.Integer(
+        string="Offers Count", 
+        compute="_compute_offer_count",
+    )
+
+
+    # -------------------------------------------------------------------------
+    # CONSTRAINTS
+    # -------------------------------------------------------------------------
+    _unique_type_name = models.Constraint(
+        'UNIQUE(name)', 
+        'A property type name must be unique.',
+    )
+
+
+    @api.depends('offer_ids')
+    def _compute_offer_count(self):
+        for property_type in self:
+            property_type.offer_count = len(property_type.offer_ids)

--- a/estate/models/res_users.py
+++ b/estate/models/res_users.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    property_ids = fields.One2many(
+        "estate.property",
+        "salesperson_id", 
+        string="Properties",
+        domain=[('state', 'in', ['new', 'offer_received'])]
+    )

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+estate.access_estate_property,access_estate_property,estate.model_estate_property,base.group_user,1,1,1,1
+estate.access_estate_property_type,access_estate_property_type,estate.model_estate_property_type,base.group_user,1,1,1,1
+estate.access_estate_property_tag,access_estate_property_tag,estate.model_estate_property_tag,base.group_user,1,1,1,1
+estate.access_estate_property_offer,access_estate_property_offer,estate.model_estate_property_offer,base.group_user,1,1,1,1

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<odoo>
+    <menuitem id="estate_menu_root" name="Real Estate">
+        <menuitem id="estate_advertisements_menu" name="Advertisements">
+            <menuitem id="estate_model_menu_action" action="estate_property_action" name="Properties"/>
+        </menuitem>
+        <menuitem id="estate_settings_menu" name="Settings">
+            <menuitem id="estate_property_type_model_menu_action" action="estate_property_type_action" name="Property Types"/>
+            <menuitem id="estate_property_tag_model_menu_action" action="estate_property_tag_action" name="Property Tags"/>
+        </menuitem>
+    </menuitem>
+</odoo>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="estate_property_offer_action" model="ir.actions.act_window">
+        <field name="name">Offers</field>
+        <field name="res_model">estate.property.offer</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('property_type_id', '=', active_id)]</field>
+    </record>
+
+    <record id="estate_property_offer_view_list" model="ir.ui.view">
+        <field name="name">estate.property.offer.list</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <list string="Property Offers" 
+                editable="bottom"
+                decoration-danger="status == 'refused'" 
+                decoration-success="status == 'accepted'">
+                <field name="price"/>
+                <field name="partner_id"/>
+                <field name="validity" string="Validity (days)"/>
+                <field name="date_deadline" string="Deadline"/>
+                <button name="action_accept" type="object" title="Accept" icon="fa-check" invisible="status"/>
+                <button name="action_refuse" type="object" title="Refuse" icon="fa-times" invisible="status"/>
+                <field name="status" column_invisible="True"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_offer_view_form" model="ir.ui.view">
+        <field name="name">estate.property.offer.form</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <form string="Property Offer">
+                <sheet>
+                    <group>
+                        <field name="price"/>
+                        <field name="partner_id"/>
+                        <field name="validity" string="Validity (days)"/>
+                        <field name="date_deadline" string="Deadline"/>
+                        <field name="status"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="estate_property_tag_action" model="ir.actions.act_window">
+        <field name="name">Property Tag</field>
+        <field name="res_model">estate.property.tag</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <record id="estate_property_tag_view_list" model="ir.ui.view">
+        <field name="name">estate.property.tag.list</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <list string="Property Tags" editable="bottom">
+                <field name="name"/>
+                <field name="color" widget="color_picker"/>
+            </list>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="estate_property_type_action" model="ir.actions.act_window">
+        <field name="name">Property Types</field>
+        <field name="res_model">estate.property.type</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <record id="estate_property_type_view_list" model="ir.ui.view">
+        <field name="name">estate.property.type.list</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <list string="Property Types">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_type_view_form" model="ir.ui.view">
+        <field name="name">estate.property.type.form</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <form string="Property Type">
+                <sheet>
+
+                    <div class="oe_button_box" name="button_box">
+                        <button name="%(estate_property_offer_action)d" 
+                                type="action" 
+                                class="oe_stat_button" 
+                                icon="fa-money">
+                            <field name="offer_count" string="Offers" widget="statinfo"/>
+                        </button>
+                    </div>
+
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name"/>
+                        </h1>
+                    </div>
+                    
+                    <notebook>
+                        <page string="Properties">
+                            <field name="property_ids">
+                                <list string="Properties">
+                                    <field name="name" string="Title"/>
+                                    <field name="expected_price"/>
+                                    <field name="state" string="Status"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="estate_property_action" model="ir.actions.act_window">
+        <field name="name">Properties</field>
+        <field name="res_model">estate.property</field>
+        <field name="view_mode">kanban,list,form</field>
+
+        <field name="context">{'search_default_available': True}</field>
+    </record>
+    
+    <record id="estate_property_view_list" model="ir.ui.view">
+        <field name="name">estate.property.list</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <list string="Properties"
+                decoration-success="state in ('offer_received', 'offer_accepted')" 
+                decoration-bf="state == 'offer_accepted'" 
+                decoration-muted="state == 'sold'">
+                <field name="name" string="Title"/>
+                <field name="property_type_id"/>
+                <field name="property_tag_ids" widget="many2many_tags"/>
+                <field name="postcode"/>
+                <field name="bedrooms"/>
+                <field name="living_area" string="Living Area (sqm)"/>
+                <field name="expected_price"/>
+                <field name="selling_price"/>
+                <field name="date_availability" string="Available From" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_view_form" model="ir.ui.view">
+        <field name="name">estate.property.form</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <form string="Property">
+                <header>
+                    <button name="action_sold" type="object" string="Sold" invisible="state in ('sold', 'canceled')"/>
+                    <button name="action_cancel" type="object" string="Cancel" invisible="state in ('sold', 'canceled')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="new,offer_received,offer_accepted,sold"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Property Title"/>
+                        </h1>
+                    </div>
+                    <div>
+                    <field name="property_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags..."/>
+                    </div>
+                    <separator/>
+
+                    <group>
+                        <group>
+                            <field name="property_type_id" options="{'no_create': True, 'no_open': True}"/>
+                            <field name="postcode"/>
+                            <field name="date_availability" string="Available From"/>
+                        </group>
+                        <group>
+                            <field name="expected_price"/>
+                            <field name="best_price"/>
+                            <field name="selling_price"/>
+                        </group>
+                    </group>
+
+                    <notebook>
+                        <page string="Description">
+                            <group>
+                                <field name="description"/>
+                                <field name="bedrooms"/>
+                                <field name="living_area" string="Living Area (sqm)"/>
+                                <field name="facades"/>
+                                <field name="garage"/>
+                                <field name="garden"/>
+                                <field name="garden_area" string="Garden Area (sqm)" invisible="not garden"/>
+                                <field name="garden_orientation" invisible="not garden"/>
+                                <field name="total_area"/>
+                            </group>
+                        </page>
+                        <page string="Offers">
+                            <field name="offer_ids" readonly="state in ('offer_accepted', 'sold', 'canceled')"/>
+                        </page>
+                        <page string="Other Info">
+                            <group>
+                                <field name="salesperson_id"/>
+                                <field name="buyer_id"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_view_kanban" model="ir.ui.view">
+        <field name="name">estate.property.view.kanban</field>
+            <field name="model">estate.property</field>
+            <field name="arch" type="xml">
+            <kanban default_group_by="property_type_id" records_draggable="false">
+                <field name="state"/>
+                
+                <templates>
+                    <t t-name="card">
+                        <div>
+                            <strong><field name="name"/></strong>
+                        </div>
+                        
+                        <div>
+                            Expected Price: <field name="expected_price"/>
+                        </div>
+                        
+                        <div t-if="record.state.raw_value == 'offer_received'">
+                            Best Price: <field name="best_price"/>
+                        </div>
+                        
+                        <div t-if="record.state.raw_value == 'offer_accepted' or record.state.raw_value == 'sold'">
+                            Selling Price: <field name="selling_price"/>
+                        </div>
+                        
+                        <div class="mt-2">
+                            <field name="property_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="estate_property_view_search" model="ir.ui.view">
+        <field name="name">estate.property.search</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <search string="Properties">
+                <field name="name" string="Title"/>
+                <field name="property_type_id"/>
+                <field name="postcode"/>
+                <field name="expected_price"/>
+                <field name="bedrooms"/>
+                <field name="living_area" string="Living Area (sqm)" filter_domain="[('living_area', '>=', self)]"/>
+                <field name="facades"/>
+                <separator/>
+                
+                <filter string="Available" name="available" domain="['|', ('state', '=', 'new'), ('state', '=', 'offer_received')]"/>
+                
+                <group>
+                    <filter string="Postcode" name="group_by_postcode" context="{'group_by':'postcode'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/estate/views/res_users_views.xml
+++ b/estate/views/res_users_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_users_view_form_inherit_estate" model="ir.ui.view">
+        <field name="name">res.users.view.form.inherit.estate</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            
+            <notebook position="inside">
+                <page string="Real Estate Properties">
+                    <field name="property_ids"/>
+                </page>
+            </notebook>
+            
+        </field>
+    </record>
+</odoo>

--- a/estate_account/__init__.py
+++ b/estate_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate_account/__manifest__.py
+++ b/estate_account/__manifest__.py
@@ -1,0 +1,7 @@
+{
+    "name": "Real Estate Accounting",
+    "depends": [
+        "estate",
+        "account",
+    ],
+}

--- a/estate_account/models/__init__.py
+++ b/estate_account/models/__init__.py
@@ -1,0 +1,1 @@
+from . import estate_property

--- a/estate_account/models/estate_property.py
+++ b/estate_account/models/estate_property.py
@@ -1,0 +1,30 @@
+from odoo import models
+
+
+class EstateProperty(models.Model):
+    _inherit = "estate.property"
+
+
+    def action_sold(self):
+        res = super().action_sold()
+ 
+        for property in self:
+            self.env["account.move"].create(
+                {
+                    "partner_id": property.buyer_id.id,
+                    "move_type": "out_invoice",
+                    "invoice_line_ids": [
+                        Command.create({
+                            'name': '6% Commission on Sales',
+                            'quantity': 1,
+                            'price_unit': property.selling_price * 0.06,
+                        }),
+                        Command.create({
+                            'name': 'Administrative Fees',
+                            'quantity': 1,
+                            'price_unit': 100.00,
+                        }),
+                    ],
+                }
+            )
+        return res


### PR DESCRIPTION
PROBLEM
Odoo does not have a built-in module to handle real estate properties, track buyer offers, or manage the property sales pipeline.

GOAL
Create Real Estate module and Real Estate Account modules to manage properties from the moment they hit the market until the final sale and invoice.

SOLUTION
Added Real Estate and Real Estate Account modules

task-6229482