### PR TITLE
[ADD] sale_zero_stock_blockage: don't allow sales without approval

### DIFF
--- a/sale_zero_stock_blockage/__init__.py
+++ b/sale_zero_stock_blockage/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_zero_stock_blockage/__manifest__.py
+++ b/sale_zero_stock_blockage/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Sale Zero Stock Blockage",
+    "application": False,
+    "installable": True,
+    "author": "sngoh",
+    "depends": ["sale"],
+    "auto_install": True,
+    "license": "LGPL-3",
+    "data": [
+        "views/sale_order_views.xml",
+    ],
+}

--- a/sale_zero_stock_blockage/models/__init__.py
+++ b/sale_zero_stock_blockage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_zero_stock_blockage/models/sale_order.py
+++ b/sale_zero_stock_blockage/models/sale_order.py
@@ -1,0 +1,22 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    zero_stock_approval = fields.Boolean(string="Zero Stock Approval")
+    has_user_access = fields.Boolean(compute="_compute_has_user_access")
+
+    @api.depends_context("uid")
+    def _compute_has_user_access(self):
+        has_access = self.env.user._is_admin()
+        for record in self:
+            record.has_user_access = not has_access
+
+    def action_confirm(self):
+        for order in self:
+            if not order.zero_stock_approval:
+                raise UserError("Please confirm the zero stock approval")
+
+        return super().action_confirm()

--- a/sale_zero_stock_blockage/views/sale_order_views.xml
+++ b/sale_zero_stock_blockage/views/sale_order_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_order_form_view_zero_stock_blockage" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.sale.zero.stock.blockage</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='order_details'] //field[@name='payment_term_id']"
+                position="after">
+                <field name="zero_stock_approval" string="Approval" readonly="has_user_access" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
There are the case where sales person can't confirm the sale order without proper permission or the approval of the administrator. This helps them to archive that functionality, now an administrator can control which sell order should not be confirm by a sales or other use.

Project: [PSIN]INTERNSHIP ONBOARDING
Task: DEV - ZERO STOCK BLOCKAGE