### PR TITLE
[ADD] hackathon_module: record participant video to server disk in chunks

### DIFF
--- a/hackathon_module/__init__.py
+++ b/hackathon_module/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/hackathon_module/__manifest__.py
+++ b/hackathon_module/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    'name': 'Hackathon Video Monitoring',
+    'version': '1.0',
+    'summary': 'Hackathon participant video recording',
+    'author': 'Pranjali',
+    'depends': ['portal', 'website'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/hackathon_menu.xml',
+        'views/hackathon_session_views.xml',
+        'views/hackathon_team_views.xml',
+        'views/hackathon_participant_views.xml',
+        'views/portal.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'hackathon_module/static/src/js/recorder.js',
+        ],
+    },
+    'installable': True,
+    'application': True,
+    'license': 'LGPL-3',
+}

--- a/hackathon_module/controllers/__init__.py
+++ b/hackathon_module/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import hackathon_module

--- a/hackathon_module/controllers/hackathon_module.py
+++ b/hackathon_module/controllers/hackathon_module.py
@@ -1,0 +1,153 @@
+import glob
+import logging
+import os
+import re
+import subprocess
+import time
+import uuid
+
+from odoo import http
+from odoo.http import request
+from werkzeug.exceptions import BadRequest
+
+_logger = logging.getLogger(__name__)
+
+RECORDINGS_ROOT = "/home/odoo/odoo-hackathon-recordings"
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _concat_chunks_to_webm(chunks, output_path):
+    
+    """Binary-concatenate raw WebM chunks into one valid WebM file.
+
+    MediaRecorder.start(timeslice) produces chunks where only the first
+    one has a valid EBML header (codec init, tracks).  Subsequent chunks
+    are bare Cluster continuation segments — not standalone files.
+    But when their raw bytes are concatenated in order, the result is a
+    single valid WebM that ffmpeg can read as one input.
+    """
+
+    with open(output_path, 'wb') as out:
+        for chunk in chunks:
+            with open(chunk, 'rb') as inp:
+                while True:
+                    block = inp.read(1 << 20)
+                    if not block:
+                        break
+                    out.write(block)
+
+
+def _build_ffmpeg_cmd(input_path, output_path):
+
+    """Build an ffmpeg command that re-encodes one WebM into a 240p MP4.
+
+    Flags:
+      -b:v 100k       → ~360 MB per 8-hour session (predictable file size)
+      -preset ultrafast → fast encode at the expense of slightly larger file
+      scale=320:240    → 240p output (low quality)
+      -an              → no audio stream (video only)
+      +faststart       → MP4 index at front for streaming
+    """
+
+    return [
+        "ffmpeg", "-y",
+        "-i", input_path,
+        "-vf", "scale=320:240",
+        "-c:v", "libx264", "-b:v", "100k", "-preset", "ultrafast",
+        "-an",
+        "-movflags", "+faststart",
+        output_path,
+    ]
+
+
+class HackathonController(http.Controller):
+
+    @http.route(['/hackathon/dashboard'], type='http', auth="user", website=True)
+    def hackathon_dashboard(self, **kw):
+        participant = request.env.user.partner_id
+        participant_record = request.env['hackathon.participant'].search([('partner_id', '=', participant.id)], limit=1)
+        team_name = str(participant_record.team_id.name or '')
+        values = {
+            'participant_name': participant.name or '',
+            'team_name': team_name
+        }
+        return request.render('hackathon_module.hackathon_dashboard_template', values)
+
+    @http.route(['/hackathon/upload_chunk'], type='http', auth="user", methods=['POST'], csrf=False)
+    def upload_chunk(self, **kw):
+
+        """Receives one 60-second WebM segment and writes it to disk.
+        Called repeatedly while a participant is recording.  Chunks are
+        named with a millisecond-timestamp prefix so they sort in
+        recording order when finalize_session concatenates them.
+        """
+
+        video_file = request.httprequest.files.get('chunk')
+        if not video_file:
+            raise BadRequest("Missing 'chunk' file in request")
+
+        session_id = kw.get('session_id', '')
+        if not session_id or not _SAFE_ID_RE.match(session_id):
+            raise BadRequest("Missing or invalid session_id")
+
+        participant = request.env.user.partner_id
+
+        safe_dir = os.path.join(RECORDINGS_ROOT, session_id, str(participant.id))
+        os.makedirs(safe_dir, exist_ok=True)
+        filename = f"{int(time.time() * 1000)}_{uuid.uuid4().hex}.webm"
+        filepath = os.path.join(safe_dir, filename)
+
+        with open(filepath, 'wb') as f:
+            video_file.save(f)
+
+        return request.make_json_response({'status': 'ok', 'stored_as': filename})
+
+    @http.route(['/hackathon/finalize_session'], type='http', auth="user", methods=['POST'], csrf=False)
+    def finalize_session(self, **kw):
+        """Called once when the participant clicks Stop.
+
+        1. Finds all raw .webm chunks on disk (sorted chronologically).
+        2. Binary-concatenates them into one combined.webm (this works
+           because MediaRecorder chunks are continuation segments of
+           one stream — only chunk 1 has the EBML header).
+        3. Re-encodes combined.webm into final.mp4 at 240p / 100 kbps.
+        4. Deletes the raw chunks and combined.webm to reclaim disk.
+        """
+        session_id = kw.get('session_id', '')
+        if not session_id or not _SAFE_ID_RE.match(session_id):
+            raise BadRequest("Missing or invalid session_id")
+
+        participant = request.env.user.partner_id
+        safe_dir = os.path.join(RECORDINGS_ROOT, session_id, str(participant.id))
+
+        if not os.path.isdir(safe_dir):
+            raise BadRequest("No recording found for this session")
+
+        chunks = sorted(glob.glob(os.path.join(safe_dir, "*.webm")))
+        if not chunks:
+            raise BadRequest("No chunks found — nothing to finalize")
+
+        combined_webm = os.path.join(safe_dir, "combined.webm")
+        _concat_chunks_to_webm(chunks, combined_webm)
+
+        final_mp4 = os.path.join(safe_dir, "final.mp4")
+        cmd = _build_ffmpeg_cmd(combined_webm, final_mp4)
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+
+        if result.returncode != 0:
+            _logger.error("ffmpeg finalize failed:\n%s", result.stderr)
+            return request.make_json_response(
+                {'status': 'error', 'message': 'Video processing failed'},
+                status=500,
+            )
+        for chunk in chunks:
+            os.remove(chunk)
+        if os.path.exists(combined_webm):
+            os.remove(combined_webm)
+
+        return request.make_json_response({
+            'status': 'ok',
+            'final_file': 'final.mp4',
+            'path': final_mp4,
+        })

--- a/hackathon_module/controllers/hackathon_module.py
+++ b/hackathon_module/controllers/hackathon_module.py
@@ -39,22 +39,24 @@ def _concat_chunks_to_webm(chunks, output_path):
 
 def _build_ffmpeg_cmd(input_path, output_path):
 
-    """Build an ffmpeg command that re-encodes one WebM into a 240p MP4.
+    """Build an ffmpeg command that re-encodes one WebM into a 360p MP4.
 
     Flags:
-      -b:v 100k       → ~360 MB per 8-hour session (predictable file size)
-      -preset ultrafast → fast encode at the expense of slightly larger file
-      scale=320:240    → 240p output (low quality)
-      -an              → no audio stream (video only)
-      +faststart       → MP4 index at front for streaming
+      -r 10           → Drop to 10 frames per second
+      -crf 30         → Slightly higher compression threshold
+      -preset fast    → Good balance of speed and compression
+      scale=640:360   → 360p output
+      -c:a aac -b:a 32k -ac 1 → Mono audio at 32kbps (saves massive space)
+      +faststart      → MP4 index at front for streaming
     """
 
     return [
         "ffmpeg", "-y",
         "-i", input_path,
-        "-vf", "scale=320:240",
-        "-c:v", "libx264", "-b:v", "100k", "-preset", "ultrafast",
-        "-an",
+        "-r", "10",
+        "-vf", "scale=640:360",
+        "-c:v", "libx264", "-crf", "30", "-preset", "fast",
+        "-c:a", "aac", "-b:a", "32k", "-ac", "1",
         "-movflags", "+faststart",
         output_path,
     ]
@@ -66,10 +68,18 @@ class HackathonController(http.Controller):
     def hackathon_dashboard(self, **kw):
         participant = request.env.user.partner_id
         participant_record = request.env['hackathon.participant'].search([('partner_id', '=', participant.id)], limit=1)
-        team_name = str(participant_record.team_id.name or '')
+        team = participant_record.team_id
+        session = team.session_id
+        
+        time_left = 0
+        if session and session.start_time and session.end_time:
+            delta = session.end_time - session.start_time
+            time_left = int(delta.total_seconds())
+
         values = {
             'participant_name': participant.name or '',
-            'team_name': team_name
+            'team_name': str(team.name or ''),
+            'time_left': time_left
         }
         return request.render('hackathon_module.hackathon_dashboard_template', values)
 
@@ -151,3 +161,20 @@ class HackathonController(http.Controller):
             'final_file': 'final.mp4',
             'path': final_mp4,
         })
+
+    @http.route(['/hackathon/status'], type='jsonrpc', auth="user", website=True)
+    def hackathon_status(self, **kw):
+        participant = request.env.user.partner_id
+        participant_record = request.env['hackathon.participant'].search([('partner_id', '=', participant.id)], limit=1)
+        
+        if not participant_record:
+            return {'status': 'draft', 'session_id': False}
+            
+        session = participant_record.team_id.session_id or participant_record.session_id
+        if not session:
+            return {'status': 'draft', 'session_id': False}
+        session_id = f"sess_{session.id}_{session.name}".replace(" ", "_")
+        return {
+            'status': session.state,
+            'session_id': session_id
+        }

--- a/hackathon_module/models/__init__.py
+++ b/hackathon_module/models/__init__.py
@@ -1,0 +1,3 @@
+from . import hackathon_session
+from . import hackathon_team
+from . import hackathon_participant

--- a/hackathon_module/models/hackathon_participant.py
+++ b/hackathon_module/models/hackathon_participant.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+class HackathonParticipant(models.Model):
+    _name = 'hackathon.participant'
+    _description = 'Hackathon Participant'
+
+    partner_id = fields.Many2one('res.partner', string='Participant', required=True)
+    team_id = fields.Many2one('hackathon.team', string='Team')
+    session_id = fields.Many2one('hackathon.session', string='Session')
+    status = fields.Selection([
+        ('registered', 'Registered'),
+        ('active', 'Active'),
+        ('finished', 'Finished')
+    ], string='Status', default='registered')

--- a/hackathon_module/models/hackathon_session.py
+++ b/hackathon_module/models/hackathon_session.py
@@ -1,0 +1,16 @@
+from odoo import fields, models
+
+
+class HackathonSession(models.Model):
+    _name = 'hackathon.session'
+    _description = 'Hackathon Session'
+
+    name = fields.Char(string='Session Name', required=True)
+    start_time = fields.Datetime(string='Start Time')
+    end_time = fields.Datetime(string='End Time')
+    duration = fields.Float(string='Duration (Hours)')
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('in_progress', 'In Progress'),
+        ('done', 'Done')
+    ], string='Status', default='draft')

--- a/hackathon_module/models/hackathon_session.py
+++ b/hackathon_module/models/hackathon_session.py
@@ -1,16 +1,50 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class HackathonSession(models.Model):
     _name = 'hackathon.session'
     _description = 'Hackathon Session'
 
-    name = fields.Char(string='Session Name', required=True)
+    name = fields.Char(string='Hackathon Name', required=True)
     start_time = fields.Datetime(string='Start Time')
     end_time = fields.Datetime(string='End Time')
-    duration = fields.Float(string='Duration (Hours)')
+    duration = fields.Char(string='Duration', compute='_compute_duration', store=True)
+
+    @api.depends('start_time', 'end_time')
+    def _compute_duration(self):
+        for record in self:
+            if record.start_time and record.end_time:
+                delta = record.end_time - record.start_time
+                total_seconds = int(delta.total_seconds())
+                hours, remainder = divmod(total_seconds, 3600)
+                minutes, seconds = divmod(remainder, 60)
+                record.duration = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+            else:
+                record.duration = "00:00:00"
+    venue = fields.Char(string='Venue')
+    team_ids = fields.One2many('hackathon.team', 'session_id', string='Teams')
+    team_count = fields.Integer(compute='_compute_team_count', string='Team Count')
     state = fields.Selection([
         ('draft', 'Draft'),
         ('in_progress', 'In Progress'),
         ('done', 'Done')
     ], string='Status', default='draft')
+
+    def _compute_team_count(self):
+        for record in self:
+            record.team_count = len(record.team_ids)
+
+    def action_start(self):
+        for record in self:
+            record.state = 'in_progress'
+            
+    def action_done(self):
+        for record in self:
+            record.state = 'done'
+
+    def action_view_teams(self):
+        self.ensure_one()
+        action = self.env['ir.actions.act_window']._for_xml_id('hackathon_module.action_hackathon_team')
+        action['domain'] = [('session_id', '=', self.id)]
+        action['context'] = {'default_session_id': self.id}
+        return action

--- a/hackathon_module/models/hackathon_team.py
+++ b/hackathon_module/models/hackathon_team.py
@@ -6,4 +6,5 @@ class HackathonTeam(models.Model):
     _description = 'Hackathon Team'
 
     name = fields.Char(string='Team Name', required=True)
+    session_id = fields.Many2one('hackathon.session', string='Hackathon')
     participant_ids = fields.One2many('hackathon.participant', 'team_id', string='Members')

--- a/hackathon_module/models/hackathon_team.py
+++ b/hackathon_module/models/hackathon_team.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class HackathonTeam(models.Model):
+    _name = 'hackathon.team'
+    _description = 'Hackathon Team'
+
+    name = fields.Char(string='Team Name', required=True)
+    participant_ids = fields.One2many('hackathon.participant', 'team_id', string='Members')

--- a/hackathon_module/security/ir.model.access.csv
+++ b/hackathon_module/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hackathon_session,hackathon.session,model_hackathon_session,,1,1,1,1
+access_hackathon_team,hackathon.team,model_hackathon_team,,1,1,1,1
+access_hackathon_participant,hackathon.participant,model_hackathon_participant,,1,1,1,1

--- a/hackathon_module/static/src/js/recorder.js
+++ b/hackathon_module/static/src/js/recorder.js
@@ -1,22 +1,23 @@
 import publicWidget from "@web/legacy/js/public/public_widget";
 
 const CHUNK_INTERVAL_MS = 60000;
-const VIDEO_BITS_PER_SECOND = 100_000;
+const VIDEO_BITS_PER_SECOND = 300_000;
 
 publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
     selector: ".o_hackathon_dashboard",
     events: {
-        "click #startBtn": "_onStartRecording",
-        "click #stopBtn": "_onStopRecording"
+        "click #acceptConsentBtn": "_onAcceptConsent",
     },
 
     init() {
         this._super(...arguments);
         this.stream = null;
         this.timer = null;
-        this.timeLeft = 28800;
+        this.pollingInterval = null;
+        this.timeLeft = 0;
         this.sessionId = null;
         this._uploadPromises = [];
+        this.isRecording = false;
     },
 
     start() {
@@ -24,12 +25,28 @@ publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
         this.timerEl = this.el.querySelector("#timerDisplay");
         this.startBtn = this.el.querySelector("#startBtn");
         this.stopBtn = this.el.querySelector("#stopBtn");
+        
+        const dataTimeLeft = parseInt(this.el.dataset.timeLeft);
+        if (!isNaN(dataTimeLeft)) {
+            this.timeLeft = dataTimeLeft;
+        }
+        
         this._renderTimer();
+        
+        // Show consent modal on load using jQuery (standard for Odoo legacy widgets)
+        const $modal = this.$("#consentModal");
+        if ($modal.length) {
+            $modal.modal("show");
+        } else {
+            console.error("CRITICAL: Consent Modal not found inside o_hackathon_dashboard! Make sure the module was upgraded.");
+        }
+        
         return this._super(...arguments);
     },
 
     destroy() {
         clearInterval(this.timer);
+        clearInterval(this.pollingInterval);
         this.stream?.getTracks().forEach((t) => t.stop());
         this._super(...arguments);
     },
@@ -39,11 +56,69 @@ publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
         this.timerEl.textContent =
             `${pad(this.timeLeft / 3600)}:${pad((this.timeLeft % 3600) / 60)}:${pad(this.timeLeft % 60)}`;
     },
+    
+    async _onAcceptConsent() {
+        if (!("MediaRecorder" in window)) {
+            this._notify("Not supported", "This browser cannot record video. Please use Chrome, Edge, or Firefox.", "danger");
+            return;
+        }
+
+        try {
+            // Request permissions right away
+            this.stream = await navigator.mediaDevices.getUserMedia({
+                video: { width: { ideal: 640 }, height: { ideal: 360 } },
+                audio: true,
+            });
+            if (this.videoEl) {
+                this.videoEl.srcObject = this.stream;
+            }
+            
+            this.$("#consentModal").modal("hide");
+            
+            // Start polling backend for hackathon status
+            this.pollingInterval = setInterval(() => this._pollStatus(), 5000);
+            this._pollStatus(); // Call immediately
+            
+            this._notify("Ready", "Permissions granted. Waiting for admin to start the hackathon.", "info");
+            
+        } catch (err) {
+            console.error(err);
+            this._notify("Camera/Mic Error", "Could not access webcam/microphone. You must allow permissions.", "danger");
+        }
+    },
+    
+    _notify(title, message, type="info") {
+        console.log(`[${title}] ${message}`);
+        if (type === 'danger' || type === 'success') {
+            // Only alert on critical issues or final success
+            alert(`${title}: ${message}`);
+        }
+    },
+    
+    async _pollStatus() {
+        try {
+            const response = await fetch("/hackathon/status", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ jsonrpc: "2.0", method: "call", params: {} }),
+            });
+            const data = await response.json();
+            const result = data.result;
+            
+            if (result && result.status === 'in_progress' && !this.isRecording) {
+                this._onStartRecording(result.session_id);
+            } else if (result && result.status === 'done' && this.isRecording) {
+                this._onStopRecording();
+            }
+        } catch (err) {
+            console.warn("Polling error", err);
+        }
+    },
+
     _uploadChunk(blob) {
         const formData = new FormData();
         formData.append("chunk", blob, `${Date.now()}.webm`);
         formData.append("session_id", this.sessionId);
-
         const promise = fetch("/hackathon/upload_chunk", {
             method: "POST",
             body: formData,
@@ -58,6 +133,7 @@ publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
         this._uploadPromises.push(promise);
         return promise;
     },
+    
     async _finalizeSession() {
         try {
             const formData = new FormData();
@@ -69,18 +145,9 @@ publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
             });
 
             if (response.ok) {
-                this.displayNotification({
-                    title: "Recording saved",
-                    message: "Your session video has been saved successfully.",
-                    type: "success",
-                });
+                this._notify("Recording saved", "Your session video has been saved successfully.", "success");
             } else {
                 console.warn("Finalize failed with status", response.status);
-                this.displayNotification({
-                    title: "Save warning",
-                    message: "Recording stopped but the final video could not be processed. Raw chunks are still on disk.",
-                    type: "warning",
-                });
             }
         } catch (err) {
             console.warn("Finalize request failed:", err);
@@ -88,63 +155,43 @@ publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
     },
 
 
-    async _onStartRecording() {
-        if (!("MediaRecorder" in window)) {
-            this.displayNotification({
-                title: "Not supported",
-                message: "This browser cannot record video. Please use Chrome, Edge, or Firefox.",
-                type: "danger",
-            });
-            return;
-        }
+    _onStartRecording(sessionId) {
+        if (!this.stream) return;
+        
+        this.isRecording = true;
+        this.sessionId = sessionId;
 
-        try {
-            this.stream = await navigator.mediaDevices.getUserMedia({
-                video: { width: { ideal: 320 }, height: { ideal: 240 } },
-                audio: false,
-            });
-            this.videoEl.srcObject = this.stream;
+        const mime = ["video/webm;codecs=vp9", "video/webm"].find((t) =>
+            MediaRecorder.isTypeSupported(t)
+        ) || "video/webm";
 
-            const mime = ["video/webm;codecs=vp9", "video/webm"].find((t) =>
-                MediaRecorder.isTypeSupported(t)
-            ) || "video/webm";
+        this.recorder = new MediaRecorder(this.stream, {
+            mimeType: mime,
+            videoBitsPerSecond: VIDEO_BITS_PER_SECOND,
+            audioBitsPerSecond: 64000,
+        });
 
-            this.sessionId = `sess_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        this.recorder.ondataavailable = (e) => {
+            if (e.data.size > 10000) {
+                this._uploadChunk(e.data);
+            }
+        };
+        this.recorder.start(CHUNK_INTERVAL_MS);
 
-            this.recorder = new MediaRecorder(this.stream, {
-                mimeType: mime,
-                videoBitsPerSecond: VIDEO_BITS_PER_SECOND,
-            });
-
-            this.recorder.ondataavailable = (e) => {
-                if (e.data.size > 10000) {
-                    this._uploadChunk(e.data);
-                }
-            };
-            this.recorder.start(CHUNK_INTERVAL_MS);
-
-            this.timer = setInterval(() => {
-                if (this.timeLeft > 0) {
-                    this.timeLeft--;
-                    this._renderTimer();
-                } else {
-                    this._onStopRecording();
-                }
-            }, 1000);
-
-            this.startBtn.disabled = true;
-            this.stopBtn.disabled = false;
-        } catch (err) {
-            console.error(err);
-            this.displayNotification({
-                title: "Camera error",
-                message: "Could not access the webcam. Please check your permissions.",
-                type: "danger",
-            });
-        }
+        this.timer = setInterval(() => {
+            if (this.timeLeft > 0) {
+                this.timeLeft--;
+                this._renderTimer();
+            } else {
+                this._onStopRecording();
+            }
+        }, 1000);
+        
+        this._notify("Started", "The hackathon has started. Recording in progress.", "info");
     },
 
     _onStopRecording() {
+        this.isRecording = false;
         if (this.recorder?.state !== "inactive") {
             this.recorder.onstop = async () => {
                 await Promise.all(this._uploadPromises);
@@ -152,12 +199,11 @@ publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
             };
             this.recorder.stop();
         }
-        this.stream?.getTracks().forEach((t) => t.stop());
-        this.videoEl.srcObject = null;
         clearInterval(this.timer);
-        this.timeLeft = 28800;
+        this.timeLeft = 0;
         this._renderTimer();
-        this.startBtn.disabled = false;
-        this.stopBtn.disabled = true;
+        clearInterval(this.pollingInterval);
+        
+        this._notify("Finished", "Hackathon is complete. Processing final video.", "info");
     },
 });

--- a/hackathon_module/static/src/js/recorder.js
+++ b/hackathon_module/static/src/js/recorder.js
@@ -1,0 +1,163 @@
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+const CHUNK_INTERVAL_MS = 60000;
+const VIDEO_BITS_PER_SECOND = 100_000;
+
+publicWidget.registry.HackathonRecorder = publicWidget.Widget.extend({
+    selector: ".o_hackathon_dashboard",
+    events: {
+        "click #startBtn": "_onStartRecording",
+        "click #stopBtn": "_onStopRecording"
+    },
+
+    init() {
+        this._super(...arguments);
+        this.stream = null;
+        this.timer = null;
+        this.timeLeft = 28800;
+        this.sessionId = null;
+        this._uploadPromises = [];
+    },
+
+    start() {
+        this.videoEl = this.el.querySelector("#webcamPreview");
+        this.timerEl = this.el.querySelector("#timerDisplay");
+        this.startBtn = this.el.querySelector("#startBtn");
+        this.stopBtn = this.el.querySelector("#stopBtn");
+        this._renderTimer();
+        return this._super(...arguments);
+    },
+
+    destroy() {
+        clearInterval(this.timer);
+        this.stream?.getTracks().forEach((t) => t.stop());
+        this._super(...arguments);
+    },
+
+    _renderTimer() {
+        const pad = (n) => String(Math.floor(n)).padStart(2, "0");
+        this.timerEl.textContent =
+            `${pad(this.timeLeft / 3600)}:${pad((this.timeLeft % 3600) / 60)}:${pad(this.timeLeft % 60)}`;
+    },
+    _uploadChunk(blob) {
+        const formData = new FormData();
+        formData.append("chunk", blob, `${Date.now()}.webm`);
+        formData.append("session_id", this.sessionId);
+
+        const promise = fetch("/hackathon/upload_chunk", {
+            method: "POST",
+            body: formData,
+        }).then((response) => {
+            if (!response.ok) {
+                console.warn("Chunk upload failed with status", response.status);
+            }
+        }).catch((err) => {
+            console.warn("Chunk upload failed:", err);
+        });
+
+        this._uploadPromises.push(promise);
+        return promise;
+    },
+    async _finalizeSession() {
+        try {
+            const formData = new FormData();
+            formData.append("session_id", this.sessionId);
+
+            const response = await fetch("/hackathon/finalize_session", {
+                method: "POST",
+                body: formData,
+            });
+
+            if (response.ok) {
+                this.displayNotification({
+                    title: "Recording saved",
+                    message: "Your session video has been saved successfully.",
+                    type: "success",
+                });
+            } else {
+                console.warn("Finalize failed with status", response.status);
+                this.displayNotification({
+                    title: "Save warning",
+                    message: "Recording stopped but the final video could not be processed. Raw chunks are still on disk.",
+                    type: "warning",
+                });
+            }
+        } catch (err) {
+            console.warn("Finalize request failed:", err);
+        }
+    },
+
+
+    async _onStartRecording() {
+        if (!("MediaRecorder" in window)) {
+            this.displayNotification({
+                title: "Not supported",
+                message: "This browser cannot record video. Please use Chrome, Edge, or Firefox.",
+                type: "danger",
+            });
+            return;
+        }
+
+        try {
+            this.stream = await navigator.mediaDevices.getUserMedia({
+                video: { width: { ideal: 320 }, height: { ideal: 240 } },
+                audio: false,
+            });
+            this.videoEl.srcObject = this.stream;
+
+            const mime = ["video/webm;codecs=vp9", "video/webm"].find((t) =>
+                MediaRecorder.isTypeSupported(t)
+            ) || "video/webm";
+
+            this.sessionId = `sess_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+            this.recorder = new MediaRecorder(this.stream, {
+                mimeType: mime,
+                videoBitsPerSecond: VIDEO_BITS_PER_SECOND,
+            });
+
+            this.recorder.ondataavailable = (e) => {
+                if (e.data.size > 10000) {
+                    this._uploadChunk(e.data);
+                }
+            };
+            this.recorder.start(CHUNK_INTERVAL_MS);
+
+            this.timer = setInterval(() => {
+                if (this.timeLeft > 0) {
+                    this.timeLeft--;
+                    this._renderTimer();
+                } else {
+                    this._onStopRecording();
+                }
+            }, 1000);
+
+            this.startBtn.disabled = true;
+            this.stopBtn.disabled = false;
+        } catch (err) {
+            console.error(err);
+            this.displayNotification({
+                title: "Camera error",
+                message: "Could not access the webcam. Please check your permissions.",
+                type: "danger",
+            });
+        }
+    },
+
+    _onStopRecording() {
+        if (this.recorder?.state !== "inactive") {
+            this.recorder.onstop = async () => {
+                await Promise.all(this._uploadPromises);
+                this._finalizeSession();
+            };
+            this.recorder.stop();
+        }
+        this.stream?.getTracks().forEach((t) => t.stop());
+        this.videoEl.srcObject = null;
+        clearInterval(this.timer);
+        this.timeLeft = 28800;
+        this._renderTimer();
+        this.startBtn.disabled = false;
+        this.stopBtn.disabled = true;
+    },
+});

--- a/hackathon_module/views/hackathon_menu.xml
+++ b/hackathon_module/views/hackathon_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="menu_hackathon_root" name="Hackathon" sequence="10"/>
+    <menuitem id="menu_hackathon_dashboard" name="Dashboard" parent="menu_hackathon_root" sequence="10"/>
+    <menuitem id="menu_hackathon_sessions" name="Sessions" parent="menu_hackathon_root" sequence="20"/>
+    <menuitem id="menu_hackathon_teams" name="Teams" parent="menu_hackathon_root" sequence="30"/>
+    <menuitem id="menu_hackathon_participants" name="Participants" parent="menu_hackathon_root" sequence="40"/>
+</odoo>

--- a/hackathon_module/views/hackathon_participant_views.xml
+++ b/hackathon_module/views/hackathon_participant_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_hackathon_participant_tree" model="ir.ui.view">
+        <field name="name">hackathon.participant.tree</field>
+        <field name="model">hackathon.participant</field>
+        <field name="arch" type="xml">
+            <list string="Participants">
+                <field name="partner_id"/>
+                <field name="team_id"/>
+                <field name="session_id"/>
+                <field name="status"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_hackathon_participant_form" model="ir.ui.view">
+        <field name="name">hackathon.participant.form</field>
+        <field name="model">hackathon.participant</field>
+        <field name="arch" type="xml">
+            <form string="Participant">
+                <sheet>
+                    <group>
+                        <field name="partner_id"/>
+                        <field name="team_id"/>
+                        <field name="session_id"/>
+                        <field name="status"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_hackathon_participant" model="ir.actions.act_window">
+        <field name="name">Participants</field>
+        <field name="res_model">hackathon.participant</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_hackathon_participants_action" parent="menu_hackathon_participants" action="action_hackathon_participant"/>
+</odoo>

--- a/hackathon_module/views/hackathon_session_views.xml
+++ b/hackathon_module/views/hackathon_session_views.xml
@@ -1,11 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="view_hackathon_session_kanban" model="ir.ui.view">
+        <field name="name">hackathon.session.kanban</field>
+        <field name="model">hackathon.session</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile">
+                <field name="name"/>
+                <field name="venue"/>
+                <field name="start_time"/>
+                <field name="end_time"/>
+                <field name="state"/>
+                <templates>
+                    <t t-name="card">
+                        <div class="o_kanban_record_top">
+                            <div class="o_kanban_record_headings">
+                                <strong class="o_kanban_record_title"><field name="name"/></strong>
+                            </div>
+                            <span class="badge rounded-pill text-bg-info"><field name="state"/></span>
+                        </div>
+                        <div class="o_kanban_record_body mt-2">
+                            <div t-if="record.venue.value"><i class="fa fa-map-marker" title="Venue"></i> <field name="venue"/></div>
+                            <div t-if="record.start_time.value"><i class="fa fa-clock-o" title="Start Time"></i> <field name="start_time"/></div>
+                            <div t-if="record.end_time.value"><i class="fa fa-clock-o" title="End Time"></i> <field name="end_time"/></div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
     <record id="view_hackathon_session_tree" model="ir.ui.view">
         <field name="name">hackathon.session.tree</field>
         <field name="model">hackathon.session</field>
         <field name="arch" type="xml">
             <list string="Sessions">
                 <field name="name"/>
+                <field name="venue"/>
                 <field name="start_time"/>
                 <field name="end_time"/>
                 <field name="state"/>
@@ -19,11 +49,19 @@
         <field name="arch" type="xml">
             <form string="Session">
                 <header>
+                    <button name="action_start" type="object" string="Start Hackathon" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_done" type="object" string="End Hackathon" invisible="state != 'in_progress'"/>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_view_teams" type="object" class="oe_stat_button" icon="fa-users">
+                            <field name="team_count" widget="statinfo" string="Teams"/>
+                        </button>
+                    </div>
                     <group>
                         <field name="name"/>
+                        <field name="venue"/>
                         <field name="start_time"/>
                         <field name="end_time"/>
                         <field name="duration"/>
@@ -36,7 +74,7 @@
     <record id="action_hackathon_session" model="ir.actions.act_window">
         <field name="name">Sessions</field>
         <field name="res_model">hackathon.session</field>
-        <field name="view_mode">list,form</field>
+        <field name="view_mode">kanban,list,form</field>
     </record>
 
     <menuitem id="menu_hackathon_sessions_action" parent="menu_hackathon_sessions" action="action_hackathon_session"/>

--- a/hackathon_module/views/hackathon_session_views.xml
+++ b/hackathon_module/views/hackathon_session_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_hackathon_session_tree" model="ir.ui.view">
+        <field name="name">hackathon.session.tree</field>
+        <field name="model">hackathon.session</field>
+        <field name="arch" type="xml">
+            <list string="Sessions">
+                <field name="name"/>
+                <field name="start_time"/>
+                <field name="end_time"/>
+                <field name="state"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_hackathon_session_form" model="ir.ui.view">
+        <field name="name">hackathon.session.form</field>
+        <field name="model">hackathon.session</field>
+        <field name="arch" type="xml">
+            <form string="Session">
+                <header>
+                    <field name="state" widget="statusbar"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="start_time"/>
+                        <field name="end_time"/>
+                        <field name="duration"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_hackathon_session" model="ir.actions.act_window">
+        <field name="name">Sessions</field>
+        <field name="res_model">hackathon.session</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_hackathon_sessions_action" parent="menu_hackathon_sessions" action="action_hackathon_session"/>
+</odoo>

--- a/hackathon_module/views/hackathon_team_views.xml
+++ b/hackathon_module/views/hackathon_team_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_hackathon_team_tree" model="ir.ui.view">
+        <field name="name">hackathon.team.tree</field>
+        <field name="model">hackathon.team</field>
+        <field name="arch" type="xml">
+            <list string="Teams">
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_hackathon_team_form" model="ir.ui.view">
+        <field name="name">hackathon.team.form</field>
+        <field name="model">hackathon.team</field>
+        <field name="arch" type="xml">
+            <form string="Team">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                    <notebook>
+                        <page string="Members">
+                            <field name="participant_ids">
+                                <list>
+                                    <field name="partner_id"/>
+                                    <field name="status"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_hackathon_team" model="ir.actions.act_window">
+        <field name="name">Teams</field>
+        <field name="res_model">hackathon.team</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_hackathon_teams_action" parent="menu_hackathon_teams" action="action_hackathon_team"/>
+</odoo>

--- a/hackathon_module/views/hackathon_team_views.xml
+++ b/hackathon_module/views/hackathon_team_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <list string="Teams">
                 <field name="name"/>
+                <field name="session_id"/>
             </list>
         </field>
     </record>
@@ -18,11 +19,12 @@
                 <sheet>
                     <group>
                         <field name="name"/>
+                        <field name="session_id"/>
                     </group>
                     <notebook>
                         <page string="Members">
                             <field name="participant_ids">
-                                <list>
+                                <list editable="bottom">
                                     <field name="partner_id"/>
                                     <field name="status"/>
                                 </list>

--- a/hackathon_module/views/portal.xml
+++ b/hackathon_module/views/portal.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="hackathon_dashboard_template" name="Hackathon Dashboard">
         <t t-call="website.layout">
-            <div id="wrap" class="container mt-5 mb-5 o_hackathon_dashboard">
+            <div id="wrap" class="container mt-5 mb-5 o_hackathon_dashboard" t-att-data-time-left="time_left">
                 <div class="row justify-content-center">
                     <div class="col-md-8 text-center">
                         <h2>Hackathon Dashboard</h2>
@@ -14,13 +14,27 @@
                             </div>
                         </div>
 
-                        <div class="mb-4">
+                        <div class="mb-4 d-none">
                             <video id="webcamPreview" autoplay="autoplay" muted="muted" playsinline="playsinline" style="width: 100%; max-width: 600px; background: #000; border-radius: 8px; border: 2px solid #ccc;"></video>
                         </div>
+                    </div>
+                </div>
 
-                        <div>
-                            <button id="startBtn" class="btn btn-success btn-lg me-2">Start Hackathon</button>
-                            <button id="stopBtn" class="btn btn-danger btn-lg" disabled="disabled">Stop Hackathon</button>
+                <!-- Consent Modal -->
+                <div class="modal fade" id="consentModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="consentModalLabel" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header bg-warning">
+                                <h5 class="modal-title" id="consentModalLabel">Recording Consent Required</h5>
+                            </div>
+                            <div class="modal-body">
+                                <p><strong>Important Notice:</strong></p>
+                                <p>During this hackathon, we will be recording your screen (video) and microphone (audio) to monitor the session and ensure fair play.</p>
+                                <p>By clicking "Allow &amp; Continue", you grant us permission to access your webcam and microphone. If you do not allow permissions, you will not be able to participate.</p>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-success" id="acceptConsentBtn">I Understand &amp; Allow</button>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/hackathon_module/views/portal.xml
+++ b/hackathon_module/views/portal.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="hackathon_dashboard_template" name="Hackathon Dashboard">
+        <t t-call="website.layout">
+            <div id="wrap" class="container mt-5 mb-5 o_hackathon_dashboard">
+                <div class="row justify-content-center">
+                    <div class="col-md-8 text-center">
+                        <h2>Hackathon Dashboard</h2>
+                        <div class="card mb-4 shadow-sm">
+                            <div class="card-body">
+                                <h4>Name: <span t-esc="participant_name"/></h4>
+                                <h5>Team: <span t-esc="team_name"/></h5>
+                                <h3 class="text-danger mt-3" id="timerDisplay">08:00:00</h3>
+                            </div>
+                        </div>
+
+                        <div class="mb-4">
+                            <video id="webcamPreview" autoplay="autoplay" muted="muted" playsinline="playsinline" style="width: 100%; max-width: 600px; background: #000; border-radius: 8px; border: 2px solid #ccc;"></video>
+                        </div>
+
+                        <div>
+                            <button id="startBtn" class="btn btn-success btn-lg me-2">Start Hackathon</button>
+                            <button id="stopBtn" class="btn btn-danger btn-lg" disabled="disabled">Stop Hackathon</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
Hackathon organizers need every participant's 8-hour session recorded
centrally for review after the event. Browser-side download to each
participant's own machine was ruled out early — with 800 participants,
files scattered across 800 personal laptops are not usable by anyone
organizing the event, and buffering a full session in browser memory
before saving it also risks losing the entire recording on a crash.

Records in 60-second WebM segments uploaded to the server as they are
captured, so a crash costs at most one segment, not the whole session.
Segments are written under RECORDINGS_ROOT/<session_id>/<participant_id>/
using server-generated filenames only, to avoid any client-controlled
path or filename reaching the filesystem.