### PR TITLE
[ADD] zero_stock_sale_approval: add zero stock approval field on sale order

### DIFF
--- a/zero_stock_sale_approval/__init__.py
+++ b/zero_stock_sale_approval/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_stock_sale_approval/__manifest__.py
+++ b/zero_stock_sale_approval/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    'name': 'Sale Zero Stock Approval',
+    'description': 'Grant permission to confirm approved orders without stock.',
+    'depends': ['sale_management', 'sale_stock'],
+    'author': 'moahi',
+    'license': 'LGPL-3',
+    'data': [
+        'views/sale_order_views.xml',
+    ]
+}

--- a/zero_stock_sale_approval/models/__init__.py
+++ b/zero_stock_sale_approval/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_zero_stock

--- a/zero_stock_sale_approval/models/sale_zero_stock.py
+++ b/zero_stock_sale_approval/models/sale_zero_stock.py
@@ -1,0 +1,23 @@
+from odoo import fields, models
+from odoo.exceptions import AccessError
+
+
+class SaleZeroStock(models.Model):
+    _inherit = 'sale.order'
+
+    zero_stock_approval = fields.Boolean(string="Approval by Manager", default=False)
+
+    def action_confirm(self):
+        for record in self:
+            for item in record.order_line:
+                if (
+                    not record.zero_stock_approval
+                    and not self.env.user.has_group("sales_team.group_sale_manager")
+                    and item.product_id.type == "consu"
+                    and item.product_id.is_storable
+                    and item.product_id.qty_available < item.product_uom_qty
+                ):
+                    raise AccessError(
+                        "Access denied: You are not allowed to confirm this sales order."
+                    )
+        return super().action_confirm()

--- a/zero_stock_sale_approval/views/sale_order_views.xml
+++ b/zero_stock_sale_approval/views/sale_order_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="sale_zero_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.sale.zero.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        
+        <field name="arch" type="xml">
+
+            <field name="payment_term_id" position="after">
+                <field name="zero_stock_approval" readonly="1" groups="!sales_team.group_sale_manager"/>
+                <field name="zero_stock_approval" groups="sales_team.group_sale_manager"/>
+            </field>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Sales users were able to confirm orders even when stock was not available. This could lead to wrong commitments, stock issues, and lack of proper control.

Introduced a zero stock approval mechanism in sale orders. Added a Boolean field zero_stock_approval to control confirmation behavior.

- Created a new module for zero stock approval
- Added zero_stock_approval field in sale.order model
- Restricted field editing to Admin/Sales Manager only
- Updated action_confirm to validate stock before confirming
- Blocked confirmation when stock is insufficient unless approval is enabled
- Extended sale order form view to display the new field