### PR TITLE
[ADD] custom_picking_report: create MO Delivery Note custom report

### DIFF
--- a/custome_picking_report/__manifest__.py
+++ b/custome_picking_report/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': 'custome_picking_report',
+    'author': "vikvi",
+    'license': 'LGPL-3',
+    'depends': ['stock'],
+    "category": "Tutorials",
+    'data': [
+        'views/stock_report_views.xml',
+        'views/report_view_without_kit.xml',
+    ]
+}

--- a/custome_picking_report/views/report_view_without_kit.xml
+++ b/custome_picking_report/views/report_view_without_kit.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_mo_delivery_slip">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="custome_picking_report.report_mo_delivery_document_clean"/>
+        </t>
+    </template>
+
+    <template id="report_mo_delivery_document_clean" inherit_id="stock.report_delivery_document">
+        <xpath expr="//table[@name='stock_move_table']/tbody" position="replace">
+            <tbody>
+                <t t-foreach="o.move_ids" t-as="move">
+                    <t t-set="production_order" t-value="move.move_orig_ids.production_id"/>
+                    <tr t-foreach="production_order.move_raw_ids" t-as="raw_move">
+                        <t t-if="not raw_move.bom_line_id or raw_move.bom_line_id.bom_id.type != 'phantom'">
+                            <td>
+                                <span t-field="raw_move.product_id"/>
+                                <p t-if="raw_move.description_picking and raw_move.description_picking != raw_move.product_id.name">
+                                    <span t-out="raw_move.description_picking"/>
+                                </p>
+                            </td>
+                            <td class="o_td_quantity text-end">
+                                <span t-out="format_number(raw_move.product_uom_qty)" class="text-nowrap"/>
+                                <span t-field="raw_move.product_uom" groups="uom.group_uom"/>
+                            </td>
+                            <td class="o_td_quantity text-end">
+                                <span t-out="format_number(raw_move.quantity)" class="text-nowrap"/>
+                                <span t-field="raw_move.product_uom" groups="uom.group_uom"/>
+                            </td>
+                        </t>
+                    </tr>
+                </t>
+            </tbody>
+        </xpath>
+    </template>
+</odoo>

--- a/custome_picking_report/views/stock_report_views.xml
+++ b/custome_picking_report/views/stock_report_views.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_report_delivery_note" model="ir.actions.report">
+        <field name="name">MO Delivery Note</field>
+        <field name="model">stock.picking</field>
+        <field name="report_name">custome_picking_report.report_mo_delivery_slip</field>
+        <field name="print_report_name">'MO Delivery Note - %s - %s' % (object.partner_id.name or '', object.name)</field>
+        <field name="binding_model_id" ref="stock.model_stock_picking"/>
+    </record>
+</odoo>


### PR DESCRIPTION
Standard delivery slips only show the final product sold, which isn't helpful for warehouse teams who need a picking list of the actual manufacturing components to fulfill the order.

- Added a new 'MO Delivery Note' option in the Print/Action menu specifically for Delivery Orders (WH/OUT).
- Instead of the final product, the report dynamically fetches and prints the actual raw materials required on the factory floor.
- Strictly filters out exploded sub-kit items to prevent confusion and accidental double-picking.

Project: [PSIN]INTERNSHIP ONBOARDING
Task: Custom Picking report