### PR TITLE
Feature: Implement Zero Stock Approval on Sales Orders

### DIFF
--- a/sale_zero_stock/__init__.py
+++ b/sale_zero_stock/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_zero_stock/__manifest__.py
+++ b/sale_zero_stock/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    "name": "sale_zero_stock",
+    "depends": ["sale"],
+    "category": "sale",
+    "installable": True,
+    "application": True,
+    "data": ["views/sale_zero_stock.xml"],
+    "author": "RADHR",
+    "license": "LGPL-3",
+}

--- a/sale_zero_stock/models/__init__.py
+++ b/sale_zero_stock/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_zero_stock

--- a/sale_zero_stock/models/sale_zero_stock.py
+++ b/sale_zero_stock/models/sale_zero_stock.py
@@ -1,0 +1,23 @@
+from odoo import fields, models, api
+from odoo.exceptions import UserError
+
+
+class SaleZeroStock(models.Model):
+    _inherit = "sale.order"
+
+    zero_stock_approval = fields.Boolean(string="Zero Stock Approval")
+    access_user = fields.Boolean(compute="_compute_has_access")
+
+    @api.depends_context("uid")
+    def _compute_has_access(self):
+
+        has_user_access = self.env.user._is_admin()
+        for record in self:
+            record.access_user = not has_user_access
+
+    def action_confirm(self):
+        for order in self:
+            if not order.zero_stock_approval:
+                raise UserError("Please confirm the zero stock approval")
+
+        return super().action_confirm()

--- a/sale_zero_stock/views/sale_zero_stock.xml
+++ b/sale_zero_stock/views/sale_zero_stock.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="sale_order_zero_stock_view_form" model="ir.ui.view">
+        <field name="name">sale.zero.stock.view.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"></field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name=&apos;payment_term_id&apos;]" position="after">
+                <field name="zero_stock_approval" readonly="access_user"></field>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR introduces a control workflow to manage Sales Orders. By adding a dedicated validation field, authorized personnel can bypass standard constraints to confirm zero-stock orders.

- Access rights have been stratified to maintain organizational security:
- Sales Administrators can grant or modify approval.
- Standard Sales Users can view the approval status but cannot alter it.