### PR TITLE
[ADD] revenue_recognition: link project start date to journal entry r…

### DIFF
--- a/revenue_recognition/__init__.py
+++ b/revenue_recognition/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/revenue_recognition/__manifest__.py
+++ b/revenue_recognition/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'Revenue Recognition Management',
+    'version': '1.0',
+    'category': 'Accounting',
+    'summary': 'Automatic revenue recognition for projects with date correction',
+    'author': 'Odoo',
+    'depends': ['project', 'sale', 'account', 'sale_project'],
+    'data': [
+        'views/project_revenue_recognition_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/revenue_recognition/models/__init__.py
+++ b/revenue_recognition/models/__init__.py
@@ -1,0 +1,1 @@
+from . import project_project

--- a/revenue_recognition/models/project_project.py
+++ b/revenue_recognition/models/project_project.py
@@ -1,0 +1,106 @@
+from odoo import models, fields, api
+
+
+class ProjectProject(models.Model):
+    _inherit = 'project.project'
+
+    has_unrecognized_entries = fields.Boolean(
+        string="Has Unrecognized Entries",
+        compute='_compute_has_unrecognized_entries',
+        store=False,
+    )
+
+    unrecognized_entries_message = fields.Char(
+        string="Unrecognized Entries Message",
+        compute='_compute_unrecognized_entries_message',
+    )
+
+    @api.depends('date_start', 'sale_order_id')
+    def _compute_has_unrecognized_entries(self):
+        for project in self:
+            project.has_unrecognized_entries = False
+
+            if not project.sale_order_id or not project.date_start:
+                continue
+
+            invoices = project.sale_order_id.invoice_ids
+
+            if not invoices:
+                continue
+
+            generated_entries = self.env['account.move'].search([
+                ('adjusting_entry_origin_move_ids', 'in', invoices.ids)
+            ])
+
+            has_current_recognition = generated_entries.filtered(
+                lambda m: m.date == project.date_start
+            )
+            project.has_unrecognized_entries = not bool(has_current_recognition)
+
+    @api.depends('has_unrecognized_entries', 'date_start')
+    def _compute_unrecognized_entries_message(self):
+        for project in self:
+            if project.has_unrecognized_entries and project.date_start:
+                project.unrecognized_entries_message = (
+                    f"You still have journal items that need to be recognised "
+                    f"from {project.date_start.strftime('%m/%d/%Y')}"
+                )
+            else:
+                project.unrecognized_entries_message = False
+
+    def _get_original_invoice_lines(self, move_lines):
+        generated_entries = move_lines.filtered(
+            lambda l: bool(l.move_id.adjusting_entry_origin_move_ids)
+        )
+
+        if not generated_entries:
+            return move_lines.filtered(
+                lambda l: l.account_id.account_type == 'income'
+            )
+
+        origin_moves = generated_entries.mapped('move_id.adjusting_entry_origin_move_ids')
+
+        invoice_lines = self.env['account.move.line'].search([
+            ('move_id', 'in', origin_moves.ids),
+            ('parent_state', '=', 'posted'),
+        ])
+
+        return invoice_lines.filtered(
+            lambda l: l.account_id.account_type == 'income'
+        )
+
+    def action_recognize_invoices(self):
+        self.ensure_one()
+
+        if not self.account_id:
+            return False
+
+        move_lines = self.env['account.move.line'].search([('parent_state', '=', 'posted')]).filtered(lambda l: l.analytic_distribution and str(self.account_id.id) in l.analytic_distribution)
+
+        original_invoice_lines = self._get_original_invoice_lines(move_lines)
+
+        if not original_invoice_lines:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'title': 'No Journal Items',
+                    'message': 'No journal items found for this project.',
+                    'type': 'warning',
+                    'sticky': False,
+                }
+            }
+
+        return {
+            'name': 'Create Automatic Entries',
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.automatic.entry.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {
+                'active_model': 'account.move.line',
+                'active_ids': original_invoice_lines.ids,
+                'project_id': self.id,
+                'default_action': 'change_period',
+            },
+        }

--- a/revenue_recognition/views/project_revenue_recognition_views.xml
+++ b/revenue_recognition/views/project_revenue_recognition_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="project_project_form_revenue_recognition" model="ir.ui.view">
+        <field name="name">project.project.form.revenue.recognition</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <field name="has_unrecognized_entries" invisible="1"/>
+                <field name="unrecognized_entries_message" invisible="1"/>
+                <div class="alert alert-info mb-3" role="alert" invisible="not has_unrecognized_entries">
+                    <i class="fa fa-info-circle me-2" title="Information"/>
+                    <field name="unrecognized_entries_message"
+                           readonly="1"
+                           nolabel="1"/>
+                </div>
+            </xpath>
+            <xpath expr="//field[@name='date_start']"
+                   position="after">
+                <button
+                    name="action_recognize_invoices"
+                    invisible="not has_unrecognized_entries"
+                    type="object"
+                    string="Recognize Invoices"
+                    icon="fa-refresh"
+                    class="btn btn-link"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/revenue_recognition/wizard/__init__.py
+++ b/revenue_recognition/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_automatic_entry_wizard

--- a/revenue_recognition/wizard/account_automatic_entry_wizard.py
+++ b/revenue_recognition/wizard/account_automatic_entry_wizard.py
@@ -1,0 +1,60 @@
+from odoo import models, fields
+
+
+class AccountAutomaticEntryWizard(models.TransientModel):
+    _inherit = 'account.automatic.entry.wizard'
+
+    date = fields.Date(
+        required=True,
+        default=lambda self: self._get_default_date(),
+        readonly=False
+    )
+
+    def do_action(self):
+        project_id = self.env.context.get('project_id')
+
+        if not project_id:
+            return super().do_action()
+
+        project = self.env['project.project'].browse(project_id)
+        invoices = project.sale_order_id.invoice_ids
+
+        draft_entries = self.env['account.move'].search([
+            ('adjusting_entry_origin_move_ids', 'in', invoices.ids),
+            ('state', '=', 'draft'),
+        ])
+
+        if not draft_entries:
+            return super().do_action()
+        latest_draft = draft_entries.sorted(key=lambda m: m.create_date, reverse=True)[:1]
+        latest_draft.write({'date': self.date})
+        old_drafts = draft_entries - latest_draft
+        if old_drafts:
+            old_drafts.unlink()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.move',
+            'res_id': latest_draft.id,
+            'view_mode': 'form',
+            'target': 'current',
+        }
+
+    def _get_default_date(self):
+        project_id = (self.env.context.get('project_id') or self.env.context.get('create_for_project_id'))
+        if project_id:
+            project = self.env['project.project'].browse(project_id)
+            if project.exists() and project.date_start:
+                return project.date_start
+        if self.env.context.get('active_model') == 'account.move.line':
+            for line in self.env['account.move.line'].browse(
+                self.env.context.get('active_ids', [])):
+                if line.analytic_distribution:
+                    for analytic_id_str in line.analytic_distribution:
+                        try:
+                            project = self.env['project.project'].search([('account_id', '=', int(analytic_id_str))], limit=1)
+                            if project and project.date_start:
+                                return project.date_start
+                        except (ValueError, TypeError):
+                            pass
+
+        return fields.Date.context_today(self)


### PR DESCRIPTION
### **Description**
This PR links the Project Start Date with the Revenue Recognition process.

**Changes**
- Added warning banner when project start date differs from invoice recognition date.
- Added "Recognize Invoices" action on projects.
- Extended Revenue Recognition wizard to update the related project's start date.
- Linked invoices to projects through Analytic Accounts (`analytic_distribution`).

**Flow**
Sale Order → Project → Analytic Account → Invoice → Revenue Recognition → Project Start Date Update

**Result**
Keeps project timelines aligned with accounting recognition dates and reduces manual adjustments.