### PR TITLE
[ADD] rental_deposit: introduce deposit mechanism for rental products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+/shop

--- a/rental_deposit/__init__.py
+++ b/rental_deposit/__init__.py
@@ -1,0 +1,1 @@
+from .import models

--- a/rental_deposit/__manifest__.py
+++ b/rental_deposit/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'rental_deposit',
+    'author': "vikvi",
+    'license': 'LGPL-3',
+    'depends': ['sale_renting'],
+    "category": "Tutorials",
+    'data': [
+        'views/product_template_view.xml',
+        'views/res_config_settings_view.xml',
+    ]
+}

--- a/rental_deposit/models/__init__.py
+++ b/rental_deposit/models/__init__.py
@@ -1,0 +1,3 @@
+from .import res_config_settings
+from .import product_template
+from .import rental_order_line

--- a/rental_deposit/models/product_template.py
+++ b/rental_deposit/models/product_template.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    is_deposit = fields.Boolean()
+    deposit_amount = fields.Float()

--- a/rental_deposit/models/rental_order_line.py
+++ b/rental_deposit/models/rental_order_line.py
@@ -1,0 +1,58 @@
+from odoo import models, fields, api
+
+
+class RentalOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    is_deposit_line = fields.Boolean(default=False)
+    linked_deposit_line_id = fields.Many2one('sale.order.line')
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        order_lines = super().create(vals_list)
+
+        for line in order_lines:
+            if (line.product_id.is_deposit and not line.is_deposit_line):
+                product_id_txt = self.env['ir.config_parameter'].sudo().get_param('sale_renting.deposit_product_id')
+                product_id = int(product_id_txt)
+                amount_to_deposit = line.product_id.deposit_amount
+
+                self.create({
+                    'product_id': product_id,
+                    'name': f"Deposit for {line.product_id.name}",
+                    'order_id': line.order_id.id,
+                    'price_unit': amount_to_deposit,
+                    'product_uom_qty': line.product_uom_qty,
+                    'is_deposit_line': True,
+                    'linked_deposit_line_id': line.id
+                })
+
+        return order_lines
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_order_line(self):
+        deposits = self.env["sale.order.line"].search(
+            [("linked_deposit_line_id", "in", self.ids)]
+        )
+        if deposits:
+            deposits.unlink()
+        return True
+
+    def write(self, vals):
+        result = super().write(vals)
+        deposit_lines = self.env['sale.order.line'].search([('linked_deposit_line_id', 'in', self.ids)])
+
+        for line in self:
+            if (line.is_deposit_line):
+                continue
+
+            filtered_deposit_line = deposit_lines.filtered(lambda d_line: d_line.linked_deposit_line_id == line)
+
+            if not filtered_deposit_line:
+                continue
+            filtered_deposit_line.write({
+                'product_uom_qty': line.product_uom_qty,
+                'price_unit': line.product_uom_qty * line.product_id.deposit_amount
+
+            })
+        return result

--- a/rental_deposit/models/res_config_settings.py
+++ b/rental_deposit/models/res_config_settings.py
@@ -1,0 +1,10 @@
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    deposit_product_id = fields.Many2one(
+        'product.product',
+        config_parameter="sale_renting.deposit_product_id"
+    )

--- a/rental_deposit/views/product_template_view.xml
+++ b/rental_deposit/views/product_template_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_rental_deposit_form_view" model="ir.ui.view">
+        <field name="name">product.template.rental.form.view</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="sale_renting.product_template_form_view_rental"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='extra_rental']" position="inside">
+                <field name="is_deposit"/>
+                <field name="deposit_amount"/>  
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/rental_deposit/views/res_config_settings_view.xml
+++ b/rental_deposit/views/res_config_settings_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="res_config_settings_deposit" model='ir.ui.view'>
+        <field name="name">res.config.settings.deposit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale_renting.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@name='rental_delay_costs']" position="inside">
+                <div class="row mt8">
+                    <label for="deposit_product_id" class="col-lg-3 o_light_label"/>
+                    <field name="deposit_product_id" class="col-lg-2"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/rental_deposit_website/__manifest__.py
+++ b/rental_deposit_website/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': 'rental_deposit_website',
+    'author': "vikvi",
+    'license': 'LGPL-3',
+    'depends': ['sale_renting', 'website_sale'],
+    "category": "Tutorials",
+    'auto_install': True,
+    'data': [
+        'views/website_cart_overview.xml',
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "rental_deposit_website/static/src/website_rental_deposit_amount.js"
+        ],
+    },
+}

--- a/rental_deposit_website/static/src/website_rental_deposit_amount.js
+++ b/rental_deposit_website/static/src/website_rental_deposit_amount.js
@@ -1,0 +1,18 @@
+document.addEventListener('change', function (event) {
+    const input = event.target;
+    if (!input.matches('input[name="add_qty"]')) {
+        return;
+    }
+    const productEl = input.closest('.js_product');
+    const depositEl = productEl?.querySelector('.deposit_div');
+    if (!depositEl) {
+        return;
+    }
+    const unit_deposit_price = parseFloat(depositEl.dataset.depositUnit) || 0;
+    const quantity = parseFloat(input.value) || 0;
+    const total = (unit_deposit_price * quantity).toFixed(2);
+    const target = depositEl.querySelector('.deposit_value');
+    if (target) {
+        target.textContent = total;
+    }
+});

--- a/rental_deposit_website/views/website_cart_overview.xml
+++ b/rental_deposit_website/views/website_cart_overview.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="product_template_inherit" inherit_id="website_sale.cta_wrapper">
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
+            <t t-if="product.is_deposit">
+                <div class="mt-3 p-2 deposit_div" t-att-data-deposit-unit="product.deposit_amount" >
+                    <div class="fw-semibold fs-6">
+                        <strong class="fw-bold text-dark"> Deposit Required:</strong>
+                        <span class="o_deposit_amount_total">
+                            <span t-esc="product.currency_id.symbol"/>
+                            <span class="deposit_value" t-esc="product.deposit_amount"/>
+                        </span>
+                    </div>
+                </div>
+            </t>
+        </xpath>
+    </template>
+    <template id="cart_lines_deposit_inherit" inherit_id="website_sale.cart_lines">
+        <xpath expr="//t[@t-foreach='website_sale_order.website_order_line']" position="inside">
+            <t t-set="deposit_param_id" t-value="request.env['ir.config_parameter'].sudo().get_param('sale_renting.deposit_product_id')"/>
+        </xpath>
+        <xpath expr="//h6[contains(@class, 'text-wrap') and contains(@class, 'mb-1')]" position="replace">
+            <h6 class="text-wrap mb-1">
+                <t t-if="deposit_param_id and line.product_id.id == int(deposit_param_id)">
+                    Deposit for <t t-out="line.linked_deposit_line_id.product_id.name"/>
+                </t>
+                <t t-else="">
+                    <t t-out="line._get_line_header()"/>
+                </t>
+            </h6>
+        </xpath>
+
+        <xpath expr="//a[hasclass('js_delete_product')]" position="attributes">
+            <attribute name="t-attf-class">{{ 'd-none' if deposit_param_id  else '' }} js_delete_product small</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Problem
Rental workflows currently lack a proper way to manage security deposits, which are a common requirement for renting high-value or damage-sensitive products. In the absence of a standard mechanism, users rely on manual workarounds such as adding extra order lines or handling deposits outside the system. This leads to inconsistent processes, higher risk of errors, and no clear link between the rented product and its associated deposit. It also impacts the website experience, as customers have no visibility of required deposits before placing an order.

Solution
This PR introduces a structured and configurable deposit mechanism to handle this scenario in a consistent and automated way across both backend and frontend flows.

Key Changes
 - Global Configuration: Added a global deposit product configuration in settings.

 - Product Controls: Allow defining deposit requirement and per-unit amount on products.

 - Automated Orders: Automatically create and manage deposit lines on sale/rental orders.

 - Quantity Sync: Ensure deposit amounts stay in sync with product quantities.

 - Website Extension: Extend the behavior to the website, displaying deposit details to customers.

Result
 - Deposits are always applied when required.

  - No manual adjustments needed.

 - Clear traceability between rental items and deposits.

 - Improved user and customer experience.