### PR TITLE
[ADD] estate, estate_account: modules for managing real estate businesses

### DIFF
--- a/awesome_owl/static/src/playground.js
+++ b/awesome_owl/static/src/playground.js
@@ -1,5 +1,13 @@
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 
 export class Playground extends Component {
     static template = "awesome_owl.playground";
+
+    setup() {
+        this.state = useState({ value: 0 });
+    }
+
+    increment() {
+        this.state.value++
+    }
 }

--- a/awesome_owl/static/src/playground.xml
+++ b/awesome_owl/static/src/playground.xml
@@ -2,9 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="awesome_owl.playground">
-        <div class="p-3">
-            hello world
-        </div>
+        <p>Counter: <t t-esc="state.value"/></p>
+        <button class="btn btn-primary" t-on-click="increment">Increment</button>
     </t>
 
 </templates>

--- a/estate/__init__.py
+++ b/estate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Real Estate",
+    "application": True,
+    "depends": ["base"],
+    "author": "Odoo S.A.",
+    "license": "LGPL-3",
+    "data": [
+        "security/ir.model.access.csv",
+        "views/estate_property_views.xml",
+        "views/estate_property_type_views.xml",
+        "views/estate_property_tag_views.xml",
+        "views/estate_property_offer_views.xml",
+        "views/estate_menus.xml",
+        "views/res_users_views.xml",
+    ],
+}

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -1,0 +1,5 @@
+from . import estate_property
+from . import estate_property_offer
+from . import estate_property_tag
+from . import estate_property_type
+from . import res_users

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,0 +1,132 @@
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools.float_utils import float_compare, float_is_zero
+
+
+class EstateProperty(models.Model):
+    _name = "estate.property"
+    _description = "Estate Property"
+    _order = "id desc"
+
+    name = fields.Char(string="Title", required=True)
+    description = fields.Text()
+    postcode = fields.Char()
+    date_availability = fields.Date(
+        string="Available From",
+        copy=False,
+        default=fields.Date.today() + relativedelta(days=3),
+    )
+    expected_price = fields.Float(required=True)
+    selling_price = fields.Float(readonly=True, copy=False)
+    bedrooms = fields.Integer(default=2)
+    living_area = fields.Integer(string="Living Area (sqm)")
+    facades = fields.Integer()
+    garages = fields.Boolean()
+    garden = fields.Boolean()
+    garden_area = fields.Integer(string="Garden Area (sqm)")
+    garden_orientation = fields.Selection(
+        selection=[
+            ("north", "North"),
+            ("south", "South"),
+            ("east", "East"),
+            ("west", "West"),
+        ],
+    )
+    active = fields.Boolean(default=True)
+    state = fields.Selection(
+        readonly=False,
+        selection=[
+            ("new", "New"),
+            ("offer_received", "Offer Received"),
+            ("offer_accepted", "Offer Accepted"),
+            ("sold", "Sold"),
+            ("canceled", "Canceled"),
+        ],
+        string="Status",
+        default="new",
+        required=True,
+    )
+    type_id = fields.Many2one("estate.property.type", string="Property Type")
+    buyer_id = fields.Many2one("res.partner", string="Buyer", copy=False, readonly=True)
+    salesperson_id = fields.Many2one(
+        "res.users",
+        string="Salesman",
+        default=lambda self: self.env.user,
+    )
+    tag_ids = fields.Many2many("estate.property.tag", string="Tags")
+    offer_ids = fields.One2many("estate.property.offer", "property_id", string="Offers")
+    total_area = fields.Integer(compute="_compute_total_area")
+    best_price = fields.Float(compute="_compute_best_price")
+
+    _check_expected_price = models.Constraint(
+        "CHECK(expected_price > 0)",
+        "A property expected price should be strictly positive.",
+    )
+
+    _check_selling_price = models.Constraint(
+        "CHECK(selling_price >= 0)", "A property selling price should be positive."
+    )
+
+    @api.depends("living_area", "garden_area")
+    def _compute_total_area(self):
+        for record in self:
+            record.total_area = record.living_area + record.garden_area
+
+    @api.depends("offer_ids.price")
+    def _compute_best_price(self):
+        for record in self:
+            record.best_price = (
+                max(record.offer_ids.mapped("price")) if record.offer_ids else 0
+            )
+
+    @api.constrains("selling_price", "expected_price")
+    def _check_selling_price(self):
+        for record in self:
+            if not float_is_zero(record.selling_price, precision_digits=2):
+                if (
+                    float_compare(
+                        record.selling_price,
+                        0.9 * record.expected_price,
+                        precision_digits=2,
+                    )
+                    < 0
+                ):
+                    raise ValidationError(
+                        _(
+                            "The selling price must be at least 90% of the expected price"
+                        )
+                    )
+
+    @api.onchange("garden")
+    def _onchange_garden(self):
+        if self.garden:
+            self.garden_area = 10
+            self.garden_orientation = "north"
+        else:
+            self.garden_area = 0
+            self.garden_orientation = None
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_new_or_canceled(self):
+        if any(record.state == "new" or record.state == "canceled" for record in self):
+            raise UserError(_("Can't delete a new or canceled property."))
+
+    def action_set_sold(self):
+        for record in self:
+            if record.state == "canceled":
+                raise UserError(_("Canceled properties cannont be sold."))
+            if not any(offer.status == "accepted" for offer in record.offer_ids):
+                raise UserError(
+                    _("You can't sell a property with no accepted offers on it")
+                )
+            record.state = "sold"
+        return True
+
+    def action_set_canceled(self):
+        for record in self:
+            if record.state == "sold":
+                raise UserError(_("Sold properties cannont be canceled."))
+            record.state = "canceled"
+        return True

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,0 +1,87 @@
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class EstatePropertyOffer(models.Model):
+    _name = "estate.property.offer"
+    _description = "Estate Property Offer"
+    _order = "price desc"
+
+    price = fields.Float()
+    status = fields.Selection(
+        selection=[("accepted", "Accepted"), ("refused", "Refused")],
+        copy=False,
+    )
+    partner_id = fields.Many2one("res.partner", required=True)
+    property_id = fields.Many2one("estate.property", required=True)
+    validity = fields.Integer(default=7, string="Validity (days)")
+    date_deadline = fields.Date(
+        compute="_compute_date_deadline",
+        inverse="_inverse_date_deadline",
+        string="Deadline",
+    )
+    property_type_id = fields.Many2one(
+        string="Property Type",
+        related="property_id.type_id",
+        store=True,
+    )
+
+    _check_price = models.Constraint(
+        "CHECK(price > 0)", "An offer price should be strictly positive."
+    )
+
+    @api.depends("create_date", "validity")
+    def _compute_date_deadline(self):
+        for record in self:
+            record.date_deadline = (
+                fields.Date.to_date(record.create_date) or fields.Date.today()
+            ) + relativedelta(days=record.validity)
+
+    def _inverse_date_deadline(self):
+        for record in self:
+            delta = record.date_deadline - (
+                fields.Date.to_date(record.create_date) or fields.Date.today()
+            )
+            record.validity = delta.days
+
+    @api.model
+    def create(self, vals_list):
+        properties = self.env["estate.property"].browse(
+            [vals["property_id"] for vals in vals_list]
+        )
+        properties_by_id = {prop.id: prop for prop in properties}
+        for vals in vals_list:
+            property = properties_by_id.get(vals["property_id"])
+            best_price = property.best_price
+            if property.state == "sold":
+                raise UserError(_("You can't create an offer for a sold property."))
+            if vals["price"] < best_price:
+                raise UserError(
+                    _(
+                        "You can't create an offer with a lower amount than an existing offer."
+                    )
+                )
+            property.state = "offer_received"
+        return super().create(vals_list)
+
+    def action_set_accepted(self):
+        states = self.property_id.offer_ids.mapped("status")
+        for record in self:
+            if "accepted" in states:
+                raise UserError(_("An offer has already been accepted."))
+            record.status = "accepted"
+            record.property_id.buyer_id = record.partner_id
+            record.property_id.selling_price = record.price
+            record.property_id.state = "offer_accepted"
+        return True
+
+    def action_set_refused(self):
+        for record in self:
+            previous_status = record.status
+            record.status = "refused"
+            if previous_status == "accepted":
+                record.property_id.buyer_id = None
+                record.property_id.selling_price = 0
+        return True

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class EstatePropertyTag(models.Model):
+    _name = "estate.property.tag"
+    _description = "Estate Property Tag"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    color = fields.Integer()
+
+    _check_unique_name = models.Constraint(
+        "UNIQUE(name)", "A property tag name should be unique."
+    )

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,0 +1,27 @@
+from odoo import api, fields, models
+
+
+class EstatePropertyType(models.Model):
+    _name = "estate.property.type"
+    _description = "Estate Property Type"
+    _order = "sequence,name"
+
+    name = fields.Char(required=True)
+    property_ids = fields.One2many("estate.property", "type_id", string="Properties")
+    sequence = fields.Integer()
+    offer_ids = fields.One2many(
+        "estate.property.offer",
+        "property_type_id",
+        string="Offers",
+    )
+    offer_count = fields.Integer(compute="_compute_offer_count")
+
+    _check_unique_name = models.Constraint(
+        "UNIQUE(name)", "A property tag name should be unique."
+    )
+
+    @api.depends("offer_ids")
+    def _compute_offer_count(self):
+        for record in self:
+            record.offer_count = len(record.offer_ids)
+        return True

--- a/estate/models/res_users.py
+++ b/estate/models/res_users.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    property_ids = fields.One2many(
+        "estate.property",
+        "salesperson_id",
+        domain="['|', ('state', '=', 'new'), ('state', '=', 'offer_received')]",
+        string="Real Estate Properties",
+    )

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_estate_property,access_estate_property,model_estate_property,base.group_user,1,1,1,1
+access_estate_property_type,access_estate_property_type,model_estate_property_type,base.group_user,1,1,1,1
+access_estate_property_tag,access_estate_property_tag,model_estate_property_tag,base.group_user,1,1,1,1
+access_estate_property_offer,access_estate_property_offer,model_estate_property_offer,base.group_user,1,1,1,1

--- a/estate/tests/__init__.py
+++ b/estate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_property_offer

--- a/estate/tests/test_property_offer.py
+++ b/estate/tests/test_property_offer.py
@@ -1,0 +1,75 @@
+from odoo.exceptions import UserError
+from odoo.tests import Form, tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class EstatePropertyTestCase(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.buyer = cls.env["res.partner"].create({"name": "Test Buyer"})
+        cls.property_type = cls.env["estate.property.type"].create(
+            {"name": "Test Type"}
+        )
+        cls.property = cls.env["estate.property"].create(
+            {
+                "name": "Test Property",
+                "type_id": cls.property_type.id,
+                "expected_price": 100000,
+            }
+        )
+
+    def test_create_offer_for_sold_property(self):
+        self.property.state = "sold"
+        with self.assertRaises(UserError):
+            self.env["estate.property.offer"].create(
+                {
+                    "property_id": self.property.id,
+                    "partner_id": self.buyer.id,
+                    "price": 90000,
+                }
+            )
+
+    def test_sell_with_no_accepted_offers(self):
+        self.env["estate.property.offer"].create(
+            {
+                "property_id": self.property.id,
+                "partner_id": self.buyer.id,
+                "price": 90000,
+            }
+        )
+        with self.assertRaises(UserError):
+            self.property.action_set_sold()
+
+    def test_sell_successful(self):
+        offer = self.env["estate.property.offer"].create(
+            {
+                "property_id": self.property.id,
+                "partner_id": self.buyer.id,
+                "price": 90000,
+            }
+        )
+        self.assertEqual(self.property.state, "offer_received")
+        offer.action_set_accepted()
+        self.assertEqual(self.property.state, "offer_accepted")
+        self.property.action_set_sold()
+        self.assertEqual(self.property.state, "sold")
+
+    def test_garden_fields_reset_on_uncheck(self):
+        with Form(self.property) as property_form:
+            property_form.garden = True
+            self.assertEqual(
+                property_form.garden_area,
+                10,
+            )
+            self.assertEqual(
+                property_form.garden_orientation,
+                "north",
+            )
+            property_form.garden = False
+            self.assertEqual(
+                property_form.garden_area,
+                0,
+            )
+            self.assertFalse(property_form.garden_orientation)

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<odoo>
+    <menuitem id="estate_property_menu_root" name="Real Estate">
+        <menuitem id="estate_property_menu" name="Advertisements">
+            <menuitem id="estate_property_menu_action" action="estate_property_action"/>
+        </menuitem>
+        <menuitem id="estate_settings_menu" name="Settings">
+            <menuitem id="estate_property_type_menu_action" action="estate_property_type_action"/>
+            <menuitem id="estate_property_tag_menu_action" action="estate_property_tag_action"/>
+        </menuitem>
+    </menuitem>
+</odoo>

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="estate_property_offer_view_form" model="ir.ui.view">
+        <field name="name">estate.property.offer.form</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <form string="Property Type">
+                <sheet>
+                    <group>
+                        <field name="price"/>
+                        <field name="partner_id"/>
+                        <field name="validity"/>
+                        <field name="date_deadline"/>
+                        <field name="status"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_offer_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.offer.list</field>
+        <field name="model">estate.property.offer</field>
+        <field name="arch" type="xml">
+            <list string="Offer" editable="top" decoration-danger="status == 'refused'" decoration-success="status == 'accepted'">
+                <field name="price"/>
+                <field name="partner_id"/>
+                <field name="validity"/>
+                <field name="date_deadline"/>
+                <button name="action_set_accepted" string="Accept" type="object" icon="fa-check" invisible="status"/>
+                <button name="action_set_refused" string="Refuse" type="object" icon="fa-times" invisible="status"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_offer_action" model="ir.actions.act_window">
+        <field name="name">Property Offers</field>
+        <field name="res_model">estate.property.offer</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('property_type_id', '=', active_id)]</field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="estate_property_tag_view_form" model="ir.ui.view">
+        <field name="name">estate.property.tag.form</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <form string="Property Tag">
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name"/></h1>
+                    </div>
+                    <group>
+                        <field name="color" widget="color_picker"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_tag_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.tag.list</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <list string="Tag" editable="top">
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_tag_action" model="ir.actions.act_window">
+        <field name="name">Property Tags</field>
+        <field name="res_model">estate.property.tag</field>
+        <field name="view_mode">list,form</field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="estate_property_type_view_form" model="ir.ui.view">
+        <field name="name">estate.property.type.form</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <form string="Property Type">
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" name="%(estate.estate_property_action)d" type="action" icon="fa-list">
+                            <div class="o_stat_info">
+                                <field name="offer_count" widget="statinfo" string="Offers"/>
+                            </div>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <h1><field name="name"/></h1>
+                    </div>
+                    <notebook>
+                        <page string="Properties">
+                            <field name="property_ids">
+                                <list>
+                                    <field name="name"/>
+                                    <field name="expected_price"/>
+                                    <field name="state"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_type_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.type.list</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <list string="Type">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="offer_count"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_type_action" model="ir.actions.act_window">
+        <field name="name">Property Types</field>
+        <field name="res_model">estate.property.type</field>
+        <field name="view_mode">list,form</field>
+    </record>
+</odoo>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="estate_property_view_search" model="ir.ui.view">
+        <field name="name">estate.property.search</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <search string="Search Properties">
+                <field name="name"/>
+                <field name="postcode"/>
+                <field name="expected_price"/>
+                <field name="bedrooms"/>
+                <field name="living_area" filter_domain="[('living_area', '&gt;=', self)]"/>
+                <field name="facades"/>
+                <filter name="available" string="Available" domain="['|',('state', '=', 'new'),('state', '=', 'offer_received')]"/>
+                <filter name="group_by_postcode" context="{'group_by': 'postcode'}"/>
+            </search>
+        </field>
+    </record>
+    
+    <record id="estate_property_view_form" model="ir.ui.view">
+        <field name="name">estate.property.form</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <form string="Property">
+                <header>
+                    <button type="object" name="action_set_sold" string="Sold" invisible="state=='canceled' or state =='sold'"/>
+                    <button type="object" name="action_set_canceled" string="Cancel" invisible="state=='canceled' or state =='sold'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="new,offer_received,offer_accepted,sold"/>
+                </header>
+                <sheet>
+                    <div class="oe_title mb-2">
+                        <h1><field name="name"/></h1>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="type_id" options="{'no_create':True, 'no_create_edit':True, 'no_quick_create': True}"/>
+                            <field name="postcode"/>
+                            <field name="date_availability"/>
+                        </group>
+                        <group>
+                            <field name="expected_price"/>
+                            <field name="best_price"/>
+                            <field name="selling_price"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description">
+                            <group>
+                                <field name="description"/>
+                                <field name="bedrooms"/>
+                                <field name="living_area"/>
+                                <field name="facades"/>
+                                <field name="garages"/>
+                                <field name="garden"/>
+                                <field name="garden_area" invisible="not garden"/>
+                                <field name="garden_orientation" invisible="not garden"/>
+                                <field name="total_area"/>
+                            </group>
+                        </page>
+                        <page string="Offers">
+                            <field name="offer_ids" readonly="state == 'offer_accepted' or state == 'sold' or state == 'canceled'"/>
+                        </page>
+                        <page string="Other Info">
+                            <group>
+                                <field name="salesperson_id"/>
+                                <field name="buyer_id"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="estate_property_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.list</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <list string="Property" decoration-success="state == 'offer_received' or state == 'offer_accepted'" decoration-bf="state == 'offer_accepted'" decoration-muted="state == 'sold'">
+                <field name="name"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                <field name="postcode"/>
+                <field name="bedrooms"/>
+                <field name="living_area"/>
+                <field name="expected_price"/>
+                <field name="selling_price"/>
+                <field name="date_availability" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="estate_property_view_kanban" model="ir.ui.view">
+        <field name="name">estate.property.kanban</field>
+        <field name="model">estate.property</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="type_id" records_draggable="false">
+                <field name="state" />
+                <templates>
+                    <t t-name="card">
+                        <div>
+                            <field name="name" class="fw-bold fs-5"/>
+                            <div>
+                                Expected Price: <field name="expected_price"/>
+                            </div>
+                            <div>
+                                <t t-if="record.state.raw_value == 'offer_received'">
+                                    Best price: <field name="best_price"/>
+                                </t>
+                                <t t-if="record.state.raw_value == 'offer_accepted'">
+                                    Selling price: <field name="selling_price"/>
+                                </t>
+                            </div>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="estate_property_action" model="ir.actions.act_window">
+        <field name="name">Properties</field>
+        <field name="res_model">estate.property</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="context">{'search_default_available': True}</field>
+    </record>
+</odoo>

--- a/estate/views/res_users_views.xml
+++ b/estate/views/res_users_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<odoo>
+<data>
+    <record id="res_users_view_form" model="ir.ui.view">
+        <field name="name">res.users.view.form.inherit.estate</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Real Estate Properties">
+                    <field name="property_ids"/>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</data>
+</odoo>

--- a/estate_account/__init__.py
+++ b/estate_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/estate_account/__manifest__.py
+++ b/estate_account/__manifest__.py
@@ -1,0 +1,6 @@
+{
+    "name": "Property Invoicing",
+    "depends": ["estate", "account"],
+    "author": "Odoo S.A.",
+    "license": "LGPL-3",
+}

--- a/estate_account/models/__init__.py
+++ b/estate_account/models/__init__.py
@@ -1,0 +1,1 @@
+from . import estate_property

--- a/estate_account/models/estate_property.py
+++ b/estate_account/models/estate_property.py
@@ -1,0 +1,31 @@
+from odoo import Command, models
+
+
+class EstateProperty(models.Model):
+    _inherit = "estate.property"
+
+    def action_set_sold(self):
+        for record in self:
+            self.env["account.move"].create(
+                {
+                    "partner_id": record.buyer_id.id,
+                    "move_type": "out_invoice",
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": f"Commission for {record.name}",
+                                "quantity": 1.0,
+                                "price_unit": record.selling_price * 0.06,
+                            }
+                        ),
+                        Command.create(
+                            {
+                                "name": "Administrative Fees",
+                                "quantity": 1.0,
+                                "price_unit": 100.00,
+                            }
+                        ),
+                    ],
+                }
+            )
+        return super().action_set_sold()


### PR DESCRIPTION
Problem:
No existing module for managing real estate businesses.

Solution:
2 new modules : "estate" and "estate_account".
The main module "estate" allows property management with Kanban, List and Form views. Types, tags and offers can be added/assigned to a property. The flow is managed through automatic state changes when offers are received/accepted.
Additionnaly, the module "estate_account" allows automatic invoice creation when a property is sold.

Task-6229416