### PR TITLE
[IMP] mrp_bom_overview: clean forecast view with consolidated status …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+/shop

--- a/mrp_bom_overview_forecast/__init__.py
+++ b/mrp_bom_overview_forecast/__init__.py
@@ -1,0 +1,1 @@
+from .import models

--- a/mrp_bom_overview_forecast/__manifest__.py
+++ b/mrp_bom_overview_forecast/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "bom_overview",
+    "version": "1.0",
+    "depends": ["mrp"],
+    "author": "vikvi",
+    "category": "Tutorials",
+    "license": "LGPL-3",
+    'installable': True,
+    "assets": {
+        "web.assets_backend": [
+            "mrp_bom_overview_forecast/static/src/**/*",
+        ],
+    },
+}

--- a/mrp_bom_overview_forecast/models/__init__.py
+++ b/mrp_bom_overview_forecast/models/__init__.py
@@ -1,0 +1,1 @@
+from .import mrp_bom_report

--- a/mrp_bom_overview_forecast/models/mrp_bom_report.py
+++ b/mrp_bom_overview_forecast/models/mrp_bom_report.py
@@ -1,0 +1,15 @@
+from odoo import models, _
+
+
+class Mrp_Bom_Report(models.AbstractModel):
+    _inherit = 'report.mrp.report_bom_structure'
+
+    def _get_bom_data(self, *args, **kwargs):
+        result = super()._get_bom_data(*args, **kwargs)
+        if result.get('level') == 0:
+            qty = int(result.get('producible_qty') or 0)
+            if qty > 0:
+                result["status"] = _("%(qty)s Ready To Produce", qty=qty)
+            else:
+                result["status"] = _("No Ready To Produce")
+        return result

--- a/mrp_bom_overview_forecast/static/src/bom_forecast.js
+++ b/mrp_bom_overview_forecast/static/src/bom_forecast.js
@@ -1,0 +1,34 @@
+import { patch } from "@web/core/utils/patch";
+import { BomOverviewLine } from "@mrp/components/bom_overview_line/mrp_bom_overview_line";
+
+
+patch(BomOverviewLine.prototype, {
+    get status() {
+        let ready_to_produce = this.data.producible_qty ? this.data.producible_qty > 0 : false;
+
+        if (this.data.hasOwnProperty('components_available') && this.data.status && ready_to_produce) {
+            return this.data.status;
+        }
+        if (!ready_to_produce && this.data.availability_display) {
+            return this.data.availability_display;
+        }
+        if (this.data.availability_display) {
+            return this.data.availability_display;
+        }
+
+        return "Not Available";
+    },
+    get statusStyleClass() {
+        let ready_to_produce = this.data.producible_qty ? this.data.producible_qty > 0 : false;
+
+        if (!this.status || this.status == "Not Available") return "text-bg-danger";
+        if (this.status && (ready_to_produce || this.status === "Available")) {
+            return "bg-success text-white fw-bold";
+        }
+        if (this.status && this.status.includes("Estimated")) return "text-bg-warning";
+        if (this.status && !ready_to_produce) {
+            return "bg-dark text-white fw-bold";
+        }
+        return "text-bg-danger";
+    }
+})

--- a/mrp_bom_overview_forecast/static/src/bom_forecast.xml
+++ b/mrp_bom_overview_forecast/static/src/bom_forecast.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mrp.BomoverviewforecastHeader" t-inherit="mrp.BomOverviewTable" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('d-flex', 'mb-5')]" position="replace"/>
+        <xpath expr="//div[hasclass('o_mrp_bom_report_page')]" position="attributes">
+            <attribute name="class">o_mrp_bom_report_page py-3 py-lg-2 px-0 overflow-auto border-bottom bg-view</attribute>
+        </xpath>
+        <xpath expr="//th[@t-if='forecastMode' and @title='Reception time estimation.']" position="replace" />
+        <xpath expr="//td[@name='td_mrp_bom_f']/following-sibling::td[@t-if='forecastMode'][3]" position="replace"/>
+        <xpath expr="//td[@name='td_mrp_bom_b']/following-sibling::td[@t-if='forecastMode'][3]" position="replace"/>
+    </t>
+
+    <t t-name="mrp.BomoverviewforecastLine" t-inherit="mrp.BomOverviewLine" t-inherit-mode="extension">
+        <xpath expr="//td[@t-if='forecastMode' and .//t[@t-if=&quot;data.hasOwnProperty('availability_state')&quot; ]]" position="replace" />
+        <xpath expr="//td[@class='text-center' and .//div[hasclass('o_field_badge')]]" position="replace">
+            <td t-if="forecastMode" class="text-center">
+                <div  class="o_field_badge" role="button" t-on-click.prevent="goToForecast">
+                    <span t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusStyleClass}}" t-out="status"/>
+                </div>
+            </td>
+        </xpath>
+    </t>    
+</templates>


### PR DESCRIPTION
This PR introduces layout optimizations and workflow simplifications to the Bill of Materials structure view based on the recent design review to enhance component visibility.

Changes Introduced:

Column Removal: Removed the Availability column from headers, data row lines, and summary footers to clean up screen real estate.

Status Consolidation: Merged forecasting lead-time notes directly into the Status column whenever a component is not fully ready to produce.

UI Refinement: Updated status badges to render with green success styling exclusively when items are ready to produce.

Navigation Enhancement: Wrapped all status column tags inside interactive button links that route users directly to the respective product's stock forecast report.