### PR TITLE
[ADD] discuss_ai_search: AI-based natural language search for Discuss

### DIFF
--- a/discuss_ai_search/__init__.py
+++ b/discuss_ai_search/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/discuss_ai_search/__manifest__.py
+++ b/discuss_ai_search/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': "Discuss AI Search",
+    'version': '1.0',
+    'category': 'Discuss',
+    'summary': "Categorize and summarize Discuss messages using AI",
+    'depends': ['mail'],
+    'data': [
+        'data/discuss_demo_data.xml'
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'discuss_ai_search/static/src/**/*',
+        ],
+    },
+    'author': "Parth Sawant",
+    'license': 'LGPL-3',
+}

--- a/discuss_ai_search/data/discuss_demo_data.xml
+++ b/discuss_ai_search/data/discuss_demo_data.xml
@@ -1,0 +1,4584 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="channel_sales_client_demo" model="discuss.channel">
+            <field name="name">Veltrix Industries - ERP Deal</field>
+            <field name="channel_type">channel</field>
+        </record>
+
+        <record id="channel_sales_client_demo_member_admin" model="discuss.channel.member">
+            <field name="channel_id" ref="channel_sales_client_demo"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+        </record>
+        <record id="channel_sales_client_demo_member_demo" model="discuss.channel.member">
+            <field name="channel_id" ref="channel_sales_client_demo"/>
+            <field name="partner_id" ref="base.partner_demo"/>
+        </record>
+
+        <record id="sc_msg_0001" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Hi Rohan, thanks for hopping on chat. I heard from Priya that Veltrix is looking to upgrade your warehouse ERP setup?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1521)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0002" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes, hi Aditya. We've outgrown our current system, it's been a mess honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1518)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0003" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Totally understand. How many warehouse locations are we talking about?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1515)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0004" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>3 right now, but we're opening a 4th in Pune by Q3.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1512)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0005" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Got it. And what's the team size that would be using the system day to day?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1509)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0006" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Roughly 40 people across all locations, mix of inventory staff and floor supervisors.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1506)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0007" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Makes sense. Are you currently using any barcode/RFID setup or is it manual entry?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1503)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0008" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Manual entry mostly. We tried barcode scanners 2 years ago but the old system never integrated well.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1500)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0009" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's a really common pain point honestly, glad you brought it up early.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1497)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0010" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah it's been frustrating. Half our stock discrepancies trace back to manual entry errors.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1494)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0011" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Makes sense why you're looking to switch then. What's the timeline you're working with?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1491)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0012" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Ideally live before the new Pune warehouse opens. So end of Q3 at the latest.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1488)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0013" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Okay that's workable. Let me pull together what modules would fit and get back to you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1485)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0014" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good. Also are you guys able to handle multi-currency? We import from 2 vendors in Germany.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1482)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0015" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yes, multi-currency is supported out of the box, no issue there.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1479)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0016" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, that was a dealbreaker with the last vendor we evaluated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1476)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0017" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know. I'll also loop in our implementation lead for a quick technical call next week.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1473)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0018" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Works for me. Tuesday or Wednesday afternoon would be ideal.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1470)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0019" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Tuesday 3pm IST?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1467)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0020" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Tuesday 3pm works, I'll block it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1464)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0021" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Great, sending the invite now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1461)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0022" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, thanks.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1458)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0023" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, do you guys also need a barcode hardware bundle or do you already have scanners?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1455)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0024" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>We have some old scanners but they're pretty outdated, probably need new ones.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1452)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0025" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Noted, I'll include a hardware recommendation separately.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1449)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0026" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1446)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0027" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>One more thing -- do you need this to integrate with your existing accounting software?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1443)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0028" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes, we use Tally currently. Integration is important.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1440)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0029" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Okay, that's a standard connector for us, shouldn't be a problem.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1437)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0030" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Great, one less thing to worry about.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1434)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0031" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick housekeeping question -- who else from your side should be on these calls? Just you, or others too?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1431)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0032" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Just me for now. I'll bring in our ops head once we're closer to deciding.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1428)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0033" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sounds good. I'll keep the conversation focused with you until then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1425)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0034" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1422)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0035" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also wanted to flag -- our support team usually does a 2-week onboarding sprint post go-live.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1419)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0036" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's good to know, we'll probably need that given our team isn't very tech savvy.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1416)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0037" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>No worries, we've onboarded much less tech-savvy teams before, it's usually smoother than people expect.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1413)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0038" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good to hear.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1410)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0039" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, let me prep the requirements doc and share it with you by tomorrow.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1407)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0040" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, talk soon.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1404)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0041" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Just a heads up, I'm out tomorrow morning, doctor's appointment, but I'll have it to you by afternoon.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1401)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0042" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>No rush, take your time.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1398)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0043" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciate that. Also, did your team already shortlist any other vendors?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1395)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0044" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>We looked at 2 others but neither felt right. One was too rigid, other was way too expensive for what we needed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1392)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0045" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Got it, helps to know what to avoid then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1389)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0046" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah for sure.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1386)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0047" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick one — does Veltrix have a preferred hosting setup, cloud or on-prem?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1383)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0048" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Cloud is fine, we don't want to manage servers internally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1380)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0049" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, that simplifies deployment a lot on our end.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1377)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0050" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good to know.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1374)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0051" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Reminder to self -- need to also check with our infra team about the Pune data residency requirement.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1371)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0052" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Oh that's actually important, Pune facility has some compliance requirements around data location.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1368)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0053" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Noted, will confirm and get back to you with specifics.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1365)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0054" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Thanks, that's a hard requirement on our end so good you're checking early.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1362)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0055" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Definitely, better to flag now than after the contract is signed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1359)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0056" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Agreed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1356)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0057" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright sending the requirements doc your way now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1353)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0058" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, will review by end of day.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1350)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0059" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Take your time, no rush on this end.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1347)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0060" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1344)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0061" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also just for my notes -- what's the current monthly inventory transaction volume roughly?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1341)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0062" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Around 12,000 transactions a month across all 3 sites.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1338)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0063" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know, that helps size the infrastructure correctly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1335)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0064" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Reviewed the doc. Looks solid overall, couple of questions though.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1332)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0065" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sure, go ahead.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1329)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0066" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Does the system support batch/lot tracking? We deal with perishable industrial chemicals.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1326)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0067" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yes, batch and lot tracking with expiry alerts is supported.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1323)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0068" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's great, that was actually a concern.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1320)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0069" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad it's covered. Anything else?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1317)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0070" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah, can we get a custom dashboard for the ops head? She likes seeing things her own way.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1314)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0071" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Custom dashboards are doable, we'll scope that as part of the implementation phase.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1311)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0072" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1308)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0073" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also wanted to check, are you open to a phased rollout? Site by site instead of all at once?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1305)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0074" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah honestly that sounds safer. Let's do phased.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1302)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0075" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good call, reduces risk a lot, especially with the team being newer to this kind of system.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1299)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0076" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Exactly my thinking.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1296)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0077" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, the technical call is tomorrow 3pm right, with our implementation lead?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1293)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0078" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes confirmed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1290)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0079" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Great, I'll join too just to keep continuity.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1287)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0080" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1284)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0081" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick favour, can you send over a sample of your current Tally export format before the call?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1281)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0082" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sure, sending it now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1278)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0083" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Got it, thanks, this'll save us time tomorrow.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1275)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0084" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>No problem.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1272)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0085" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, the printer in our office just died, so if I sound distracted later it's because IT is fixing it lol</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1269)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0086" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha no worries.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1266)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0087" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Okay technical call went well on our end, did it feel good for you too?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1263)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0088" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes, your implementation lead really understood our pain points, especially around the manual entry issue.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1260)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0089" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad to hear that, she's great at this stuff.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1257)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0090" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Definitely came across that way.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1254)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0091" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Next step would be to get you a detailed proposal with costing. Should I prepare that?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1251)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0092" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes please, ops head wants to see numbers before our internal review next month.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1248)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0093" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Understood, I'll have a draft proposal ready in a few days.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1245)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0094" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1242)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0095" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>One thing I want to flag -- the hardware bundle (scanners) will be a separate cost from the software licensing.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1239)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0096" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's fine, we expected that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1236)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0097" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good, just wanted to be transparent about that upfront.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1233)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0098" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate the transparency honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1230)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0099" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also do you want training included for all 40 users or just the supervisors initially?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1227)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0100" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Let's start with supervisors, they can train the rest internally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1224)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0101" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Makes sense, that's usually more cost-effective too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1221)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0102" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good to know.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1218)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0103" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, drafting the proposal now. Will share by Thursday.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1215)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0104" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, that gives me time before our internal review.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1212)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0105" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Exactly the plan.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1209)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0106" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>One more thing -- can the system generate compliance reports for chemical handling? Regulatory requirement for us.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1206)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0107" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yes, we have a compliance reporting module specifically for hazardous/regulated materials.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1203)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0108" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's a relief, that almost killed our last vendor evaluation.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1200)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0109" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good thing we have it covered then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1197)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0110" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Definitely.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1194)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0111" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick unrelated thing -- are you the only approver on your side or does finance also need to sign off?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1191)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0112" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Finance will need to sign off above a certain threshold, but I have authority up to a decent amount.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1188)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0113" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know for planning the approval timeline.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1185)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0114" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah I'll flag early if we're going to need finance's sign-off.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1182)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0115" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciate that, helps us plan internally too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1179)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0116" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>No problem.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1176)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0117" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Drafting the proposal now, will follow up Thursday as promised.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1173)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0118" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, talk then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1170)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0119" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, did you ever resolve the barcode scanner issue from your old vendor or still pending?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1167)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0120" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Still pending, we're basically waiting on you guys for that now honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1164)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0121" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Got it, I'll prioritize the hardware recommendation list then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1161)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0122" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1158)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0123" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also just a process note -- once we send the proposal, validity is usually 30 days.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1155)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0124" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's fine, we move reasonably fast once we decide.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1152)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0125" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1149)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0126" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Reminder to team -- don't forget to CC finance on any proposal over a certain value, per our internal policy.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1146)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0127" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Makes sense on your end too I assume.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1143)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0128" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yeah, standard internal process for us.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1140)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0129" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Understood.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1137)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0130" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick one, are you guys flexible on go-live date if implementation runs slightly long, or is Q3 hard?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1134)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0131" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Q3 is fairly hard because of the Pune warehouse opening, but a couple weeks of buffer should be fine.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1131)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0132" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know, gives us some breathing room in planning.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1128)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0133" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah just don't push it too far, ops head will not be happy.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1125)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0134" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Noted, will keep that in mind while planning the implementation timeline.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1122)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0135" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1119)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0136" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright I'm heads down on the proposal now, will have a draft by Thursday like planned.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1116)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0137" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, looking forward to it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1113)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0138" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, has the Pune compliance data-residency thing been confirmed on your side yet?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1110)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0139" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Still checking with our legal team, should know by next week.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1107)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0140" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>No rush, just wanted to keep it on both our radars.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1104)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0141" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated, will update you as soon as I hear back.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1101)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0142" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sending over the proposal now, take a look when you get a chance.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1098)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0143" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, will review today.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1095)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0144" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick note, the printer at our office is still acting up, so the PDF formatting might look slightly off if you print it, viewing on screen is cleaner.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1092)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0145" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha noted, will view on screen.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1089)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0146" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Let me know if the pricing structure makes sense or if you have questions.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1086)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0147" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will do, give me a day.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1083)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0148" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>No rush.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1080)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0149" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Quick question, is this pricing per warehouse or a blanket pricing for all locations?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1077)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0150" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good question, it's blanket pricing covering all current and the new Pune location.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1074)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0151" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's helpful clarity, makes the proposal easier to present internally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1071)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0152" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad that's clear now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1068)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0153" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Also is the hardware bundle pricing in the same document or separate?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1065)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0154" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Separate section in the same document, scroll down a bit, it's clearly labeled.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1062)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0155" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Ah found it, thanks.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1059)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0156" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>No problem.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1056)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0157" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Reminder to self, need to double check the printer pricing list IT sent for the new office printer, totally unrelated to this deal lol.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1053)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0158" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha all good, take your time with that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1050)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0159" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciate it, internal stuff piling up today.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1047)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0160" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Happens to all of us.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1044)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0161" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anyway, back to the proposal. Any initial thoughts after a first read?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1041)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0162" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Looks reasonable on the surface, need to discuss internally before locking anything in.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1038)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0163" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Understood, take the time you need.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1035)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0164" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will do.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1032)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0165" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I think we quoted a similar setup for another client last year, let me check the old quotation for reference to make sure our numbers are consistent.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1029)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0166" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sure, that makes sense for your own internal consistency.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1026)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0167" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yeah just want to make sure we're being fair and consistent across clients.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1023)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0168" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate that approach honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1020)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0169" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick one, does the quotation need to be in INR or would USD work better for your internal approval process?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1017)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0170" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>INR is fine, that's what finance expects.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1014)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0171" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good, keeping it in INR then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1011)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0172" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1008)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0173" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Just flagging, our quotation format changed slightly last quarter, make sure you're looking at the latest one I sent, not an older draft.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1005)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0174" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yep, using the latest one you just sent.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=1002)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0175" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, just wanted to avoid confusion.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=999)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0176" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=996)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0177" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also, quotation validity is 30 days as I mentioned, just a reminder as we get closer to your internal review.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=993)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0178" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Noted, should be within that window.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=990)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0179" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=987)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0180" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Quick one on my side, can you resend the quotation PDF, my inbox seems to have dropped the attachment.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=984)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0181" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sure, resending now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=981)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0182" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it this time, thanks.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=978)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0183" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>No problem.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=975)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0184" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Reminder to team -- don't forget to CC finance on every quotation over a certain threshold per company policy.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=972)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0185" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Makes sense as an internal control.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=969)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0186" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yeah, keeps things clean on our end.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=966)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0187" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Understood.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=963)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0188" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, did the quotation also factor in the phased rollout we discussed, or is it for a single go-live?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=960)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0189" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>It accounts for the phased rollout, costs are broken into 3 phases matching your sites.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=957)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0190" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's clear, makes it easier to present each phase separately to finance if needed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=954)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0191" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Exactly the intention behind structuring it that way.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=951)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0192" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Smart approach.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=948)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0193" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick note, IT finally fixed the office printer, so no more weird formatting issues on documents from our side lol.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=945)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0194" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha glad to hear it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=942)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0195" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Small victories.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=939)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0196" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Anyway, discussing the quotation with our ops head tomorrow, will update you after.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=936)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0197" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sounds good, take your time.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=933)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0198" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will do.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=930)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0199" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also just curious, did the other 2 vendors you evaluated give you a quotation too, just curious how we compare structurally, not asking for numbers.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=927)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0200" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah they did, honestly your quotation structure is much clearer than both of theirs.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=924)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0201" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to hear, we try to keep things transparent.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=921)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0202" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>It shows.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=918)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0203" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick internal note to self, need to check the old printer-toner quotation IT sent, totally separate thing, ignore this if you see it lol.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=915)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0204" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha no worries, ignored.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=912)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0205" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sorry for the noise, busy day.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=909)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0206" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>All good, happens.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=906)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0207" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anyway, let me know how the internal discussion with your ops head goes tomorrow.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=903)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0208" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will update you right after.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=900)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0209" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciated, talk soon.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=897)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0210" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Talk soon.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=894)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0211" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Just a heads up, I'm in back to back meetings tomorrow morning, might be slow to respond but will get to you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=891)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0212" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>No worries, take your time.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=888)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0213" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciate that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=885)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0214" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick reminder to self -- need to standardize how we name our quotation files internally, getting a bit messy on our drive.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=882)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0215" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha that's a very relatable internal problem.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=879)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0216" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Tell me about it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=876)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0217" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Anyway, ops head reviewed the quotation, she had a couple of questions about the discount structure.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=873)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0218" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sure, happy to clarify, what's she curious about?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=870)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0219" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Mainly whether the discount applies if we commit to a 2-year contract instead of 1-year.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=867)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0220" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good question, let me check internally and get back to you on that specific structure.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=864)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0221" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, no rush on our end either.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=861)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0222" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>So checked internally, yes a 2-year commitment unlocks a better discount tier than the standard 1-year.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=858)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0223" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's helpful, will bring that back to the ops head.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=855)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0224" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Let me know what she thinks once she's had a chance to review.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=852)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0225" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will do.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=849)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0226" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also wanted to ask, how's the Pune compliance check going on your legal team's end?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=846)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0227" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Honestly that's been slower than I expected, legal is stretched thin this month.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=843)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0228" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Understood, these things take time, no pressure on our end.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=840)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0229" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate that, I know it's been a few weeks since we said it'd be quick.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=837)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0230" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>No worries at all, happens with internal processes everywhere.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=834)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0231" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah unfortunately so.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=831)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0232" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, just checking in on the overall timeline -- still feeling okay about hitting Q3?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=828)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0233" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Honestly I'm a bit concerned. Between legal being slow and our ops head's calendar being packed, things feel like they're slipping again.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=825)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0234" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I hear you, that's a valid concern given how tight Q3 already is.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=822)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0235" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah, it's been a recurring pattern on our side this quarter, lots of internal bottlenecks.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=819)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0236" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Is there anything we can do on our end to help move things along faster internally for you?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=816)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0237" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Maybe a one-pager summary I can forward to legal and the ops head, something quick they can skim instead of the full proposal.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=813)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0238" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's a great idea, I'll put that together today.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=810)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0239" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That would genuinely help a lot, thank you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=807)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0240" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Of course, happy to make this easier on your end.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=804)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0241" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Really appreciate you being flexible about this, it's been a stressful month internally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=801)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0242" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Totally understand, we want this to work for you, not add more friction.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=798)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0243" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That means a lot honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=795)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0244" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sending the one-pager by end of day.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=792)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0245" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, thank you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=789)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0246" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, completely unrelated, anyone free for a quick sync later on the onboarding flow for a different client? Not you, just an internal note to my team here lol.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=786)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0247" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha all good, ignored.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=783)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0248" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sorry, sometimes these internal messages slip into the wrong thread.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=780)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0249" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>No worries at all, happens.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=777)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0250" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anyway, one-pager is ready, sending now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=774)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0251" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, this is exactly what I needed, much easier to forward.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=771)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0252" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad it helps, let me know if legal or your ops head have any questions after reading it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=768)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0253" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will do, fingers crossed this speeds things up.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=765)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0254" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Rooting for you on that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=762)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0255" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=759)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0256" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick one, did the discount conversation go anywhere with your ops head, the 2-year vs 1-year thing?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=756)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0257" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes actually, she liked the idea of locking in 2 years given the better rate.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=753)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0258" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's great to hear, want me to update the quotation to reflect the 2-year structure formally?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=750)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0259" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes please, that would help move things along on our side.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=747)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0260" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>On it, will have the updated numbers to you by tomorrow.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=744)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0261" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, thank you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=741)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0262" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also just to confirm, are we still assuming the phased rollout across the 3 existing sites first, Pune joining as phase 4?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=738)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0263" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes that structure still works for us.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=735)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0264" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Great, keeping that as is then in the updated numbers.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=732)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0265" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=729)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0266" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>One more thing while I have you, payment terms wise, are you thinking quarterly or annual upfront?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=726)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0267" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Quarterly works much better for our cash flow honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=723)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0268" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quarterly it is, I'll structure the updated proposal that way.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=720)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0269" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated, that's a big help on our end.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=717)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0270" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Happy to accommodate, want this to be smooth for you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=714)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0271" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Thank you, genuinely.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=711)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0272" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, updating the numbers now with 2-year commitment and quarterly payment terms baked in.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=708)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0273" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, will keep an eye out for it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=705)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0274" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, has legal gotten back on the Pune data residency question yet?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=702)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0275" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Not yet, but the one-pager you sent helped, they said they'd prioritize it this week.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=699)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0276" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's good progress, glad the one-pager helped move things.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=696)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0277" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah it really did, thank you for putting that together so quickly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=693)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0278" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anytime, that's what we're here for.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=690)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0279" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate the partnership approach honestly, makes a difference.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=687)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0280" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Means a lot to hear that, we try to operate that way with all our clients.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=684)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0281" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>It shows.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=681)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0282" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, sending the updated proposal with new terms shortly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=678)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0283" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, looking forward to it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=675)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0284" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick reminder to self, need to water the office plants before I forget, they're looking rough lol, unrelated to anything here.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=672)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0285" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha all good, hope the plants survive.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=669)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0286" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Fingers crossed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=666)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0287" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anyway, updated proposal incoming with the 2-year and quarterly terms locked in.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=663)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0288" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, will check shortly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=660)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0289" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Take your time.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=657)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0290" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Reviewed it, looks good. Delivery date for the implementation kickoff would be early next month then?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=654)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0291" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yes, assuming sign-off lands this week, kickoff is targeted for the 3rd of next month.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=651)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0292" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That works well with our Pune timeline.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=648)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0293" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Great, I'll pencil that in tentatively on our side too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=645)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0294" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=642)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0295" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also just confirming once more, the 2-year commitment locks in the better discount tier we discussed, that's now reflected.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=639)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0296" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes, confirmed on our side too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=636)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0297" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, that's the full picture then: 2-year term, quarterly payments, phased rollout starting with the 3 sites, kickoff targeted 3rd of next month.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=633)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0298" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's exactly how we understand it too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=630)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0299" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Great, glad we're aligned on all of that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=627)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0300" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Likewise.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=624)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0301" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, did legal confirm anything yet on data residency for Pune?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=621)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0302" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes! Finally got confirmation yesterday, we're cleared on that front.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=618)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0303" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's fantastic news, one less thing blocking timeline.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=615)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0304" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Huge relief honestly, that was hanging over us for weeks.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=612)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0305" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I bet, glad it's resolved.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=609)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0306" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Ops head is happy too, said we can move toward finalizing now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=606)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0307" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Great to hear, let me know what's still needed from our side to get to sign-off.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=603)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0308" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>I think just the final numbers reflecting everything we discussed, then we're good to take it to finance.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=600)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0309" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, I'll have that consolidated and sent over today.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=597)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0310" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=594)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0311" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick unrelated thing, is Connaught Place area convenient if we ever needed an in-person meeting, or is your office elsewhere in Delhi?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=591)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0312" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>We're actually based out of Gurgaon, but Connaught Place works fine if needed, central enough for both of us.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=588)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0313" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know for future reference.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=585)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0314" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Anytime.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=582)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0315" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also, just curious, how's the new Pune facility coming along construction-wise?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=579)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0316" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Mostly done actually, just some final electrical work pending.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=576)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0317" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's good progress, lines up well with our implementation timeline.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=573)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0318" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yeah the timing is working out better than I expected honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=570)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0319" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad to hear it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=567)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0320" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Reminder to team, the all-hands is at 4pm today, don't forget, this is just an internal note that landed here by mistake lol.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=564)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0321" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha no worries, ignored again.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=561)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0322" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>These internal pings keep slipping into client threads today, sorry about that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=558)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0323" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>All good, it's kind of funny honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=555)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0324" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad you're a good sport about it.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=552)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0325" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>No problem at all.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=549)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0326" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, consolidating the final numbers now based on everything we've locked in.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=546)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0327" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, take your time getting it right.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=543)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0328" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Will do, want to make sure everything's accurate before it goes to your finance team.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=540)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0329" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated, that attention to detail matters a lot on our side.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=537)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0330" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Always want to get it right the first time.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=534)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0331" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>It shows in how this whole process has gone honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=531)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0332" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That really means a lot, thank you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=528)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0333" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Well deserved.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=525)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0334" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Okay, just finished going through everything with our finance team internally to lock the final number.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=522)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0335" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Great, what's the final figure looking like?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=519)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0336" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>After factoring the 2-year commitment discount, the all-in total comes to 18 lakhs 40 thousand for the full 3-phase rollout including the hardware bundle.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=516)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0337" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Okay that's within the range I was expecting honestly, good news.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=513)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0338" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's great to hear, makes the finance conversation easier on your side too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=510)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0339" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Definitely will.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=507)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0340" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I'll get the formal updated document over to you reflecting that 18.4L figure broken down by phase.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=504)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0341" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, that breakdown will help a lot when I present internally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=501)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0342" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sending it shortly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=498)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0343" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=495)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0344" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>By the way, completely separate thing, do you know if Veltrix has any other locations that might eventually need this too, just curious for future planning on our end, not pushing anything now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=492)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0345" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>We do have a smaller facility in Chennai, but no plans to touch that for at least a year or two.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=489)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0346" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know for the future, no pressure at all on that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=486)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0347" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate you not pushing on that right now honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=483)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0348" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Not our style, let's get this one right first.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=480)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0349" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Exactly the right approach.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=477)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0350" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, sending the final breakdown document now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=474)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0351" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, will review and forward to finance today.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=471)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0352" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, let me know if finance has any questions, happy to hop on a call with them directly if needed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=468)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0353" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will definitely let you know, appreciate the offer.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=465)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0354" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anytime, want to make this as smooth as possible for everyone involved.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=462)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0355" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>It's been a genuinely smooth process so far, thank you for that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=459)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0356" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's great to hear, means a lot.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=456)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0357" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Well deserved feedback.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=453)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0358" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick reminder to self, parking garage is closed this weekend for maintenance, unrelated note to self again lol.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=450)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0359" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha these internal notes keep finding their way here.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=447)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0360" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I promise I'm usually more careful with this, busy week.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=444)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0361" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>All good, genuinely don't mind.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=441)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0362" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciate the patience.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=438)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0363" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anyway, any update from finance after forwarding the breakdown?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=435)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0364" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Reviewing it now actually, should hear back by tomorrow.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=432)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0365" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sounds good, fingers crossed it goes smoothly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=429)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0366" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Should be fine, the number you gave is reasonable for what we're getting.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=426)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0367" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad you feel that way, we tried to be fair given the multi-year commitment.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=423)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0368" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>It shows, appreciate the fairness honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=420)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0369" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's always the goal with long-term partnerships.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=417)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0370" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Feels that way from our side too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=414)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0371" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick one, did finance flag any concerns at all on first look?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=411)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0372" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>None so far, they actually said the quarterly payment structure makes it easier to approve internally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=408)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0373" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's great to hear, glad that structure is working in our favour here too.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=405)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0374" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Definitely helping move things faster.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=402)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0375" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, let's hope for a quick sign-off then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=399)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0376" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Fingers crossed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=396)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0377" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good news, finance approved it. We're good to move forward.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=393)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0378" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's fantastic news! Really glad to hear that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=390)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0379" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Ops head is thrilled too, this has been a long time coming for us.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=387)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0380" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Excited to get started, this has been a great process on both sides honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=384)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0381" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Couldn't agree more.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=381)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0382" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I'll get the formal contract drafted and sent over for signature.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=378)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0383" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good, who needs to sign on our end?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=375)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0384" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Just need an authorized signatory, sounds like that's you given what you mentioned earlier about your approval limit.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=372)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0385" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes, I can sign this one, it's within my threshold.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=369)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0386" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, sending the contract for signature shortly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=366)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0387" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will keep an eye out.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=363)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0388" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also, once signed, kickoff is still targeted for the 3rd of next month as discussed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=360)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0389" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Yes, still works perfectly with our Pune timeline.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=357)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0390" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Great, I'll start coordinating the implementation team on our end now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=354)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0391" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated, looking forward to getting started.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=351)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0392" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Likewise, this has been a genuinely smooth deal to work on.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=348)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0393" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Feels the same from our side.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=345)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0394" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sending the contract now, should be in your inbox shortly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=342)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0395" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, reviewing now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=339)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0396" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Take your time, let me know if anything needs adjusting.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=336)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0397" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Looks accurate, matches everything we discussed, 2-year term, quarterly payments, phased rollout, 18.4L total.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=333)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0398" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That's exactly right, glad it all lines up cleanly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=330)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0399" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Signing now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=327)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0400" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Wonderful, thank you so much.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=324)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0401" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Signed and sent back.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=321)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0402" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Received it, we are officially good to go!</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=318)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0403" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Excited to get this rolling finally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=315)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0404" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Same here, I'll have our implementation lead reach out this week to schedule the kickoff call.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=312)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0405" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, I'll make sure our ops head is available for that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=309)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0406" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sounds great, talk soon.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=306)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0407" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Talk soon, and thank you again for being so patient through our internal delays.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=303)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0408" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Honestly it was a pleasure, these things take the time they take, glad we got here.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=300)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0409" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Really appreciate that mindset.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=297)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0410" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Looking forward to a great partnership ahead.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=294)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0411" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Likewise, here's to a smooth implementation.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=291)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0412" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Cheers to that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=288)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0413" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>By the way, small thing, can you loop in your implementation lead's direct contact so I don't have to go through this main thread for day to day stuff?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=285)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0414" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Of course, sharing her direct email and number now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=282)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0415" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Got it, thank you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=279)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0416" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>She'll be your main point of contact from here for implementation specifics.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=276)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0417" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, makes sense to streamline that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=273)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0418" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I'll still be around for anything contractual or relationship related though.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=270)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0419" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good to know, appreciate you staying in the loop.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=267)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0420" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Always.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=264)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0421" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Alright, I think that wraps up everything on my end for now.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=261)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0422" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Agreed, this has been a really smooth process, thank you for your trust in us.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=258)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0423" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Thank you for the patience and flexibility throughout, genuinely made a difference.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=255)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0424" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That means a lot, looking forward to seeing this implementation succeed.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=252)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0425" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Same here, talk soon once kickoff is scheduled.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=249)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0426" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Talk soon!</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=246)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0427" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>One last thing, quick favour, can you send a one-line summary email of the final terms for my records? Just for my own filing.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=243)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0428" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Of course, sending a summary email now: 2-year contract, quarterly payments, phased 4-site rollout including Pune, total value 18 lakhs 40 thousand, kickoff targeted 3rd of next month.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=240)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0429" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, exactly what I needed for my records, thank you.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=237)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0430" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Anytime, glad we could close this out cleanly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=234)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0431" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Couldn't have asked for a smoother process honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=231)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0432" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That means a lot to hear, excited for what's ahead.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=228)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0433" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Likewise! Talk soon.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=225)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0434" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Talk soon, take care.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=222)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0435" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick one while I have you, do you want the contract sent as PDF or do you use DocuSign on your end?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=219)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0436" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>DocuSign works better for us, faster turnaround internally.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=216)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0437" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Perfect, I'll send it via DocuSign then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=213)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0438" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=210)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0439" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also, just so I have it on record, what's the best email for the formal contract, this one or a different one?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=207)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0440" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>This one is fine, I check it daily.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=204)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0441" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good to know.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=201)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0442" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>By the way, will the hardware bundle ship separately or together with onboarding?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=198)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0443" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Hardware usually ships about a week before onboarding starts, so your team has time to unbox and set up.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=195)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0444" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That timing makes sense, gives us a buffer.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=192)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0445" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Exactly the intention.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=189)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0446" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Also curious, is there a warranty period on the scanners?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=186)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0447" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yes, 1 year standard warranty, extendable if you want extra coverage.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=183)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0448" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good to know, might look into extending depending on usage.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=180)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0449" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Happy to share those extension details whenever you're ready.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=177)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0450" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Will reach out closer to that time.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=174)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0451" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Sounds good.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=171)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0452" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Random reminder to self, need to submit my timesheet before Friday, ignore this lol.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=168)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0453" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha all good, very relatable.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=165)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0454" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Thanks for being a good sport about these stray internal notes today.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=162)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0455" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Honestly kind of enjoying the behind-the-scenes glimpse.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=159)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0456" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Glad it's entertaining at least.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=156)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0457" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Quick one, will there be a dedicated support contact post go-live or a general support line?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=153)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0458" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Both actually, dedicated contact for the first 60 days, general support line after that.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=150)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0459" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's reassuring, especially for the first couple months.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=147)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0460" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Exactly why we structure it that way.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=144)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0461" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Smart approach honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=141)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0462" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also wanted to check, will your ops head need a separate login from the supervisors or same access level?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=138)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0463" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>She'll need elevated access, full visibility across all sites.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=135)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0464" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Noted, we'll set up an admin-level account for her specifically.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=132)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0465" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, that's exactly what she'd want.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=129)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0466" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Good, we'll configure that during onboarding.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=126)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0467" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sounds good.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=123)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0468" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick one, are weekends a hard no for any onboarding sessions, or could we do a Saturday if needed?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=120)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0469" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Weekdays strongly preferred, team isn't thrilled about weekend sessions.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=117)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0470" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Totally fair, we'll stick to weekdays then.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=114)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0471" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=111)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0472" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Also, just double-checking, the Pune team will join onboarding remotely or will someone travel there in person?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=108)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0473" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Probably remote initially, in-person only if absolutely necessary.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=105)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0474" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>That works fine on our end too, remote onboarding has gone smoothly for similar clients.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=102)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0475" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good to know, that puts my mind at ease a bit.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=99)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0476" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>We'll make sure it's just as thorough remotely.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=96)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0477" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate the reassurance.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=93)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0478" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Quick favour, can you share the Pune site's internet bandwidth specs, just so we can flag any infra concerns early?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=90)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0479" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Sure, let me get that from our facilities team and send it over.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=87)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0480" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>No rush, just want to avoid surprises closer to go-live.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=84)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0481" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Makes sense, will get that to you this week.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=81)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0482" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciated.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=78)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0483" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Also, are there any costs we should expect beyond what's already in the proposal, like add-ons we might not be thinking of?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=75)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0484" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Nothing beyond what's listed, the only variable would be if you add more users beyond the 40 down the line.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=72)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0485" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Good to know, don't expect that anytime soon but useful to know the trigger point.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=69)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0486" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Exactly why I wanted to flag it now rather than later.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=66)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0487" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciate the transparency, again.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=63)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0488" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Always our approach.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=60)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0489" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Quick one, is there a mobile app component or is this purely desktop/terminal based for warehouse staff?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=57)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0490" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>There's a lightweight mobile app for scanning on the floor, desktop for the back-office side.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=54)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0491" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>That's great, floor staff will prefer mobile over carrying terminals around.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=51)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0492" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Yeah that's been a popular feature with similar warehouse clients.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=48)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0493" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Makes sense why.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=45)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0494" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Reminder to team, the new badge readers are installed on the 2nd floor, unrelated internal note again, sorry.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=42)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0495" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Haha no worries, these have been a fun addition to the thread today.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=39)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0496" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>I promise tomorrow will be cleaner.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=36)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0497" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>No complaints here honestly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=33)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0498" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Appreciate the patience regardless.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=30)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0499" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Quick one, will there be a formal project plan document once contract is signed, or do we figure timeline out live?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=27)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0500" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Formal project plan, our implementation lead will share that within a few days of kickoff.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=24)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0501" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Perfect, that'll help me keep ops head and legal updated without me chasing details constantly.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=21)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0502" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Exactly the intention behind having that document.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=18)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0503" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Smart.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=15)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0504" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Alright, I think we've covered most of the operational questions, anything else on your mind before we move to closing this out?</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=12)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0505" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>I think that covers it from my side for now, can always circle back if something comes up.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=9)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0506" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_admin"/>
+            <field name="body"><![CDATA[<p>Of course, door's always open for questions.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=6)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+        <record id="sc_msg_0507" model="mail.message">
+            <field name="model">discuss.channel</field>
+            <field name="res_id" ref="channel_sales_client_demo"/>
+            <field name="message_type">comment</field>
+            <field name="subtype_id" ref="mail.mt_comment"/>
+            <field name="author_id" ref="base.partner_demo"/>
+            <field name="body"><![CDATA[<p>Appreciated, genuinely.</p>]]></field>
+            <field name="date" eval="(DateTime.today() - timedelta(minutes=3)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+
+    </data>
+</odoo>

--- a/discuss_ai_search/models/__init__.py
+++ b/discuss_ai_search/models/__init__.py
@@ -1,0 +1,2 @@
+from . import discuss_ai
+from . import discuss_channel

--- a/discuss_ai_search/models/discuss_ai.py
+++ b/discuss_ai_search/models/discuss_ai.py
@@ -1,0 +1,53 @@
+import requests
+from odoo.exceptions import UserError
+from odoo import _
+
+GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent"
+
+
+def _get_api_key(env):
+    api_key = env['ir.config_parameter'].sudo().get_param('ai.google_key')
+    if not api_key:
+        raise UserError(_("Please configure the Google API key in Settings."))
+    return api_key
+
+
+def ask_ai(env, prompt):
+    headers = {
+        "x-goog-api-key": _get_api_key(env),
+        "Content-Type": "application/json"
+    }
+    payload = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "responseMimeType":"application/json",
+            "responseSchema":{
+                "type":"object",
+                "properties":{
+                    "answer":{"type":"string"},
+                    "message_ids":{
+                        "type":"array",
+                        "items":{"type":"integer"}
+                    }
+                },
+                "required":["answer","message_ids"]
+            }
+        }
+    }
+    response = requests.post(GEMINI_URL, headers=headers, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    return  data['candidates'][0]['content']['parts'][0]['text']
+  
+def ask_ai_summarize(env, prompt):
+    headers = {
+        "x-goog-api-key": _get_api_key(env),
+        "Content-Type": "application/json"
+    }
+    payload = {
+        "contents": [{"parts": [{"text": prompt}]}]
+    }
+    response = requests.post(GEMINI_URL, headers=headers, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    return  data['candidates'][0]['content']['parts'][0]['text']

--- a/discuss_ai_search/models/discuss_channel.py
+++ b/discuss_ai_search/models/discuss_channel.py
@@ -1,0 +1,69 @@
+from odoo import models
+from odoo.tools import html2plaintext
+import json
+from odoo.addons.mail.tools.discuss import Store
+from . import discuss_ai
+
+
+class DiscussChannel(models.Model):
+    _inherit = "discuss.channel"
+    
+    def action_ask_ai(self, user_prompt):
+        self.ensure_one()
+
+        messages = self.message_ids.filtered(lambda m: m.message_type == 'comment').sorted('id')
+        if not messages:
+            return "There are no messages in this conversation yet.", {}, []
+
+        lines = messages.mapped(
+            lambda m: f"[{m.id}] {m.author_id.name}: {html2plaintext(m.body)}"
+        )
+
+        conversation = "\n".join(lines)
+
+        prompt = f"""You are answering a question about a team chat conversation.
+Use ONLY the messages below. Each line starts with its message id in brackets, e.g. "[42]".
+Answer in 2-4 plain sentences, written naturally for a human to read.
+The "answer" field must contain ONLY natural language prose. Do NOT include any
+message ids, numbers in brackets like "[42]", or a trailing list of numbers
+(e.g. "...,22,23,24,25") anywhere in the answer text.
+Put the ids of the messages you relied on ONLY in the separate message_ids field (at most 5).
+
+Conversation:
+{conversation}
+
+User Prompt: {user_prompt}
+"""
+        text = discuss_ai.ask_ai(self.env, prompt)
+        result = json.loads(text)
+        breakpoint()
+        answer = result['answer']
+        message_ids = result['message_ids']
+        references = self.env['mail.message'].browse(message_ids).exists()
+        store_data = Store().add(references).get_result()
+        return answer, store_data, references.ids
+
+
+    def action_summarize_ai(self):
+        self.ensure_one()
+
+        messages = self.message_ids.filtered(lambda m: m.message_type == 'comment').sorted('id')
+        if not messages:
+            return "There are no messages in this conversation yet."
+
+        lines = messages.mapped(
+            lambda m: f"{m.author_id.name}: {html2plaintext(m.body)}"
+        )
+        conversation = "\n".join(lines)
+
+        prompt = f"""Summarize the conversation below in a short paragraph, then add a heading
+"Key points:" in bold, followed by the key decisions made as a bullet list.
+Format the entire response as simple HTML using only <p>, <strong>, <ul>, and <li> tags.
+Do NOT use markdown syntax (no "*", "#", "**") and do NOT wrap the output in
+a code block.
+
+Conversation:
+{conversation}
+"""
+        summary = discuss_ai.ask_ai_summarize(self.env, prompt)
+        return summary

--- a/discuss_ai_search/static/src/ai_search_panel.js
+++ b/discuss_ai_search/static/src/ai_search_panel.js
@@ -1,0 +1,53 @@
+import { Component } from "@odoo/owl";
+import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+import { useState } from "@odoo/owl";
+import {useService} from "@web/core/utils/hooks";
+import {MessageCardList} from "@mail/core/common/message_card_list";
+import { markup } from "@odoo/owl";
+
+export class AiSearchPanel extends Component {
+    static template = "discuss_ai_search.AiSearchPanel";
+    static props = ["thread"];
+    static components = { ActionPanel, MessageCardList };
+    
+
+    setup() {
+        this.orm = useService("orm");
+        this.store = useService("mail.store");
+        this.state = useState({
+            user_prompt: "",
+            answer: "",
+            messageIds: [],
+        });
+
+    }
+    async ask() {
+        this.state.answer = ""
+        this.state.messageIds = []
+        const [answer, storeData, messageIds] = await this.orm.call(
+            "discuss.channel",
+            "action_ask_ai",
+            [this.props.thread.id, this.state.user_prompt]
+        )
+        this.store.insert(storeData)
+        this.state.answer = answer
+        this.state.messageIds = messageIds
+    }
+
+    get messages() {
+        return this.state.messageIds.map((id) => this.store["mail.message"].get(id)).filter(Boolean)
+    }
+
+    async summarize() {
+        this.state.user_prompt = ""
+        this.state.messageIds = []
+        this.state.answer = ""
+        const summarize = await this.orm.call(
+            "discuss.channel",
+            "action_summarize_ai",
+            [this.props.thread.id]
+        )
+        this.state.answer = markup(summarize)
+        
+    }
+}

--- a/discuss_ai_search/static/src/ai_search_panel.scss
+++ b/discuss_ai_search/static/src/ai_search_panel.scss
@@ -1,0 +1,47 @@
+.o-discuss-AiSearchPanel {
+    &-input {
+        font-size: 13.5px;
+        border-color: #e5d4d4;
+
+        &:focus {
+            border-color: #a9425a;
+            box-shadow: 0 0 0 2px rgba(169, 66, 90, 0.12);
+        }
+    }
+
+    &-ask {
+        background-color: #a9425a;
+        color: #ffffff;
+        font-weight: 600;
+        border: none;
+
+        &:hover {
+            background-color: #8f3549;
+            color: #ffffff;
+        }
+    }
+
+    &-summarize {
+        background-color: #f9dfe2;
+        color: #7a2f3d;
+        font-weight: 500;
+        border: 1px solid #f0c4ca;
+
+        &:hover {
+            background-color: #f3cdd2;
+        }
+    }
+
+    &-response {
+        background-color: #fdf6f7;
+        border: 1px solid #f0c4ca;
+        border-radius: 6px;
+        padding: 10px 12px;
+        font-size: 13.5px;
+        line-height: 1.5;
+
+        p:last-child, ul:last-child {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/discuss_ai_search/static/src/ai_search_panel.xml
+++ b/discuss_ai_search/static/src/ai_search_panel.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="discuss_ai_search.AiSearchPanel">
+        <ActionPanel title="'Search with AI'" minWidth="250" initialWidth="350" icon="'fa fa-magic'">
+            <div class="o-discuss-AiSearchPanel d-flex flex-column gap-2">
+                <div class="d-flex align-items-stretch gap-2">
+                    <textarea 
+                        class="o-discuss-AiSearchPanel-input form-control"
+                        placeholder="Find the chat about quotation meeting"
+                        t-model="state.user_prompt"
+                    />
+                    <button class="o-discuss-AiSearchPanel-ask btn btn-primary" t-on-click="ask">
+                        Ask
+                    </button>
+                </div>
+                <button class="o-discuss-AiSearchPanel-summarize btn mt-1" t-on-click="summarize">
+                    Summarize this conversation
+                </button>
+                <div class="o-discuss-AiSearchPanel-response" t-if="state.answer">
+                    <t t-out="state.answer"/>
+                </div>
+                <t t-if="messages.length">
+                    <p class="o-discuss-AiSearchPanel-count text-muted fw-bolder text-uppercase small mb-0">
+                        <t t-esc="messages.length"/> message<t t-if="messages.length > 1">s</t> found
+                    </p>
+                    <MessageCardList messages="messages" mode="'search'" thread="props.thread"/>
+                </t>
+            </div>
+        </ActionPanel>
+    </t>
+</templates>

--- a/discuss_ai_search/static/src/thread_action.js
+++ b/discuss_ai_search/static/src/thread_action.js
@@ -1,0 +1,13 @@
+import { registerThreadAction } from "@mail/core/common/thread_actions";
+import { AiSearchPanel } from "@discuss_ai_search/ai_search_panel";
+import { _t } from "@web/core/l10n/translation";
+
+registerThreadAction("discuss_ai_search", {
+    actionPanelComponent: AiSearchPanel,
+    condition: ({ thread }) => thread?.model === "discuss.channel",
+    icon: "fa fa-fw fa-magic",
+    name: _t("Ask AI"),
+    sequence: 9,
+    sequenceGroup: 30,
+    toggle: true,
+});


### PR DESCRIPTION
Discuss's built-in message search only matches literal keywords/substrings in message text. It misses relevant messages that use different wording than the search query, and gives no way to ask a question and get back the matching conversation in context.

This adds an AI search panel to the Discuss sidebar that lets the user type a natural-language prompt and get back the relevant messages from the channel, even when they don't contain the exact words typed:
- discuss_channel.action_ask_ai sends the prompt with the channel's message history to an LLM (Gemini), which returns a natural-language answer plus the ids of the messages that actually match the intent of the prompt, so results stay linked to the real conversation instead of just literal keyword hits.
- discuss_channel.action_summarize_ai adds a one-click AI summary of the channel (short paragraph + key-points bullet list) for quickly catching up on long threads.
- static/src/thread_action.js and static/src/ai_search_panel.js wire both actions into a new Discuss sidebar panel.

This makes Discuss search understand intent rather than exact wording, surfacing relevant chats even when the search prompt doesn't share the same words as the original messages.