### PR TITLE
[IMP] sale_zero_stock_blockage: add zero stock approval restriction o…

### DIFF
--- a/dev_zero_stock_blockage/__init__.py
+++ b/dev_zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from .import models

--- a/dev_zero_stock_blockage/__manifest__.py
+++ b/dev_zero_stock_blockage/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "dev_stock_blockage",
+    "version": "1.0",
+    "depends": ["sale"],
+    "author": "vikvi",
+    "category": "Tutorials",
+    "license": "LGPL-3",
+    'installable': True,
+    "data": [
+        'views/sale_zero_stock.xml'
+    ]
+}

--- a/dev_zero_stock_blockage/models/__init__.py
+++ b/dev_zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from .import zero_stoack_blockage

--- a/dev_zero_stock_blockage/models/zero_stoack_blockage.py
+++ b/dev_zero_stock_blockage/models/zero_stoack_blockage.py
@@ -12,9 +12,9 @@ class ZeroStock(models.Model):
             if not record.zero_stock_approval:
                 for line in record.order_line:
                     if line.product_id.qty_available <= 0:
-                        raise ValidationError(
+                        raise ValidationError(_(
                             "You cannot confirm this order because the product '%s' has zero stock. "
                             "Please ask a Sales Manager to toggle the 'Zero Stock Approval' checkbox first!"
-                            % line.product_id.name
+                            % line.product_id.name)
                         )
         return super().action_confirm()

--- a/dev_zero_stock_blockage/models/zero_stoack_blockage.py
+++ b/dev_zero_stock_blockage/models/zero_stoack_blockage.py
@@ -1,0 +1,20 @@
+from odoo import models, fields, _
+from odoo.exceptions import ValidationError
+
+
+class ZeroStock(models.Model):
+    _inherit = "sale.order"
+
+    zero_stock_approval = fields.Boolean(string="Approve", default=False)
+
+    def action_confirm(self):
+        for record in self:
+            if not record.zero_stock_approval:
+                for line in record.order_line:
+                    if line.product_id.qty_available <= 0:
+                        raise ValidationError(
+                            "You cannot confirm this order because the product '%s' has zero stock. "
+                            "Please ask a Sales Manager to toggle the 'Zero Stock Approval' checkbox first!"
+                            % line.product_id.name
+                        )
+        return super().action_confirm()

--- a/dev_zero_stock_blockage/models/zero_stoack_blockage.py
+++ b/dev_zero_stock_blockage/models/zero_stoack_blockage.py
@@ -13,8 +13,7 @@ class ZeroStock(models.Model):
                 for line in record.order_line:
                     if line.product_id.qty_available <= 0:
                         raise ValidationError(_(
-                            "You cannot confirm this order because the product '%s' has zero stock. "
-                            "Please ask a Sales Manager to toggle the 'Zero Stock Approval' checkbox first!"
-                            % line.product_id.name)
+                            "You cannot confirm this order because the product has zero stock. "
+                            "Please ask a Sales Manager to toggle the 'Zero Stock Approval' checkbox first!")
                         )
         return super().action_confirm()

--- a/dev_zero_stock_blockage/views/sale_zero_stock.xml
+++ b/dev_zero_stock_blockage/views/sale_zero_stock.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_zero_stock" model="ir.ui.view">
+        <field name="name">zero.stock.blockage</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="zero_stock_approval" readonly="1" groups="!sales_team.group_sale_manager" />
+                <field name="zero_stock_approval" groups="sales_team.group_sale_manager" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR introduces a new Zero Stock Approval workflow to prevent out-of-stock items from being processed without managerial consent.

Changes Introduced:

Field Addition: Added a boolean field zero_stock_approval to the sale.order model.

UI Access Control: Configured the view layout to make the field readonly for regular users and editable only for sales managers.

Workflow Validation: Overrode action_confirm to validate stock availability before allowing order confirmation.