### PR TITLE
[ADD] purchase: add global discount wizard for purchase orders

### DIFF
--- a/purchase_global_discount/__init__.py
+++ b/purchase_global_discount/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/purchase_global_discount/__manifest__.py
+++ b/purchase_global_discount/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Purchase Order Global Discount',
+    'version': "1.0",
+    'category': "Supply Chain/Purchase",
+    'description': "Creates a Discount Option in Purchase Order",
+    'depends': ['purchase'],
+    'data': [
+        'security/ir.model.access.csv',
+        'wizard/purchase_order_discount_views.xml',
+        'views/purchase_views.xml',
+    ],
+    'auto_install': True,
+    'author': "times",
+    'license': "LGPL-3",
+}

--- a/purchase_global_discount/models/__init__.py
+++ b/purchase_global_discount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/purchase_global_discount/models/purchase_order.py
+++ b/purchase_global_discount/models/purchase_order.py
@@ -1,0 +1,16 @@
+from odoo import _, api, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    @api.readonly
+    def action_open_discount_wizard(self):
+        self.ensure_one()
+        return {
+            'name': _("Discount"),
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.order.discount',
+            'view_mode': 'form',
+            'target': 'new',
+        }

--- a/purchase_global_discount/security/ir.model.access.csv
+++ b/purchase_global_discount/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_order_discount,access_purchase_order_discount,model_purchase_order_discount,purchase.group_purchase_manager,1,1,1,0

--- a/purchase_global_discount/views/purchase_views.xml
+++ b/purchase_global_discount/views/purchase_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="purchase_order_form_discount" model="ir.ui.view">
+        <field name="name">purchase.order.form.discount</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']" position="after">
+                <div class="d-flex justify-content-end mt-2 mb-2"
+                    name="po_button_below_order_lines">
+                    <button
+                        string="Discount"
+                        name="action_open_discount_wizard"
+                        type="object"
+                        class="btn btn-secondary"
+                    />
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/purchase_global_discount/wizard/__init__.py
+++ b/purchase_global_discount/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order_discount

--- a/purchase_global_discount/wizard/purchase_order_discount.py
+++ b/purchase_global_discount/wizard/purchase_order_discount.py
@@ -1,0 +1,33 @@
+from odoo import api, fields, models
+
+
+class PurchaseOrderDiscount(models.TransientModel):
+    _name = "purchase.order.discount"
+    _description = "Discount Wizard"
+
+    purchase_order_id = fields.Many2one(
+        'purchase.order', default=lambda self: self.env.context.get('active_id'), required=True)
+    company_id = fields.Many2one(related='purchase_order_id.company_id')
+    currency_id = fields.Many2one(related='purchase_order_id.currency_id')
+    discount_amount = fields.Monetary(string="Amount")
+    discount_percentage = fields.Float(string="Percentage")
+    discount_type = fields.Selection([
+        ('amount', "Amount (Total)"),
+        ('percentage', "Percentage"),
+    ], default='percentage')
+
+    def _get_original_total(self):
+        return sum(
+            line.price_unit * line.product_qty
+            for line in self.purchase_order_id.order_line
+        )
+
+    @api.onchange('discount_amount')
+    def _onchange_discount_amount(self):
+        original_total = self._get_original_total()
+        if original_total:
+            self.discount_percentage = (self.discount_amount / original_total)
+
+    def action_apply_discount(self):
+        self.ensure_one()
+        self.purchase_order_id.order_line.write({'discount': self.discount_percentage * 100})

--- a/purchase_global_discount/wizard/purchase_order_discount_views.xml
+++ b/purchase_global_discount/wizard/purchase_order_discount_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="purchase_order_line_wizard_form" model="ir.ui.view">
+        <field name="name">purchase.order.discount.form</field>
+        <field name="model">purchase.order.discount</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <field name="purchase_order_id" invisible="1" />
+                    <field name="company_id" invisible="1" />
+                    <field name="currency_id" invisible="1" />
+                    <div class="d-flex gap-5">
+                        <div class="col-sm-5 col-md-4 col-lg-4 col-4">
+                            <group>
+                                <label for="discount_amount" string="Discount"
+                                    invisible="discount_type != 'amount'" />
+                                <field name="discount_amount" invisible="discount_type != 'amount'"
+                                    nolabel="1" />
+                                <label for="discount_percentage"
+                                    string="Discount"
+                                    invisible="discount_type != 'percentage'" />
+                                <field name="discount_percentage"
+                                    invisible="discount_type != 'percentage'"
+                                    widget="percentage" nolabel="1" />
+                            </group>
+                        </div>
+                        <div invisible="discount_type != 'amount'">
+                            <field name="discount_percentage" class="text-muted" widget="percentage" readonly="1"/>
+                        </div>
+                        <div class="col-sm-7 col-md-8 col-lg-8 col-8">
+                            <field name="discount_type" widget="radio" />
+                        </div>
+                    </div>
+                </sheet>
+                <footer>
+                    <button type="object" string="Apply" name="action_apply_discount"
+                        class="btn btn-primary"
+                        data-hotkey="q" />
+                    <button special="cancel" string="Discard" class="btn btn-secondary"
+                        data-hotkey="x" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Introduced a transient wizard to apply an order-wide discount to purchase order lines based on an amount or percentage.

Rationale:
Purchasing teams need a fast, error-free way to distribute global vendor discounts across all order lines. Manually calculating line-level deductions is slow and prone to discrepancy. This wizard allows users to enter a fixed cash value or a total percentage, automatically deriving the relative values and updating all linked line items in bulk.

Technical choices:
- Created the 'purchase.order.discount' TransientModel to capture input without database bloat.
- Implemented an '@api.onchange' trigger utilizing a clean helper method to compute proportional percentage values dynamically when an amount is specified.
- Wrapped execution contexts using 'with_company(self.company_id)' to ensure correct multi-company record updating behavior.
- Injected an execution button cleanly under the 'order_line' field in the inherited purchase order view using precise XPath positioning.

Task Reference: 6253108