### PR TITLE
[ADD] stock_picking: Repeat fields on Picking Operations Report PDF

### DIFF
--- a/stock_picking/__manifest__.py
+++ b/stock_picking/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'Custom Picking Operation Report Header',
+    'version': '1.0',
+    'category': 'Tutorial',
+    'summary': 'Picking information on multi-page PDF report header',
+    'depends': ['stock'],
+    'data': [
+        'views/report_stockpicking_operations.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'author': 'Rini Pillai',
+    'license': 'LGPL-3',
+}

--- a/stock_picking/views/report_stockpicking_operations.xml
+++ b/stock_picking/views/report_stockpicking_operations.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_stockpicking_operations_inherited" inherit_id="stock.report_picking">
+        <xpath expr="//div[hasclass('o_report_stockpicking_operations')]" position="attributes">
+            <attribute name="style">page-break-after: always;</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('o_stock_report_header_row')]" position="replace"/>
+        <xpath expr="//table/thead/tr" position="before">            
+            <tr>
+                <th class="o_report_stockpicking_operations">
+                    <div class="o_stock_report_header_row mb32 mt32">
+                        <div t-if="o.origin" name="div_origin">
+                            <strong>Order:</strong>
+                            <p t-field="o.origin">S0001</p>
+                        </div>
+                        <div name="div_warehouse">
+                            <strong>Warehouse:</strong>
+                            <div t-if="o.picking_type_id.warehouse_id.partner_id"
+                                t-field="o.picking_type_id.warehouse_id.partner_id"
+                                t-options='{"widget": "contact", "fields": ["name"], "no_marker": True}'/>
+                            <div t-else=""
+                                t-field="o.picking_type_id.warehouse_id.name"/>
+                            </div>
+                        <div t-if="o.picking_type_id.code == 'internal' and o.partner_id" class="col" name="div_contact">
+                            <strong>Contact</strong>
+                            <div t-field="o.partner_id" class="m-0"/>
+                        </div>
+                        <div name="div_state">
+                            <strong>Status:</strong>
+                            <p t-field="o.state">Draft</p>
+                        </div>
+                        <div t-if="o.user_id" name="div_operator">
+                            <strong>Operator:</strong>
+                            <p t-field="o.user_id">Mitchel Admin</p>
+                        </div>
+                        <div name="div_picking_date">
+                            <t t-if="o.state == 'done' and o.date_done">
+                                <strong>Done Date:</strong>
+                                <p t-field="o.date_done" t-options='{"widget": "date"}'>2023-09-24</p>
+                            </t>
+                            <t t-elif="o.state != 'done' and o.scheduled_date">
+                                <strong>Scheduled Date:</strong>
+                                <p t-field="o.scheduled_date" t-options='{"widget": "date"}'>2023-09-24</p>
+                            </t>
+                        </div>
+                        <div name="div_warn" t-if="o.picking_warning_text">
+                            <strong>Instructions:</strong>
+                            <div t-field="o.picking_warning_text"/>
+                        </div>
+                        <div name="div_vendor" t-if="o.picking_type_id.code=='incoming' and o.partner_id">
+                            <strong>Vendor:</strong>
+                            <div t-field="o.partner_id.commercial_partner_id"
+                                t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True, "phone_icons": True}'>
+                            </div>
+                        </div>
+                    </div>
+                </th>
+            </tr>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
### Purpose
The task requested that specific header fields remain visible on subsequent pages when a **Picking Operations PDF report** spans multiple pages. Currently, these details are only visible on the first page when the table extends to the next page.
### Changes Made
- **Template Inheritance:** Inherited the default template `stock.report_picking`.
- **Header Relocation:** Moved the `o_stock_report_header_row` elements into a `<tr>` inside the table header (`<thead>`).
- **Page Persistence:** Using standard `wkhtmltopdf` behavior, placing this data inside the `<thead>` forces the browser engine to repeat the header fields automatically on every new page break.
### Technical Details
**Model:** `stock.picking`
**Custom Template:** `report_stockpicking_operations_inherited`
### Why
- `wkhtmltopdf` repeats any content wrapped inside a `<thead>` tag at the top of every new page when a table overflows. Moving the data here solves the client's request using standard HTML behavior without the need for complex custom logic.
- Rather than rebuilding the layout this change targets the structure directly to ensure the data is present on page 2 and beyond.
### Verification Steps
1. Install **Custom Picking Operation Report Header** module from Apps.
2. Go to Inventory -> Receipts.
3. Select or create a picking record (stock.picking) with enough operations/lines to span across at least 2 pages.
4. Click Print -> Picking Operations.
5. Verify that the document fields repeat at the top of the second page exactly as they appear on the first page.