### PR TITLE
[IMP] project: add revenue recognition synchronization from project start date

### DIFF
--- a/invoice_recognition_sync/__init__.py
+++ b/invoice_recognition_sync/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/invoice_recognition_sync/__init__.py
+++ b/invoice_recognition_sync/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/invoice_recognition_sync/__manifest__.py
+++ b/invoice_recognition_sync/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "Project Revenue Sync",
+    "version": "1.0",
+    "category": "Accounting",
+    "depends": [
+        "project",
+        "sale_project",
+        "sale",
+        "account",
+    ],
+    "data": [
+        "views/project_project_views.xml",
+    ],
+    'author': 'vivah',
+    'license': 'AGPL-3',
+    'sequence': 2,
+    "installable": True,
+    "application": False,
+}

--- a/invoice_recognition_sync/__manifest__.py
+++ b/invoice_recognition_sync/__manifest__.py
@@ -1,19 +1,18 @@
 {
     "name": "Project Revenue Sync",
-    "version": "1.0",
-    "category": "Accounting",
+    "version": "19.0.1.0.0",
+    "category": "Accounting/Accounting",
+    "summary": "Synchronize project start dates with revenue recognition entries",
     "depends": [
-        "project",
         "sale_project",
-        "sale",
-        "account",
+        "accountant",
     ],
     "data": [
         "views/project_project_views.xml",
     ],
-    'author': 'vivah',
-    'license': 'AGPL-3',
-    'sequence': 2,
+    "author": "vivah",
+    "license": "AGPL-3",
+    "sequence": 2,
     "installable": True,
     "application": False,
 }

--- a/invoice_recognition_sync/models/__init__.py
+++ b/invoice_recognition_sync/models/__init__.py
@@ -1,0 +1,1 @@
+from . import project_project

--- a/invoice_recognition_sync/models/project_project.py
+++ b/invoice_recognition_sync/models/project_project.py
@@ -1,0 +1,49 @@
+from odoo import api, fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    needs_recognition_sync = fields.Boolean(
+        compute="_compute_recognition_sync"
+    )
+
+    recognition_sync_message = fields.Char(
+        compute="_compute_recognition_sync"
+    )
+
+    def _get_recognition_moves(self):
+        self.ensure_one()
+
+        sale_order = self.sale_order_id
+
+        if not sale_order:
+            return self.env["account.move"]
+
+        invoices = sale_order.invoice_ids
+
+        return invoices.mapped("adjusting_entries_move_ids")
+
+    @api.depends("date_start")
+    def _compute_recognition_sync(self):
+        for project in self:
+            project.needs_recognition_sync = False
+            project.recognition_sync_message = False
+
+            if not project.date_start:
+                continue
+
+            recognition_moves = project._get_recognition_moves()
+
+            if not recognition_moves:
+                continue
+
+            recognition_dates = recognition_moves.mapped("date")
+
+            if project.date_start not in recognition_dates:
+                project.needs_recognition_sync = True
+
+                project.recognition_sync_message = (
+                    "Revenue recognition entries are not aligned "
+                    "with the project start date."
+                )

--- a/invoice_recognition_sync/models/project_project.py
+++ b/invoice_recognition_sync/models/project_project.py
@@ -1,49 +1,125 @@
-from odoo import api, fields, models
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+logger = logging.getLogger(__name__)
 
 
 class ProjectProject(models.Model):
     _inherit = "project.project"
 
     needs_recognition_sync = fields.Boolean(
-        compute="_compute_recognition_sync"
+        compute="_compute_recognition_sync",
     )
 
     recognition_sync_message = fields.Char(
-        compute="_compute_recognition_sync"
+        compute="_compute_recognition_sync",
     )
 
-    def _get_recognition_moves(self):
+    def _get_recognition_sync_target_date(self):
+        self.ensure_one()
+        return self.date_start
+
+    def _get_adjusting_entries(self):
         self.ensure_one()
 
-        sale_order = self.sale_order_id
+        sale_orders = (self.sale_order_id | self.reinvoiced_sale_order_id)
 
-        if not sale_order:
+        logger.warning("self.sale_order_id ============ %s", self.sale_order_id)
+        logger.warning("self.reinvoiced_sale_order_id ============ %s", self.reinvoiced_sale_order_id)
+        logger.warning("sale_orders ============ %s", sale_orders)
+        if not sale_orders:
             return self.env["account.move"]
 
-        invoices = sale_order.invoice_ids
+        invoice_entries = sale_orders.invoice_ids.adjusting_entries_move_ids
 
-        return invoices.mapped("adjusting_entries_move_ids")
+        logger.warning("invoice_entries  --------- %s", invoice_entries.read())
 
-    @api.depends("date_start")
+        if not invoice_entries:
+            return self.env["account.move"]
+
+        wizard_entries = invoice_entries.adjusting_entries_move_ids
+        # logger.warning("wizard_entries ----------------- %s", wizard_entries)
+        return invoice_entries | wizard_entries
+
+    @api.depends(
+        "date_start",
+        "sale_order_id.invoice_ids.adjusting_entries_move_ids.date",
+        "sale_order_id.invoice_ids.adjusting_entries_move_ids.adjusting_entries_move_ids.date",
+        "reinvoiced_sale_order_id.invoice_ids.adjusting_entries_move_ids.date",
+        "reinvoiced_sale_order_id.invoice_ids.adjusting_entries_move_ids.adjusting_entries_move_ids.date",
+    )
     def _compute_recognition_sync(self):
         for project in self:
             project.needs_recognition_sync = False
             project.recognition_sync_message = False
 
-            if not project.date_start:
+            target_date = (
+                project._get_recognition_sync_target_date()
+            )
+            # logger.warning("Target date =========== %s", target_date)
+            if not target_date:
                 continue
 
-            recognition_moves = project._get_recognition_moves()
+            entries = project._get_adjusting_entries()
+            # logger.warning("Entries  ++++++++++ %s", entries)
 
-            if not recognition_moves:
+            if not entries:
                 continue
 
-            recognition_dates = recognition_moves.mapped("date")
+            dates = entries.mapped("date")
 
-            if project.date_start not in recognition_dates:
-                project.needs_recognition_sync = True
+            if target_date in dates:
+                continue
 
-                project.recognition_sync_message = (
-                    "Revenue recognition entries are not aligned "
-                    "with the project start date."
+            project.needs_recognition_sync = True
+
+            count = len(entries)
+            # logger.info("Count of date ---------- %s", count)
+            project.recognition_sync_message = _(
+                "%(count)d revenue recognition entries are not aligned with the project start date (%(date)s).",
+                count=count, date=target_date, )
+
+    def action_open_recognition_wizard(self):
+        self.ensure_one()
+
+        entries = self._get_adjusting_entries()
+
+        if not entries:
+            raise UserError(
+                _("No revenue recognition entries found.")
+            )
+
+        move_lines = entries.line_ids.filtered(
+            lambda line: (
+                    line.account_id.account_type == "income"
+                    and line.move_id.state == "posted"
+                    and not line.reconciled
+            )
+        )
+
+        if not move_lines:
+            raise UserError(
+                _(
+                    "There are no eligible journal "
+                    "items to synchronize."
                 )
+            )
+
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Revenue Recognition"),
+            "res_model": "account.automatic.entry.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "active_model": "account.move.line",
+                "active_ids": move_lines.ids,
+                "default_action": "change_period",
+                "default_date": (
+                    self._get_recognition_sync_target_date()
+                ),
+                "invoice_recognition_sync_project_id": self.id,
+            },
+        }

--- a/invoice_recognition_sync/models/project_project.py
+++ b/invoice_recognition_sync/models/project_project.py
@@ -1,9 +1,5 @@
-import logging
-
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-
-logger = logging.getLogger(__name__)
 
 
 class ProjectProject(models.Model):
@@ -26,21 +22,16 @@ class ProjectProject(models.Model):
 
         sale_orders = (self.sale_order_id | self.reinvoiced_sale_order_id)
 
-        logger.warning("self.sale_order_id ============ %s", self.sale_order_id)
-        logger.warning("self.reinvoiced_sale_order_id ============ %s", self.reinvoiced_sale_order_id)
-        logger.warning("sale_orders ============ %s", sale_orders)
         if not sale_orders:
             return self.env["account.move"]
 
         invoice_entries = sale_orders.invoice_ids.adjusting_entries_move_ids
 
-        logger.warning("invoice_entries  --------- %s", invoice_entries.read())
-
         if not invoice_entries:
             return self.env["account.move"]
 
         wizard_entries = invoice_entries.adjusting_entries_move_ids
-        # logger.warning("wizard_entries ----------------- %s", wizard_entries)
+
         return invoice_entries | wizard_entries
 
     @api.depends(
@@ -58,12 +49,11 @@ class ProjectProject(models.Model):
             target_date = (
                 project._get_recognition_sync_target_date()
             )
-            # logger.warning("Target date =========== %s", target_date)
+
             if not target_date:
                 continue
 
             entries = project._get_adjusting_entries()
-            # logger.warning("Entries  ++++++++++ %s", entries)
 
             if not entries:
                 continue
@@ -76,10 +66,10 @@ class ProjectProject(models.Model):
             project.needs_recognition_sync = True
 
             count = len(entries)
-            # logger.info("Count of date ---------- %s", count)
+
             project.recognition_sync_message = _(
                 "%(count)d revenue recognition entries are not aligned with the project start date (%(date)s).",
-                count=count, date=target_date, )
+                count=count, date=target_date)
 
     def action_open_recognition_wizard(self):
         self.ensure_one()

--- a/invoice_recognition_sync/views/project_project_views.xml
+++ b/invoice_recognition_sync/views/project_project_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_project_form_recognition_sync" model="ir.ui.view">
+        <field name="name">project.project.form.recognition.sync</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning" invisible="not needs_recognition_sync">
+                    <field name="recognition_sync_message" readonly="1"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/invoice_recognition_sync/views/project_project_views.xml
+++ b/invoice_recognition_sync/views/project_project_views.xml
@@ -6,9 +6,22 @@
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="before">
-                <div class="alert alert-warning" invisible="not needs_recognition_sync">
-                    <field name="recognition_sync_message" readonly="1"/>
+
+                <div class="alert alert-warning mb-3" role="alert" invisible="not needs_recognition_sync">
+                    <i class="fa fa-info-circle me-2" title="Information"/>
+                    <field name="recognition_sync_message"
+                           readonly="1"
+                           nolabel="1"/>
+
                 </div>
+            </xpath>
+            <xpath expr="//field[@name='date_start']" position="after">
+                <button name="action_open_recognition_wizard"
+                        type="object"
+                        string="Recognize Invoices"
+                        class="btn btn-primary text-nowrap ms-2"
+                        icon="fa-refresh"
+                        invisible="not needs_recognition_sync"/>
             </xpath>
         </field>
     </record>

--- a/invoice_recognition_sync/wizard/__init__.py
+++ b/invoice_recognition_sync/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_automatic_entry_wizard

--- a/invoice_recognition_sync/wizard/account_automatic_entry_wizard.py
+++ b/invoice_recognition_sync/wizard/account_automatic_entry_wizard.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import _, models
 
 
 class AccountAutomaticEntryWizard(models.TransientModel):
@@ -12,7 +12,8 @@ class AccountAutomaticEntryWizard(models.TransientModel):
         if (project_id and "date" in fields_list and not values.get("date")):
             project = (self.env["project.project"].browse(project_id).exists())
 
-            if project: values["date"] = (project._get_recognition_sync_target_date())
+            if project:
+                values["date"] = project._get_recognition_sync_target_date()
 
         return values
 
@@ -21,12 +22,38 @@ class AccountAutomaticEntryWizard(models.TransientModel):
         if self.action == "change_period" and project_id:
             project = self.env["project.project"].browse(project_id).exists()
             if project:
-                old_entries = project._get_adjusting_entries()
-                if old_entries:
-                    posted = old_entries.filtered(lambda m: m.state == "posted")
-                    draft = old_entries.filtered(lambda m: m.state == "draft")
-                    if posted:
-                        posted.button_draft()
-                    (posted | draft).button_cancel()
+                entries = project._get_adjusting_entries()
+                if entries:
+                    wizard_entries = entries.filtered("auto_post_origin_id")
+                    if wizard_entries:
+                        posted = wizard_entries.filtered(lambda m: m.state == "posted")
+                        if posted:
+                            posted.button_draft()
+                        wizard_entries.button_cancel()
+                        wizard_entries.unlink()
+
+                    invoice_entries = entries - wizard_entries
+                    if invoice_entries:
+                        if all(e.date == self.date for e in invoice_entries):
+                            return {
+                                "type": "ir.actions.act_window",
+                                "name": _("Revenue Recognition"),
+                                "res_model": "account.move",
+                                "view_mode": "list,form",
+                                "domain": [("id", "in", invoice_entries.ids)],
+                            }
+                        posted = invoice_entries.filtered(lambda m: m.state == "posted")
+                        if posted:
+                            posted.button_draft()
+                        invoice_entries.date = self.date
+                        if posted:
+                            posted._post()
+                        return {
+                            "type": "ir.actions.act_window",
+                            "name": _("Revenue Recognition"),
+                            "res_model": "account.move",
+                            "view_mode": "list,form",
+                            "domain": [("id", "in", invoice_entries.ids)],
+                        }
 
         return super().do_action()

--- a/invoice_recognition_sync/wizard/account_automatic_entry_wizard.py
+++ b/invoice_recognition_sync/wizard/account_automatic_entry_wizard.py
@@ -1,0 +1,32 @@
+from odoo import models
+
+
+class AccountAutomaticEntryWizard(models.TransientModel):
+    _inherit = "account.automatic.entry.wizard"
+
+    def default_get(self, fields_list):
+        values = super().default_get(fields_list)
+
+        project_id = self.env.context.get("invoice_recognition_sync_project_id")
+
+        if (project_id and "date" in fields_list and not values.get("date")):
+            project = (self.env["project.project"].browse(project_id).exists())
+
+            if project: values["date"] = (project._get_recognition_sync_target_date())
+
+        return values
+
+    def do_action(self):
+        project_id = self.env.context.get("invoice_recognition_sync_project_id")
+        if self.action == "change_period" and project_id:
+            project = self.env["project.project"].browse(project_id).exists()
+            if project:
+                old_entries = project._get_adjusting_entries()
+                if old_entries:
+                    posted = old_entries.filtered(lambda m: m.state == "posted")
+                    draft = old_entries.filtered(lambda m: m.state == "draft")
+                    if posted:
+                        posted.button_draft()
+                    (posted | draft).button_cancel()
+
+        return super().do_action()


### PR DESCRIPTION
## Purpose

This improvement ensures that revenue recognition entries remain aligned with the project start date.

Previously, when the project start date was modified after revenue recognition entries had already been generated, the accounting recognition dates remained unchanged, creating inconsistencies between project planning and revenue recognition.

## Functional Changes

### Project Synchronization Check

* Added a synchronization check between:

  * Project Start Date
  * Related Revenue Recognition Entries

* A warning message is displayed when revenue recognition entries are not aligned with the project start date.

### Recognition Sync Action

* Added a project action that allows users to synchronize related revenue recognition entries directly from the project.

* The action opens the existing Revenue Recognition wizard with the project start date prefilled.

### Revenue Recognition Update

* Existing revenue recognition entries are updated to match the project start date.
* Wizard-generated recognition entries are automatically regenerated when necessary.
* Original invoice recognition entries are updated while preserving the existing accounting workflow.

## Benefits

* Keeps project planning and accounting recognition dates consistent.
* Reduces manual adjustments performed from invoices.
* Improves visibility when recognition entries require synchronization.
* Provides a centralized workflow directly from the project form.

## Technical Notes

* Added computed synchronization status and warning message on `project.project`.
* Added helper methods to retrieve related revenue recognition entries.
* Extended `account.automatic.entry.wizard` to support project-driven synchronization.
* Added project form view enhancements for synchronization visibility and actions.
