### PR TITLE
[IMP] sale: add global discount with automatic recalculation on order…

### DIFF
--- a/sales_discount_update/__init__.py
+++ b/sales_discount_update/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sales_discount_update/__manifest__.py
+++ b/sales_discount_update/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'Sale Global Discount Update',
+    'version': '1.0',
+    'category': 'Sales',
+    'author': 'Pranjali',
+    'summary': 'Update global discount when sale order lines change',
+    'depends': ['sale'],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/sales_discount_update/models/__init__.py
+++ b/sales_discount_update/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sales_order
+from . import sales_order_line

--- a/sales_discount_update/models/sales_order.py
+++ b/sales_discount_update/models/sales_order.py
@@ -1,0 +1,11 @@
+from odoo import models, fields
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    global_discount_percentage = fields.Float(
+        string="Global Discount Percentage",
+        default=0.0,
+        copy=False,
+    )

--- a/sales_discount_update/models/sales_order_line.py
+++ b/sales_discount_update/models/sales_order_line.py
@@ -1,0 +1,77 @@
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    def _update_global_discount(self):
+        for order in self.mapped('order_id'):
+            if not order.global_discount_percentage:
+                continue
+            discount_lines = order.order_line.filtered(
+                lambda line: line._is_global_discount()
+            )
+            normal_lines = order.order_line.filtered(
+                lambda line: not line._is_global_discount()
+            )
+            if not normal_lines:
+                if discount_lines:
+                    discount_lines.with_context(
+                        skip_global_discount_update=True
+                    ).unlink()
+                continue
+            main_discount = discount_lines[:1]
+            extra_discounts = discount_lines[1:]
+            if extra_discounts:
+                extra_discounts.with_context(
+                    skip_global_discount_update=True
+                ).unlink()
+            if not main_discount:
+                continue
+            subtotal = sum(normal_lines.mapped('price_subtotal'))
+            discount_amount = (
+                subtotal * order.global_discount_percentage / 100
+            )
+            main_discount.with_context(
+                skip_global_discount_update=True
+            ).write({
+                'price_unit': -discount_amount,
+                'name': (
+                    f'Discount '
+                    f'{order.global_discount_percentage:.2f}%'
+                ),
+            })
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super().create(vals_list)
+        if self.env.context.get('skip_global_discount_update'):
+            return lines
+        normal_lines = lines.filtered(
+            lambda line: not line._is_global_discount()
+        )
+        if normal_lines:
+            normal_lines._update_global_discount()
+        return lines
+
+    def write(self, vals):
+        if self.env.context.get('skip_global_discount_update'):
+            return super().write(vals)
+
+        orders = self.mapped('order_id')
+
+        result = super().write(vals)
+
+        for order in orders:
+            order.order_line._update_global_discount()
+
+        return result
+
+    def unlink(self):
+        if self.env.context.get('skip_global_discount_update'):
+            return super().unlink()
+        orders = self.mapped('order_id')
+        result = super().unlink()
+        for order in orders:
+            order.order_line._update_global_discount()
+        return result

--- a/sales_discount_update/wizard/__init__.py
+++ b/sales_discount_update/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sales_discount_update_wizard

--- a/sales_discount_update/wizard/sales_discount_update_wizard.py
+++ b/sales_discount_update/wizard/sales_discount_update_wizard.py
@@ -1,0 +1,26 @@
+from odoo import models
+
+
+class SaleOrderDiscount(models.TransientModel):
+    _inherit = 'sale.order.discount'
+
+    def action_apply_discount(self):
+        self.ensure_one()
+
+        if self.discount_type == 'so_discount':
+            order = self.sale_order_id
+
+            discount_lines = order.order_line.filtered(
+                lambda line: line._is_global_discount()
+            )
+
+            if discount_lines:
+                discount_lines.with_context(
+                    skip_global_discount_update=True
+                ).unlink()
+
+            order.global_discount_percentage = (
+                self.discount_percentage * 100
+            )
+
+        return super().action_apply_discount()


### PR DESCRIPTION
**Problem**: When a global discount is applied to a Sale Order, the discount amount is generated based on the current subtotal. However, when order lines are subsequently added, updated, or removed, the discount amount is not recalculated and becomes inconsistent with the current order subtotal.

Additionally, multiple discount lines can be created when applying a new global discount, and discount lines may remain even when all product lines have been removed.

**Solution**: Implemented automatic synchronization of the global discount with Sale Order lines.

**Changes**

- Recalculate the global discount when Sale Order lines are:
      - Created
      - Updated
      - Deleted
- Remove the discount line when no product lines remain.
- Ensure only a single global discount line exists at any time.
- Replace the existing discount when a new global discount percentage is applied.
- Keep the stored discount percentage and discount line amount synchronized with the current order subtotal.
<img width="916" height="408" alt="2026-06-08_16-21" src="https://github.com/user-attachments/assets/c919b242-3b54-426e-85ed-bcf3c8e404d5" />
