### PR TITLE
[ADD] sale_kit_product: establish custom kit bundling framework

### DIFF
--- a/sale_kit_product/__init__.py
+++ b/sale_kit_product/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_kit_product/__manifest__.py
+++ b/sale_kit_product/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    "name": "Sale Kit Product",
+    "application": False,
+    "installable": True,
+    "author": "sngoh",
+    "depends": ["base", "product", "sale"],
+    "auto_install": True,
+    "license": "LGPL-3",
+    "data": [
+        "security/ir.model.access.csv",
+        "wizard/sale_kit_product_wizard_view.xml",
+        "views/product_template_views.xml",
+        "views/sale_order_views.xml",
+    ],
+}

--- a/sale_kit_product/models/__init__.py
+++ b/sale_kit_product/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_template
+from . import sale_order_line

--- a/sale_kit_product/models/__init__.py
+++ b/sale_kit_product/models/__init__.py
@@ -1,2 +1,4 @@
 from . import product_template
 from . import sale_order_line
+from . import sale_order
+from . import account_move

--- a/sale_kit_product/models/account_move.py
+++ b/sale_kit_product/models/account_move.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _get_move_lines_to_report(self):
+        lines = super()._get_move_lines_to_report()
+        return lines.filtered(
+            lambda l: (
+                not l.sale_line_ids.is_sub_product
+                or l.sale_line_ids.order_id.print_in_report
+            )
+        )

--- a/sale_kit_product/models/product_template.py
+++ b/sale_kit_product/models/product_template.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    is_kit = fields.Boolean(string="Is Kit")
+    sub_products = fields.Many2many(
+        comodel_name="product.product", string="Sub Products"
+    )

--- a/sale_kit_product/models/sale_order.py
+++ b/sale_kit_product/models/sale_order.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    print_in_report = fields.Boolean()
+
+    def _get_order_lines_to_report(self):
+        lines = super()._get_order_lines_to_report()
+        return lines.filtered(
+            lambda l: not l.is_sub_product or l.order_id.print_in_report
+        )

--- a/sale_kit_product/models/sale_order_line.py
+++ b/sale_kit_product/models/sale_order_line.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    is_sub_product = fields.Boolean()
+    parent_kit_line_id = fields.Many2one("sale.order.line", ondelete="cascade")
+    kit_line_ids = fields.One2many("sale.order.line", "parent_kit_line_id")

--- a/sale_kit_product/models/sale_order_line.py
+++ b/sale_kit_product/models/sale_order_line.py
@@ -4,6 +4,8 @@ from odoo import fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    is_kit = fields.Boolean(related="product_template_id.is_kit")
     is_sub_product = fields.Boolean()
     parent_kit_line_id = fields.Many2one("sale.order.line", ondelete="cascade")
     kit_line_ids = fields.One2many("sale.order.line", "parent_kit_line_id")
+    kit_component_price = fields.Monetary()

--- a/sale_kit_product/security/ir.model.access.csv
+++ b/sale_kit_product/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sub_product_wizard_view,access_sub_product_wizard_view,model_sale_kit_product_sub_product_wizard,base.group_user,1,1,1,1
+sale_kit_product.access_sale_kit_product_wizard_line,access_sale_kit_product_wizard_line,sale_kit_product.model_sale_kit_product_wizard_line,base.group_user,1,1,1,1

--- a/sale_kit_product/views/product_template_views.xml
+++ b/sale_kit_product/views/product_template_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="new_product_type_product_template_form_view" model="ir.ui.view">
+        <field name="name">new.product.type.product.template.form.view</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='general_information'] //group[@name='group_general']"
+                position="inside">
+                <field name="is_kit" />
+                <field name="sub_products" invisible="not is_kit" widget="many2many_tags" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_kit_product/views/sale_order_views.xml
+++ b/sale_kit_product/views/sale_order_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="sale_kit_product_view_order_form" model="ir.ui.view">
+        <field name="name">sale.kit.product.view.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']//field[@name='product_template_id']"
+                position="after">
+
+                <button name="%(sale_kit_product.sub_products_wizard_view_action)d"
+                    type="action"
+                    target="new"
+                    icon="fa-cog"
+                    title="Sub Product List"
+                    class="btn-primary"
+                />
+
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_kit_product/views/sale_order_views.xml
+++ b/sale_kit_product/views/sale_order_views.xml
@@ -15,8 +15,40 @@
                     icon="fa-cog"
                     title="Sub Product List"
                     class="btn-primary"
+                    invisible="not is_kit"
                 />
 
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_id']"
+                position="before">
+                <field name="is_sub_product" column_invisible="True" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list" position="attributes">
+                <attribute name="decoration-info">is_sub_product</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_id']"
+                position="attributes">
+                <attribute name="readonly">is_sub_product</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='product_uom_qty']"
+                position="attributes">
+                <attribute name="readonly">is_sub_product</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='customer_lead']"
+                position="attributes">
+                <attribute name="readonly">is_sub_product</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']"
+                position="attributes">
+                <attribute name="readonly">is_sub_product</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='discount']"
+                position="attributes">
+                <attribute name="readonly">is_sub_product</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='tax_ids']"
+                position="attributes">
+                <attribute name="readonly">is_sub_product</attribute>
             </xpath>
         </field>
     </record>

--- a/sale_kit_product/views/sale_order_views.xml
+++ b/sale_kit_product/views/sale_order_views.xml
@@ -6,8 +6,13 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="print_in_report" />
+            </xpath>
+
             <xpath expr="//field[@name='order_line']//field[@name='product_template_id']"
-                position="after">
+                position="after" >
 
                 <button name="%(sale_kit_product.sub_products_wizard_view_action)d"
                     type="action"
@@ -15,7 +20,7 @@
                     icon="fa-cog"
                     title="Sub Product List"
                     class="btn-primary"
-                    invisible="not is_kit"
+                    invisible="not is_kit or state not in ['draft','sent']"
                 />
 
             </xpath>

--- a/sale_kit_product/wizard/__init__.py
+++ b/sale_kit_product/wizard/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_kit_product_wizard_view
+from . import sale_kit_product_wizard_line

--- a/sale_kit_product/wizard/sale_kit_product_wizard_line.py
+++ b/sale_kit_product/wizard/sale_kit_product_wizard_line.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class SaleKitProductWizardLine(models.TransientModel):
+    _name = "sale.kit.product.wizard.line"
+    _description = "This is the model for showing the sub product lines in wizard."
+
+    product_wizard_line = fields.Many2one("sale.kit.product.sub.product.wizard")
+    product_id = fields.Many2one("product.product")
+    product_qty = fields.Integer(default=0)
+    product_price = fields.Float(string="Product Unit Price")

--- a/sale_kit_product/wizard/sale_kit_product_wizard_line.py
+++ b/sale_kit_product/wizard/sale_kit_product_wizard_line.py
@@ -7,5 +7,5 @@ class SaleKitProductWizardLine(models.TransientModel):
 
     product_wizard_line = fields.Many2one("sale.kit.product.sub.product.wizard")
     product_id = fields.Many2one("product.product")
-    product_qty = fields.Integer(default=0)
-    product_price = fields.Float(string="Product Unit Price")
+    product_qty = fields.Integer(default=0, string="Quantity")
+    product_price = fields.Float(string="Unit Price ")

--- a/sale_kit_product/wizard/sale_kit_product_wizard_view.py
+++ b/sale_kit_product/wizard/sale_kit_product_wizard_view.py
@@ -1,0 +1,34 @@
+from odoo import api, Command, fields, models
+
+
+class SubKitProductWizard(models.TransientModel):
+    _name = "sale.kit.product.sub.product.wizard"
+    _description = "Sub products view of a kit product"
+
+    sale_line_id = fields.Many2one("sale.order.line")
+    wizard_line_ids = fields.One2many(
+        "sale.kit.product.wizard.line", "product_wizard_line"
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        active_id = self.env.context.get("active_id")
+        res["sale_line_id"] = self.env["sale.order.line"].browse(active_id)
+        sub_product_ids = res["sale_line_id"].product_id.product_tmpl_id.sub_products
+        if sub_product_ids:
+            lines = []
+            for sub_product in sub_product_ids:
+                lines.append(
+                    Command.create(
+                        {
+                            "product_id": sub_product.id,
+                            "product_qty": 1,
+                            "product_price": sub_product.lst_price,
+                        }
+                    )
+                )
+            # res["wizard_line_ids"] = lines
+            res.update({"wizard_line_ids": lines})
+
+        return res

--- a/sale_kit_product/wizard/sale_kit_product_wizard_view.py
+++ b/sale_kit_product/wizard/sale_kit_product_wizard_view.py
@@ -14,10 +14,22 @@ class SubKitProductWizard(models.TransientModel):
     def default_get(self, fields):
         res = super().default_get(fields)
         active_id = self.env.context.get("active_id")
-        res["sale_line_id"] = self.env["sale.order.line"].browse(active_id)
-        sub_product_ids = res["sale_line_id"].product_id.product_tmpl_id.sub_products
-        if sub_product_ids:
-            lines = []
+        sale_line = self.env["sale.order.line"].browse(active_id)
+        res["sale_line_id"] = sale_line.id
+        sub_product_ids = sale_line.product_id.product_tmpl_id.sub_products
+        lines = []
+        if sale_line.kit_line_ids:
+            for kit_line in sale_line.kit_line_ids:
+                lines.append(
+                    Command.create(
+                        {
+                            "product_id": kit_line.product_id.id,
+                            "product_qty": kit_line.product_uom_qty,
+                            "product_price": kit_line.kit_component_price,
+                        }
+                    )
+                )
+        elif sub_product_ids:
             for sub_product in sub_product_ids:
                 lines.append(
                     Command.create(
@@ -28,7 +40,34 @@ class SubKitProductWizard(models.TransientModel):
                         }
                     )
                 )
-            # res["wizard_line_ids"] = lines
-            res.update({"wizard_line_ids": lines})
+        res.update({"wizard_line_ids": lines})
 
         return res
+
+    def action_confirm(self):
+        self.ensure_one()
+        self.sale_line_id.kit_line_ids.unlink()
+        total_price = 0
+        sub_product_lines = []
+        for line in self.wizard_line_ids:
+            total_price += line.product_qty * line.product_price
+            sub_product_lines.append(
+                Command.create(
+                    {
+                        "order_id": self.sale_line_id.order_id.id,
+                        "product_id": line.product_id.id,
+                        "product_uom_qty": line.product_qty,
+                        "price_unit": 0,
+                        "kit_component_price": line.product_price,
+                        "parent_kit_line_id": self.sale_line_id.id,
+                        "is_sub_product": True,
+                    }
+                )
+            )
+        if sub_product_lines:
+            self.sale_line_id.order_id.write({"order_line": sub_product_lines})
+
+        if self.sale_line_id.price_unit != total_price:
+            self.sale_line_id.update({"price_unit": total_price})
+
+        return {"type": "ir.actions.act_window_close"}

--- a/sale_kit_product/wizard/sale_kit_product_wizard_view.xml
+++ b/sale_kit_product/wizard/sale_kit_product_wizard_view.xml
@@ -8,12 +8,17 @@
             <form string="Product">
                 <sheet>
                     <field name="wizard_line_ids" options="{'no_open': True}">
-                        <list>
+                        <list editable="bottom" edit="True">
                             <field name="product_id" options="{'no_create': True}" />
                             <field name="product_qty" />
                             <field name="product_price" />
                         </list>
                     </field>
+                    <footer>
+                        <button class="btn-primary" string="Confirm" name="action_confirm"
+                            type="object" />
+                        <button class="btn-secondary" string="Cancel" special="cancel" />
+                    </footer>
                 </sheet>
             </form>
         </field>

--- a/sale_kit_product/wizard/sale_kit_product_wizard_view.xml
+++ b/sale_kit_product/wizard/sale_kit_product_wizard_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="sub_products_wizard_form_view" model="ir.ui.view">
+        <field name="name">sub.products.wizard.form.view</field>
+        <field name="model">sale.kit.product.sub.product.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Product">
+                <sheet>
+                    <field name="wizard_line_ids" options="{'no_open': True}">
+                        <list>
+                            <field name="product_id" options="{'no_create': True}" />
+                            <field name="product_qty" />
+                            <field name="product_price" />
+                        </list>
+                    </field>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="sub_products_wizard_view_action" model="ir.actions.act_window">
+        <field name="name">Product </field>
+        <field name="res_model">sale.kit.product.sub.product.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Selling packaged services or product bundles often leads to customer billing confusion if every minor component displays an individual price on a quote. This framework allows sales teams to manage grouped offerings under a single, unified parent price.

Defining these component relationships and introducing a dedicated configuration interface ensures that complex bundles can be reviewed and adjusted to fit specific customer needs directly within the sales workflow.

Project: [PSIN]INTERNSHIP ONBOARDING
Task: New Product Type in Odoo