### PR TITLE
[ADD] account_supplier_portal: add bill upload button for vendors

### DIFF
--- a/account_supplier_portal/__init__.py
+++ b/account_supplier_portal/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/account_supplier_portal/__manifest__.py
+++ b/account_supplier_portal/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Supplier Portal",
+    "application": False,
+    "installable": True,
+    "author": "sngoh",
+    "depends": ["base", "website", "account"],
+    "auto_install": True,
+    "license": "LGPL-3",
+    "data": [
+        "views/portal_templates.xml",
+        "views/account_supplier_portal_view.xml",
+    ],
+}

--- a/account_supplier_portal/__manifest__.py
+++ b/account_supplier_portal/__manifest__.py
@@ -7,6 +7,7 @@
     "auto_install": True,
     "license": "LGPL-3",
     "data": [
+        "data/supplier_portal_data.xml",
         "views/portal_templates.xml",
         "views/account_supplier_portal_view.xml",
     ],

--- a/account_supplier_portal/controllers/__init__.py
+++ b/account_supplier_portal/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/account_supplier_portal/controllers/main.py
+++ b/account_supplier_portal/controllers/main.py
@@ -1,0 +1,9 @@
+from odoo import http
+from odoo.http import request
+
+
+class SupplierPortalController(http.Controller):
+    @http.route("/my/supplier/upload_bill", type="http", auth="public", website=True)
+    def uploadBill(self, page=1):
+
+        return request.render("account_supplier_portal.account_supplier_portal_view")

--- a/account_supplier_portal/controllers/main.py
+++ b/account_supplier_portal/controllers/main.py
@@ -1,9 +1,75 @@
+import base64
+
 from odoo import http
 from odoo.http import request
 
 
 class SupplierPortalController(http.Controller):
-    @http.route("/my/supplier/upload_bill", type="http", auth="public", website=True)
-    def uploadBill(self, page=1):
+    @http.route(
+        "/my/supplier/upload_bill",
+        type="http",
+        auth="public",
+        methods=["get"],
+        website=True,
+    )
+    def supplierPortal(self):
+        user = request.env.user
 
-        return request.render("account_supplier_portal.account_supplier_portal_view")
+        return request.render(
+            "account_supplier_portal.account_supplier_portal_view",
+            {
+                "allowed_companies": user.partner_id.parent_id,
+            },
+        )
+
+    @http.route(
+        "/my/supplier/upload_bill",
+        type="http",
+        auth="public",
+        methods=["post"],
+        website=True,
+    )
+    def submitBill(self, **kwargs):
+
+        partner_id = int(kwargs.get("partner_id"))
+        pdf_file = kwargs.get("pdf_file")
+        xml_file = kwargs.get("xml_file")
+
+        bill_vals = {
+            "move_type": "in_invoice",  # Inbound Vendor Bill
+            "state": "draft",
+            "partner_id": partner_id,
+        }
+        new_bill = request.env["account.move"].sudo().create(bill_vals)
+
+        attachments_to_create = []
+
+        if pdf_file:
+            attachments_to_create.append(
+                {
+                    "name": pdf_file.filename,
+                    "datas": base64.b64encode(pdf_file.read()),
+                    "res_model": "account.move",
+                    "res_id": new_bill.id,
+                }
+            )
+
+        if xml_file:
+            attachments_to_create.append(
+                {
+                    "name": xml_file.filename,
+                    "datas": base64.b64encode(xml_file.read()),
+                    "res_model": "account.move",
+                    "res_id": new_bill.id,
+                }
+            )
+
+        if attachments_to_create:
+            request.env["ir.attachment"].sudo().create(attachments_to_create)
+
+            new_bill.sudo().message_post(
+                body="Vendor Bill submitted via Supplier Portal.",
+                attachment_ids=[att.id for att in new_bill.attachment_ids],
+            )
+
+        return request.redirect("/supplier-portal-bill-added")

--- a/account_supplier_portal/data/supplier_portal_data.xml
+++ b/account_supplier_portal/data/supplier_portal_data.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="bill_added_page" model="website.page">
+        <field name="name">Bill Added</field>
+        <field name="type">qweb</field>
+        <field name="url">/supplier-portal-bill-added</field>
+        <field name="website_indexed" eval="False" />
+        <field name="is_published">True</field>
+        <field name="key">account_supplier_portal.bill_added_page</field>
+        <field name="arch" type="xml">
+            <t name="Bill Added" t-name="account_supplier_portal.bill_added_page">
+                <t t-call="website.layout">
+                    <div id="wrap" class="oe_structure">
+                        <section class="s_text_block pt-5 pb-5">
+                            <div class="container">
+                                <div class="row">
+                                    <div class="col-lg-8 offset-lg-2 text-center">
+                                        <div class="p-5 border-0 bg-white">
+                                            <div class="mb-4">
+                                                <i class="fa fa-file-text fa-4x text-primary"
+                                                    role="presentation" />
+                                            </div>
+
+                                            <h1 class="fw-bold mb-3">Bill Successfully Uploaded</h1>
+                                            <p class="lead text-muted mb-4">
+                                                Your vendor bill has been received.
+                                            </p>
+
+                                            <div class="d-flex justify-content-center gap-2">
+                                                <a href="/" class="btn btn-outline-primary ">Back to
+                                                    Home</a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+                </t>
+            </t>
+        </field>
+    </record>
+
+</odoo>

--- a/account_supplier_portal/views/account_supplier_portal_view.xml
+++ b/account_supplier_portal/views/account_supplier_portal_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="account_supplier_portal_view">
+        <t t-call="website.layout">
+            Hello, This is the working test of the website.
+        </t>
+    </template>
+
+</odoo>

--- a/account_supplier_portal/views/account_supplier_portal_view.xml
+++ b/account_supplier_portal/views/account_supplier_portal_view.xml
@@ -3,7 +3,49 @@
 
     <template id="account_supplier_portal_view">
         <t t-call="website.layout">
-            Hello, This is the working test of the website.
+            <div class="container mt-5">
+                <div class="row justify-content-center">
+                    <div class="col-md-6 border p-4 bg-white rounded shadow-sm">
+                        <h3 class="text-center mb-4">Bill Details</h3>
+
+                        <form action="/my/supplier/upload_bill" method="post"
+                            enctype="multipart/form-data">
+                            <input type="hidden" name="csrf_token"
+                                t-att-value="request.csrf_token()" />
+
+                            <div class="form-group mb-3">
+                                <label for="partner_id" class="form-label font-weight-bold">Select
+                                    Organisation:</label>
+                                <select name="partner_id" id="parent_id" class="form-control"
+                                    required="required">
+                                    <t t-foreach="allowed_companies" t-as="comp">
+                                        <option t-att-value="comp.id">
+                                            <t t-esc="comp.name" />
+                                        </option>
+                                    </t>
+                                </select>
+                            </div>
+
+                            <div class="form-group mb-3">
+                                <label for="pdf_file" class="form-label">Upload PDF:</label>
+                                <input type="file" name="pdf_file" id="pdf_file"
+                                    class="form-control" accept="application/pdf"
+                                    required="required" />
+                            </div>
+
+                            <div class="form-group mb-4">
+                                <label for="xml_file" class="form-label">Upload XML file:</label>
+                                <input type="file" name="xml_file" id="xml_file"
+                                    class="form-control" accept=".xml" required="required" />
+                            </div>
+
+                            <div class="text-center">
+                                <button type="submit" class="btn btn-primary px-5">Submit</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
         </t>
     </template>
 

--- a/account_supplier_portal/views/portal_templates.xml
+++ b/account_supplier_portal/views/portal_templates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    
+    <template id="custom_header_button" inherit_id="portal.placeholder_user_sign_in"
+        name="Add Custom Header Button">
+        <xpath expr="." position="inside">
+            <li class="o_no_autohide_item" t-if="user_id.has_group('base.group_portal')">
+                <a href="/my/supplier/upload_bill" class="btn btn-secondary">
+                    Add Bill
+                </a>
+            </li>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Vendors currently have to email their invoices, which creates manual data entry work for the internal team.

This adds a new action button to the portal webpage that is only visible to vendor users. This gives them the entry point to upload their files directly through the portal.

Project: [PSIN]INTERNSHIP ONBOARDING
Task: Supplier Portal