### PR TITLE
[ADD] Zero_quantity_account_move: added zero quantity for invoice lines

### DIFF
--- a/zero_quantity_account_move/__init__.py
+++ b/zero_quantity_account_move/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/zero_quantity_account_move/__manifest__.py
+++ b/zero_quantity_account_move/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    'name': 'Zero Accounting Approval',
+    'description': 'Adding the zero quantity on account move line and If it is checked the quantity would be passed as 0 in einvoicing',
+    'depends': ['l10n_in_edi'],
+    'author': 'moahi',
+    'data': [
+        'views/zero_views.xml',
+    ],
+    'license': 'LGPL-3'
+}

--- a/zero_quantity_account_move/models/__init__.py
+++ b/zero_quantity_account_move/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move_line
+from . import zero_account_move

--- a/zero_quantity_account_move/models/account_move_line.py
+++ b/zero_quantity_account_move/models/account_move_line.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ZeroAccountMove(models.Model):
+    _inherit = 'account.move.line'
+
+    zero_move = fields.Boolean(string="Is Zero Quantity", default=False)

--- a/zero_quantity_account_move/models/zero_account_move.py
+++ b/zero_quantity_account_move/models/zero_account_move.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _get_l10n_in_edi_line_details(self, index, line, line_tax_details):
+        res = super()._get_l10n_in_edi_line_details(index, line, line_tax_details)
+
+        if line.zero_move:
+            res['Qty'] = 0
+
+        return res

--- a/zero_quantity_account_move/tests/__init__.py
+++ b/zero_quantity_account_move/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_zero

--- a/zero_quantity_account_move/tests/test_zero.py
+++ b/zero_quantity_account_move/tests/test_zero.py
@@ -1,0 +1,72 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestZeroQuantityEDI(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test Customer',
+        })
+
+        self.product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'type': 'consu',
+            'list_price': 20,
+        })
+
+    def _get_tax_details(self):
+        return {
+            'tax_details': {}
+        }
+
+    def test_zero_quantity_in_edi(self):
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+        })
+
+        self.env['account.move.line'].create({
+            'move_id': move.id,
+            'product_id': self.product.id,
+            'quantity': 9,
+            'price_unit': 10,
+            'zero_move': True,
+            'name': 'Test line',
+        })
+
+        move.action_post()
+        line = move.invoice_line_ids[0]
+
+        res = move._get_l10n_in_edi_line_details(
+            1, line, self._get_tax_details()
+        )
+
+        self.assertEqual(res.get('Qty'), 0)
+
+    def test_normal_quantity_in_edi(self):
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+        })
+
+        self.env['account.move.line'].create({
+            'move_id': move.id,
+            'product_id': self.product.id,
+            'quantity': 5,
+            'price_unit': 100,
+            'zero_move': False,
+            'name': 'Test line',
+        })
+
+        move.action_post()
+        line = move.invoice_line_ids[0]
+
+        res = move._get_l10n_in_edi_line_details(
+            1, line, self._get_tax_details()
+        )
+
+        self.assertEqual(res.get('Qty'), 5)

--- a/zero_quantity_account_move/views/zero_views.xml
+++ b/zero_quantity_account_move/views/zero_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_move_form_inherit_zero_qty" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.zero.qty</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='invoice_line_ids']//list//field[@name='quantity']" position="after">
+                <field name="zero_move" optional="hide"/>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Added a boolean field 'zero_move'(Is Zero Quantity) on account move line.

For rejected or scrap goods, quantity should be sent as 0 even if a credit note is created.

* Added zero_move field in account.move.line
* Overridden EDI method to send quantity as 0 when ticked
* Added test cases for validation